### PR TITLE
chore: codify iam policy for postgres

### DIFF
--- a/modules/aws/eks/main.tf
+++ b/modules/aws/eks/main.tf
@@ -92,7 +92,7 @@ resource "kubernetes_storage_class" "gp3_default" {
 resource "aws_iam_role" "langsmith" {
   count = var.create_langsmith_irsa_role ? 1 : 0
 
-  name = "langsmith-${module.eks.cluster_name}"
+  name = "${module.eks.cluster_name}-irsa-role"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"

--- a/modules/aws/eks/main.tf
+++ b/modules/aws/eks/main.tf
@@ -86,3 +86,31 @@ resource "kubernetes_storage_class" "gp3_default" {
 
   depends_on = [aws_eks_addon.ebs-csi]
 }
+
+# IRSA role for LangSmith pods
+# Allows any service account in the cluster to assume this role
+resource "aws_iam_role" "langsmith" {
+  count = var.create_langsmith_irsa_role ? 1 : 0
+
+  name = "langsmith-${module.eks.cluster_name}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = module.eks.oidc_provider_arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "${module.eks.oidc_provider}:aud" = "sts.amazonaws.com"
+          }
+        }
+      }
+    ]
+  })
+
+  depends_on = [module.eks]
+}

--- a/modules/aws/eks/outputs.tf
+++ b/modules/aws/eks/outputs.tf
@@ -1,3 +1,23 @@
 output "cluster_name" {
   value = module.eks.cluster_name
 }
+
+output "oidc_provider" {
+  description = "OIDC provider URL for IRSA"
+  value       = module.eks.oidc_provider
+}
+
+output "oidc_provider_arn" {
+  description = "OIDC provider ARN for IRSA"
+  value       = module.eks.oidc_provider_arn
+}
+
+output "langsmith_irsa_role_arn" {
+  description = "ARN of the IRSA role for LangSmith pods"
+  value       = var.create_langsmith_irsa_role ? aws_iam_role.langsmith[0].arn : null
+}
+
+output "langsmith_irsa_role_name" {
+  description = "Name of the IRSA role for LangSmith pods"
+  value       = var.create_langsmith_irsa_role ? aws_iam_role.langsmith[0].name : null
+}

--- a/modules/aws/eks/variables.tf
+++ b/modules/aws/eks/variables.tf
@@ -49,3 +49,10 @@ variable "create_gp3_storage_class" {
   description = "Whether to create the gp3 storage class. The gp3 storage class will be patched to make it default and allow volume expansion."
   default     = true
 }
+
+# IRSA (IAM Roles for Service Accounts) settings
+variable "create_langsmith_irsa_role" {
+  type        = bool
+  description = "Whether to create an IRSA role for LangSmith pods"
+  default     = false
+}

--- a/modules/aws/langsmith/main.tf
+++ b/modules/aws/langsmith/main.tf
@@ -67,5 +67,5 @@ module "postgres" {
   password = var.postgres_password
 
   iam_database_authentication_enabled = var.postgres_iam_database_authentication_enabled
-  iam_database_user = var.postgres_iam_database_user
+  iam_database_user                   = var.postgres_iam_database_user
 }

