### PR TITLE
Add `langgraph-cloud-enabled` tag to ECS cluster

### DIFF
--- a/modules/langgraph_cloud_setup/main.tf
+++ b/modules/langgraph_cloud_setup/main.tf
@@ -101,6 +101,9 @@ resource "aws_ecs_cluster" "langgraph_cloud_cluster" {
     value = "enabled"
   }
 
+  tags = {
+    langgraph-cloud-enabled = "1"
+  }
 }
 
 // Create ECS role with ECR access and access to its own secret


### PR DESCRIPTION
### Summary
I just noticed we don't tag the ECS cluster. Any reason not to?

This came up when trying to figure out how to filter CloudWatch metrics for cross account Cloud Watch console.