### PR TITLE
Add `create_elb_service_linked_role` to BYOC module

### DIFF
--- a/modules/langgraph_cloud_setup/README.md
+++ b/modules/langgraph_cloud_setup/README.md
@@ -3,7 +3,9 @@ This module sets up the LangGraph Cloud BYOC (Bring Your Own Cloud) environment.
 It will provision the necessary resources in your account and also grant the necessary permissions to the LangSmith Role.
 This role will be used by the LangSmith service to interact with your cloud environment.
 
-For `langsmith_data_region`, specify `"us"` or `"eu"` based on your LangSmith account's data region.
+- For `langsmith_data_region`, specify `"us"` or `"eu"` based on your LangSmith account's data region.
+- For `langgraph_external_ids`, specify your LangSmith Organization ID(s).
+- For `create_elb_service_linked_role`, specify `true` to create the Elastic Load Balancing service-linked role. Specify `false` if the Elastic Load Balancing service-linked role already exists. Note: the service-linked role may have been created by some other AWS service/workflow outside of this Terraform module.
 
 For license checking, services deployed on the ECS cluster must have access to the public internet (i.e. egress). This Terraform module does not set up the required infrastructure to enable this. A NAT gateway or other alternative may be required and should be configured outside the scope of this module.
 
@@ -12,10 +14,11 @@ For license checking, services deployed on the ECS cluster must have access to t
 module "langgraph_cloud_setup" {
   source = "github.com/langchain-ai/terraform//modules/langgraph_cloud_setup"
 
-  vpc_id                 = "YOUR VPC ID"
-  private_subnet_ids     = ["YOUR PRIVATE SUBNET IDS"]
-  public_subnet_ids      = ["YOUR PUBLIC SUBNET IDS"]
-  langsmith_data_region  = "us"
-  langgraph_external_ids = ["Your LangSmith Organization ID"]
+  vpc_id                         = "YOUR VPC ID"
+  private_subnet_ids             = ["YOUR PRIVATE SUBNET IDS"]
+  public_subnet_ids              = ["YOUR PUBLIC SUBNET IDS"]
+  langsmith_data_region          = "us"
+  langgraph_external_ids         = ["Your LangSmith Organization ID"]
+  create_elb_service_linked_role = true
 }
 ```

--- a/modules/langgraph_cloud_setup/main.tf
+++ b/modules/langgraph_cloud_setup/main.tf
@@ -154,6 +154,7 @@ resource "aws_iam_role_policy_attachment" "secrets_read" {
 
 // Create Load Balancer Service Linked Role
 resource "aws_iam_service_linked_role" "elastic_load_balancing" {
+  count            = var.create_elb_service_linked_role ? 1 : 0
   aws_service_name = "elasticloadbalancing.amazonaws.com"
 }
 

--- a/modules/langgraph_cloud_setup/variables.tf
+++ b/modules/langgraph_cloud_setup/variables.tf
@@ -23,3 +23,9 @@ variable "langgraph_external_ids" {
   description = "External IDs for LangGraph Cloud that will be used to access resources. Needs to be able to assume role in your AWS account. These will typically be your organization ids."
   type        = list(string)
 }
+
+variable "create_elb_service_linked_role" {
+  description = "Whether to create the ELB Service Linked Role"
+  type        = bool
+  default     = true
+}

--- a/modules/langgraph_cloud_setup/variables.tf
+++ b/modules/langgraph_cloud_setup/variables.tf
@@ -25,7 +25,7 @@ variable "langgraph_external_ids" {
 }
 
 variable "create_elb_service_linked_role" {
-  description = "Whether to create the ELB Service Linked Role"
+  description = "Whether to create the ELB service-linked role."
   type        = bool
   default     = true
 }


### PR DESCRIPTION
### Summary
Some AWS environments already have the Elastic Load Balancing service-linked role created. The BYOC module should be updated to make it optional to create it.