### PR TITLE
Add `langsmith_data_region` variable to module

### DIFF
--- a/modules/langgraph_cloud_setup/README.md
+++ b/modules/langgraph_cloud_setup/README.md
@@ -3,6 +3,8 @@ This module sets up the LangGraph Cloud BYOC (Bring Your Own Cloud) environment.
 It will provision the necessary resources in your account and also grant the necessary permissions to the LangSmith Role.
 This role will be used by the LangSmith service to interact with your cloud environment.
 
+For `langsmith_data_region`, specify `"us"` or `"eu"` based on your LangSmith account's data region.
+
 For license checking, services deployed on the ECS cluster must have access to the public internet (i.e. egress). This Terraform module does not set up the required infrastructure to enable this. A NAT gateway or other alternative may be required and should be configured outside the scope of this module.
 
 ## Usage
@@ -13,7 +15,7 @@ module "langgraph_cloud_setup" {
   vpc_id                 = "YOUR VPC ID"
   private_subnet_ids     = ["YOUR PRIVATE SUBNET IDS"]
   public_subnet_ids      = ["YOUR PUBLIC SUBNET IDS"]
-  langgraph_role_arn     = "arn:aws:iam::640174622193:role/HostBackendRoleProd"
+  langsmith_data_region  = "us"
   langgraph_external_ids = ["Your Organization ID"]
 }
 ```

--- a/modules/langgraph_cloud_setup/main.tf
+++ b/modules/langgraph_cloud_setup/main.tf
@@ -70,7 +70,14 @@ data "aws_iam_policy_document" "assume_role" {
 
     principals {
       type        = "AWS"
-      identifiers = [var.langgraph_role_arn]
+      identifiers = lookup(
+        {
+          us = ["arn:aws:iam::640174622193:role/HostBackendRoleProd"]
+          eu = ["arn:aws:iam::640174622193:role/HostBackendRoleProdEu"]
+        },
+        var.langsmith_data_region,
+        ["arn:aws:iam::640174622193:role/HostBackendRoleProd"]
+      )
     }
 
     condition {

--- a/modules/langgraph_cloud_setup/main.tf
+++ b/modules/langgraph_cloud_setup/main.tf
@@ -69,7 +69,7 @@ data "aws_iam_policy_document" "assume_role" {
     actions = ["sts:AssumeRole"]
 
     principals {
-      type        = "AWS"
+      type = "AWS"
       identifiers = lookup(
         {
           us = ["arn:aws:iam::640174622193:role/HostBackendRoleProd"]

--- a/modules/langgraph_cloud_setup/variables.tf
+++ b/modules/langgraph_cloud_setup/variables.tf
@@ -13,10 +13,10 @@ variable "public_subnet_ids" {
   type        = list(string)
 }
 
-variable "langgraph_role_arn" {
-  description = "Role ARN for LangGraph Cloud that will be used to access resources. Needs to be able to assume role in your AWS account."
+variable "langsmith_data_region" {
+  description = "The data region of the LangSmith account. Valid values: us, eu."
   type        = string
-  default     = "arn:aws:iam::640174622193:role/HostBackendRoleProd"
+  default     = "us"
 }
 
 variable "langgraph_external_ids" {


### PR DESCRIPTION
### Summary
The `langsmith_data_region` variable will determine which IAM role is selected for the assume role policy.