### PR TITLE
Create AWS Cloud Map namespace for Redis ECS service discovery

### DIFF
--- a/modules/langgraph_cloud_setup/README.md
+++ b/modules/langgraph_cloud_setup/README.md
@@ -14,3 +14,4 @@ module "langgraph_cloud_setup" {
   langgraph_role_arn     = "arn:aws:iam::640174622193:role/HostBackendRoleProd"
   langgraph_external_ids = ["Your Organization ID"]
 }
+```

--- a/modules/langgraph_cloud_setup/main.tf
+++ b/modules/langgraph_cloud_setup/main.tf
@@ -217,3 +217,14 @@ resource "aws_security_group" "langgraph_cloud_service_sg" {
     langgraph-cloud-enabled = "1"
   }
 }
+
+// Create AWS Cloud Map namespace for Redis ECS service discovery
+resource "aws_service_discovery_private_dns_namespace" "langgraph_cloud_redis" {
+  name        = "langgraph-cloud-redis"
+  description = "LangGraph Cloud Redis service discovery namespace"
+  vpc         = var.vpc_id
+
+  tags = {
+    langgraph-cloud-enabled = "1"
+  }
+}


### PR DESCRIPTION
### Summary
Create AWS Cloud Map namespace for Redis ECS service discovery. Services and service instances will be created dynamically by the control plane for each Redis ECS service.