### PR TITLE
fix: use correct role as default

### DIFF
--- a/modules/langgraph_cloud_setup/variables.tf
+++ b/modules/langgraph_cloud_setup/variables.tf
@@ -16,7 +16,7 @@ variable "public_subnet_ids" {
 variable "langgraph_role_arn" {
   description = "Role ARN for LangGraph Cloud that will be used to access resources. Needs to be able to assume role in your AWS account."
   type        = string
-  default     = "arn:aws:iam::640174622193:role/HostBackendRole"
+  default     = "arn:aws:iam::640174622193:role/HostBackendRoleProd"
 }
 
 variable "langgraph_external_ids" {


### PR DESCRIPTION
Was correctly specified in README but default was incorrect after role name changes.