### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tf_format.yaml
+++ b/.github/workflows/tf_format.yaml
@@ -6,6 +6,9 @@ on:
       - "modules/**"
       - ".github/workflows/tf_format.yaml"
 
+permissions:
+  contents: read
+
 jobs:
   terraform_check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/langchain-ai/terraform/security/code-scanning/1](https://github.com/langchain-ai/terraform/security/code-scanning/1)

To fix the problem, add an explicit `permissions` block that grants only the minimal rights needed. This workflow only checks out code and runs Terraform commands locally; it does not write to the repository, create releases, or modify issues/PRs. Therefore, setting `contents: read` is sufficient and aligns with the recommendation from CodeQL and GitHub.

The best way to fix this without changing functionality is to add a workflow-level `permissions` block near the top of `.github/workflows/tf_format.yaml`, so it applies to all jobs. Place it after the `name` (and optionally after `on:`) but before `jobs:`. For this specific file, modify `.github/workflows/tf_format.yaml` to include:

```yaml
permissions:
  contents: read
```

No imports, methods, or additional definitions are needed since this is GitHub Actions configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
