### PR TITLE
chore: prevent terraform from tying to downsize instance

### DIFF
--- a/modules/aws/postgres/main.tf
+++ b/modules/aws/postgres/main.tf
@@ -39,4 +39,10 @@ resource "aws_db_instance" "this" {
   vpc_security_group_ids = [aws_security_group.this.id]
   publicly_accessible    = false
   deletion_protection    = true
+
+  # Prevents terraform from trying to downsize a database that scaled up automatically.
+  # To manually increase the storage, you can use the AWS console.
+  lifecycle {
+    ignore_changes = var.max_allocated_storage > 0 ? [allocated_storage] : []
+  }
 }


### PR DESCRIPTION
After your instance autoscales, you can find yourself in a position where terraform will try to downsize it again. This leads to terraform errors. We can safely ignore this field if autoscaling is enabled.