--- a/modules/aws/langsmith/main.tf
+++ b/modules/aws/langsmith/main.tf
@@ -35,6 +35,9 @@ module "eks" {
   create_gp3_storage_class = var.create_gp3_storage_class
   eks_managed_node_groups  = var.eks_managed_node_groups
   public_cluster_enabled   = var.enable_public_eks_cluster
+
+  # IRSA settings
+  create_langsmith_irsa_role = var.create_langsmith_irsa_role
 }
 
 module "redis" {
@@ -68,4 +71,7 @@ module "postgres" {
 
   iam_database_authentication_enabled = var.postgres_iam_database_authentication_enabled
   iam_database_user                   = var.postgres_iam_database_user
+  iam_auth_role_name                  = module.eks.langsmith_irsa_role_name
+
+  depends_on = [module.eks]
 }

--- a/modules/aws/langsmith/main.tf
+++ b/modules/aws/langsmith/main.tf
@@ -67,4 +67,5 @@ module "postgres" {
   password = var.postgres_password
 
   iam_database_authentication_enabled = var.postgres_iam_database_authentication_enabled
+  iam_database_user = var.postgres_iam_database_user
 }

--- a/modules/aws/langsmith/outputs.tf
+++ b/modules/aws/langsmith/outputs.tf
@@ -3,6 +3,11 @@ output "postgres_connection_url" {
   sensitive = true
 }
 
+output "postgres_iam_connection_url" {
+  description = "Connection URL for IAM authentication (no password)."
+  value       = module.postgres.iam_connection_url
+}
+
 output "redis_connection_url" {
   value     = module.redis.connection_url
   sensitive = true

--- a/modules/aws/langsmith/variables.tf
+++ b/modules/aws/langsmith/variables.tf
@@ -116,3 +116,9 @@ variable "postgres_iam_database_authentication_enabled" {
   description = "Whether to enable IAM database authentication for the postgres database"
   default     = true
 }
+
+variable "postgres_iam_database_user" {
+  type        = string
+  description = "Database username for IAM authentication. This user must be created in PostgreSQL with 'GRANT rds_iam TO <user>'"
+  default     = null
+}

--- a/modules/aws/langsmith/variables.tf
+++ b/modules/aws/langsmith/variables.tf
@@ -122,3 +122,10 @@ variable "postgres_iam_database_user" {
   description = "Database username for IAM authentication. This user must be created in PostgreSQL with 'GRANT rds_iam TO <user>'"
   default     = null
 }
+
+# IRSA (IAM Roles for Service Accounts) settings
+variable "create_langsmith_irsa_role" {
+  type        = bool
+  description = "Whether to create an IRSA role for LangSmith pods"
+  default     = true
+}

--- a/modules/aws/postgres/main.tf
+++ b/modules/aws/postgres/main.tf
@@ -75,7 +75,7 @@ resource "aws_iam_policy" "rds_iam_auth" {
 # NOTE: The IAM database user must be created manually in PostgreSQL.
 # Connect as the admin user and run:
 #
-#   CREATE USER <iam_database_user> WITH LOGIN;
+#   CREATE USER <iam_database_user>;
 #   GRANT rds_iam TO <iam_database_user>;
 #   GRANT ALL PRIVILEGES ON DATABASE <db_name> TO <iam_database_user>;
 #   GRANT ALL PRIVILEGES ON SCHEMA public TO <iam_database_user>;

--- a/modules/aws/postgres/main.tf
+++ b/modules/aws/postgres/main.tf
@@ -78,9 +78,9 @@ resource "aws_iam_policy" "rds_iam_auth" {
 #   CREATE USER <iam_database_user>;
 #   GRANT rds_iam TO <iam_database_user>;
 #   GRANT ALL PRIVILEGES ON DATABASE <db_name> TO <iam_database_user>;
+#   GRANT USAGE ON SCHEMA public TO <iam_database_user>;
 #   GRANT ALL PRIVILEGES ON SCHEMA public TO <iam_database_user>;
 #   GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO <iam_database_user>;
 #   GRANT ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public TO <iam_database_user>;
 #   ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO <iam_database_user>;
 #   ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON SEQUENCES TO <iam_database_user>;
-#

--- a/modules/aws/postgres/main.tf
+++ b/modules/aws/postgres/main.tf
@@ -64,8 +64,8 @@ resource "aws_iam_policy" "rds_iam_auth" {
     Version = "2012-10-17"
     Statement = [
       {
-        Effect = "Allow"
-        Action = "rds-db:connect"
+        Effect   = "Allow"
+        Action   = "rds-db:connect"
         Resource = "arn:aws:rds-db:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:dbuser:${aws_db_instance.this.resource_id}/${var.iam_database_user}"
       }
     ]

--- a/modules/aws/postgres/main.tf
+++ b/modules/aws/postgres/main.tf
@@ -72,6 +72,14 @@ resource "aws_iam_policy" "rds_iam_auth" {
   })
 }
 
+# Attach the policy to the specified IAM role (e.g., IRSA role for K8s pods)
+resource "aws_iam_role_policy_attachment" "rds_iam_auth" {
+  count = var.iam_database_authentication_enabled && var.iam_database_user != null && var.iam_auth_role_name != null ? 1 : 0
+
+  role       = var.iam_auth_role_name
+  policy_arn = aws_iam_policy.rds_iam_auth[0].arn
+}
+
 # NOTE: The IAM database user must be created manually in PostgreSQL.
 # Connect as the admin user and run:
 #

--- a/modules/aws/postgres/outputs.tf
+++ b/modules/aws/postgres/outputs.tf
@@ -2,3 +2,8 @@ output "connection_url" {
   value     = "postgres://${aws_db_instance.this.username}:${aws_db_instance.this.password}@${aws_db_instance.this.endpoint}/${aws_db_instance.this.db_name}"
   sensitive = true
 }
+
+output "iam_connection_url" {
+  description = "Connection URL for IAM authentication (no password)"
+  value       = var.iam_database_user != null ? "postgres://${var.iam_database_user}@${aws_db_instance.this.endpoint}/${aws_db_instance.this.db_name}" : null
+}

--- a/modules/aws/postgres/outputs.tf
+++ b/modules/aws/postgres/outputs.tf
@@ -4,6 +4,6 @@ output "connection_url" {
 }
 
 output "iam_connection_url" {
-  description = "Connection URL for IAM authentication (no password)"
-  value       = var.iam_database_user != null ? "postgres://${var.iam_database_user}@${aws_db_instance.this.endpoint}/${aws_db_instance.this.db_name}" : null
+  description = "Connection URL for IAM authentication (no password). Use as POSTGRES_IAM_CONNECTION_URI"
+  value       = var.iam_database_user != null ? "postgresql://${var.iam_database_user}@${aws_db_instance.this.endpoint}/${aws_db_instance.this.db_name}" : null
 }

--- a/modules/aws/postgres/variables.tf
+++ b/modules/aws/postgres/variables.tf
@@ -69,3 +69,9 @@ variable "iam_database_user" {
   description = "Database username for IAM authentication. This user must be created in PostgreSQL with 'GRANT rds_iam TO <user>'"
   default     = null
 }
+
+variable "iam_auth_role_name" {
+  type        = string
+  description = "Name of the IAM role to attach the RDS IAM auth policy to (e.g., IRSA role for K8s pods)"
+  default     = null
+}

--- a/modules/aws/postgres/variables.tf
+++ b/modules/aws/postgres/variables.tf
@@ -63,3 +63,9 @@ variable "iam_database_authentication_enabled" {
   description = "Whether to enable IAM database authentication"
   default     = true
 }
+
+variable "iam_database_user" {
+  type        = string
+  description = "Database username for IAM authentication. This user must be created in PostgreSQL with 'GRANT rds_iam TO <user>'"
+  default     = null
+}


### PR DESCRIPTION
saw this in tf plan:
```
# module.langsmith.module.postgres.aws_iam_policy.rds_iam_auth[0] will be created
  + resource "aws_iam_policy" "rds_iam_auth" {
      + arn              = (known after apply)
      + attachment_count = (known after apply)
      + description      = "Allows IAM authentication to RDS PostgreSQL instance langsmith-postgres-self-hosted-ci"
      + id               = (known after apply)
      + name             = "langsmith-postgres-self-hosted-ci-rds-iam-auth"
      + name_prefix      = (known after apply)
      + path             = "/"
      + policy           = jsonencode(
            {
              + Statement = [
                  + {
                      + Action   = "rds-db:connect"
                      + Effect   = "Allow"
                      + Resource = "arn:aws:rds-db:us-west-2:<REDACTED>:dbuser:db-<REDACTED>/langsmith_iam_user"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + policy_id        = (known after apply)
      + tags_all         = (known after apply)
    }
```