### PR TITLE
docs(modules): fix Azure ARCHITECTURE image paths and stale terraform/<provider>/ refs

### DIFF
--- a/modules/aws/QUICK_REFERENCE.md
+++ b/modules/aws/QUICK_REFERENCE.md
@@ -1,13 +1,13 @@
 # LangSmith on AWS — Quick Reference
 
-All commands run from `terraform/aws/`. Run `make help` to see all targets.
+All commands run from `modules/aws/`. Run `make help` to see all targets.
 
 ---
 
 ## First-Time Setup
 
 ```bash
-cd terraform/aws
+cd modules/aws
 
 # 1. Generate terraform.tfvars (interactive wizard — region, node size, TLS, addons)
 make quickstart
@@ -207,7 +207,7 @@ aws iam get-role --role-name <irsa-role-name>
 ## Terraform Commands
 
 ```bash
-cd terraform/aws/infra
+cd modules/aws/infra
 
 terraform init
 terraform plan
@@ -226,7 +226,7 @@ terraform state list
 ## Teardown
 
 ```bash
-cd terraform/aws
+cd modules/aws
 
 # Option A: script-driven deploy
 make uninstall

--- a/modules/azure/ARCHITECTURE.md
+++ b/modules/azure/ARCHITECTURE.md
@@ -8,7 +8,7 @@
 
 **[LangSmith Azure — Production Architecture (v0.13.28)](https://app.eraser.io/workspace/oto9FgBOY2s7877578R2)**
 
-![LangSmith Azure Production Architecture](diagrams/production-deploy-architecture.png)
+![LangSmith Azure Production Architecture](diagrams/lang_smith_deployment_pass_4_5.png)
 
 Full topology: all passes (2–4), AKS namespaces, pod names, external managed services, Workload Identity flow, Key Vault, TLS, KEDA, NGINX.
 
@@ -51,7 +51,7 @@ Exact pod topology from `kubectl get pods -n langsmith` after successful Pass 2 
 
 **[LangSmith Azure — Light Deploy Architecture (v0.13.28)](https://app.eraser.io/workspace/sQxjXna8084czm2eRPFj)**
 
-![LangSmith Azure Light Deploy Architecture](diagrams/light-deploy-architecture.png)
+![LangSmith Azure Light Deploy Architecture](diagrams/lang_smith_deployment_light.png)
 
 ---
 

--- a/modules/azure/QUICK_REFERENCE.md
+++ b/modules/azure/QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # LangSmith Azure — Quick Reference
 
-All commands run from `terraform/azure/`. Run `make help` to see all targets.
+All commands run from `modules/azure/`. Run `make help` to see all targets.
 
 For demo/POC (all in-cluster DBs) see [BUILDING_LIGHT_LANGSMITH.md](BUILDING_LIGHT_LANGSMITH.md).
 
@@ -9,7 +9,7 @@ For demo/POC (all in-cluster DBs) see [BUILDING_LIGHT_LANGSMITH.md](BUILDING_LIG
 ## First-Time Setup
 
 ```bash
-cd terraform/azure
+cd modules/azure
 
 # 1. Generate terraform.tfvars (interactive wizard — subscription, region, ingress, TLS, sizing)
 make quickstart

--- a/modules/gcp/QUICK_REFERENCE.md
+++ b/modules/gcp/QUICK_REFERENCE.md
@@ -1,6 +1,6 @@
 # LangSmith on GCP — Quick Reference
 
-All commands run from `terraform/gcp/`. Run `make help` to see all targets.
+All commands run from `modules/gcp/`. Run `make help` to see all targets.
 
 ---
 
@@ -22,7 +22,7 @@ Each pass builds on the previous. Verify pods are healthy before enabling the ne
 ## First-Time Setup
 
 ```bash
-cd terraform/gcp
+cd modules/gcp
 
 # Interactive wizard — generates terraform.tfvars from guided prompts
 make quickstart
@@ -127,14 +127,14 @@ gcloud config set project <your-project-id>
 gcloud auth application-default login
 
 # Recommended workflow
-cd terraform/gcp
+cd modules/gcp
 make preflight
 make init
 make plan
 make apply
 
 # Configure
-cd terraform/gcp/infra
+cd modules/gcp/infra
 cp terraform.tfvars.example terraform.tfvars
 # Edit terraform.tfvars with your values
 
@@ -160,7 +160,7 @@ kubectl get secrets -n langsmith
 
 ```bash
 # Recommended: use the scripted deployment
-cd terraform/gcp
+cd modules/gcp
 make init-values   # generates values-overrides.yaml from Terraform outputs
 make deploy        # runs helm upgrade --install with the full values chain
 


### PR DESCRIPTION
## Summary

Two content bugs across the per-provider module READMEs:

**Bug 1 — broken image refs in [modules/azure/ARCHITECTURE.md](modules/azure/ARCHITECTURE.md):** the two `![...](diagrams/...)` embeds pointed at files that don't exist in [modules/azure/diagrams/](modules/azure/diagrams/). Remapped to the files that are actually on disk:

| Section | Old reference | New reference |
|---|---|---|
| Production Deploy (External Postgres + Redis) | `diagrams/production-deploy-architecture.png` | `diagrams/lang_smith_deployment_pass_4_5.png` |
| Light Deploy (All In-Cluster) | `diagrams/light-deploy-architecture.png` | `diagrams/lang_smith_deployment_light.png` |

The production diagram maps to `pass_4_5` (the most complete pass) — surrounding text describes "Full topology: all passes (2–4), AKS namespaces, pod names, external managed services, Workload Identity flow, Key Vault, TLS, KEDA, NGINX." `pass_2.png` and `pass_3.png` remain unreferenced as images; the Pass 2/3/4 sections only link to Eraser workspaces, consistent with the existing pattern.

**Bug 2 — stale `terraform/<provider>/` path refs** in the three QUICK_REFERENCE.md files. Upstream layout is `modules/<provider>/`, so opening-paragraph "run from" instructions and every `cd terraform/<provider>` block needed to be retargeted. Updated 11 occurrences across aws (4), azure (2), and gcp (5).

Per the source brief: no YAML frontmatter changes — that's a separate planned PR.

## Test plan

- [ ] Open this PR on GitHub and confirm both images in [modules/azure/ARCHITECTURE.md](modules/azure/ARCHITECTURE.md) render (Production Deploy + Light Deploy sections).
- [ ] Confirm the three QUICK_REFERENCE.md files no longer contain `terraform/aws/`, `terraform/azure/`, or `terraform/gcp/` references: `git grep -n 'terraform/aws\|terraform/azure\|terraform/gcp' modules/*/QUICK_REFERENCE.md` should return nothing.