### PR TITLE
docs(all): add page frontmatter to module READMEs

### DIFF
--- a/modules/aws/ARCHITECTURE.md
+++ b/modules/aws/ARCHITECTURE.md
@@ -1,3 +1,10 @@
+---
+title: "Architecture Reference"
+description: "Platform layers, component overview, and infrastructure architecture for LangSmith on AWS."
+provider: "aws"
+type: "reference"
+---
+
 # LangSmith on AWS — Architecture
 
 ---

--- a/modules/aws/QUICK_REFERENCE.md
+++ b/modules/aws/QUICK_REFERENCE.md
@@ -1,3 +1,10 @@
+---
+title: "Quick Reference"
+description: "Essential commands and shortcuts for managing a LangSmith deployment on AWS."
+provider: "aws"
+type: "reference"
+---
+
 # LangSmith on AWS — Quick Reference
 
 All commands run from `terraform/aws/`. Run `make help` to see all targets.

--- a/modules/aws/TEARDOWN.md
+++ b/modules/aws/TEARDOWN.md
@@ -1,3 +1,10 @@
+---
+title: "Teardown Guide"
+description: "Step-by-step instructions for safely destroying a LangSmith deployment on AWS."
+provider: "aws"
+type: "teardown"
+---
+
 # LangSmith on AWS — Teardown Guide
 
 > Check the [LangSmith Self-Hosted Changelog](https://docs.langchain.com/langsmith/self-hosted-changelog) before destroying for any notes on data migration or export.

--- a/modules/aws/TROUBLESHOOTING.md
+++ b/modules/aws/TROUBLESHOOTING.md
@@ -1,3 +1,10 @@
+---
+title: "Troubleshooting Guide"
+description: "Common issues, diagnostics, and fixes for LangSmith deployments on AWS."
+provider: "aws"
+type: "troubleshooting"
+---
+
 # LangSmith on AWS — Troubleshooting Guide
 
 > Check the [LangSmith Self-Hosted Changelog](https://docs.langchain.com/langsmith/self-hosted-changelog) before upgrading for breaking changes and required variable updates.

--- a/modules/azure/ARCHITECTURE.md
+++ b/modules/azure/ARCHITECTURE.md
@@ -1,3 +1,10 @@
+---
+title: "Architecture Reference"
+description: "Platform layers, component overview, and infrastructure architecture for LangSmith on Azure."
+provider: "azure"
+type: "reference"
+---
+
 # LangSmith Azure — Architecture
 
 *Updated as deployment is validated.*

--- a/modules/azure/QUICK_REFERENCE.md
+++ b/modules/azure/QUICK_REFERENCE.md
@@ -1,3 +1,10 @@
+---
+title: "Quick Reference"
+description: "Essential commands and shortcuts for managing a LangSmith deployment on Azure."
+provider: "azure"
+type: "reference"
+---
+
 # LangSmith Azure — Quick Reference
 
 All commands run from `terraform/azure/`. Run `make help` to see all targets.

--- a/modules/azure/TEARDOWN.md
+++ b/modules/azure/TEARDOWN.md
@@ -1,3 +1,10 @@
+---
+title: "Teardown Guide"
+description: "Step-by-step instructions for safely destroying a LangSmith deployment on Azure."
+provider: "azure"
+type: "teardown"
+---
+
 # LangSmith Azure — Teardown Guide
 
 > Before destroying, back up any traces or data you want to keep — PostgreSQL and Blob Storage are permanently deleted.

--- a/modules/azure/TROUBLESHOOTING.md
+++ b/modules/azure/TROUBLESHOOTING.md
@@ -1,3 +1,10 @@
+---
+title: "Troubleshooting Guide"
+description: "Common issues, diagnostics, and fixes for LangSmith deployments on Azure."
+provider: "azure"
+type: "troubleshooting"
+---
+
 # LangSmith Azure — Troubleshooting
 
 Issues, gotchas, and fixes. Updated as deployments are validated.

--- a/modules/gcp/ARCHITECTURE.md
+++ b/modules/gcp/ARCHITECTURE.md
@@ -1,3 +1,10 @@
+---
+title: "Architecture Reference"
+description: "Platform layers, component overview, and infrastructure architecture for LangSmith on GCP."
+provider: "gcp"
+type: "reference"
+---
+
 # LangSmith on GCP — Architecture
 
 ---

--- a/modules/gcp/QUICK_REFERENCE.md
+++ b/modules/gcp/QUICK_REFERENCE.md
@@ -1,3 +1,10 @@
+---
+title: "Quick Reference"
+description: "Essential commands and shortcuts for managing a LangSmith deployment on GCP."
+provider: "gcp"
+type: "reference"
+---
+
 # LangSmith on GCP — Quick Reference
 
 All commands run from `terraform/gcp/`. Run `make help` to see all targets.

--- a/modules/gcp/TEARDOWN.md
+++ b/modules/gcp/TEARDOWN.md
@@ -1,3 +1,10 @@
+---
+title: "Teardown Guide"
+description: "Step-by-step instructions for safely destroying a LangSmith deployment on GCP."
+provider: "gcp"
+type: "teardown"
+---
+
 # LangSmith on GCP — Teardown Guide
 
 > Check the [LangSmith Self-Hosted Changelog](https://docs.langchain.com/langsmith/self-hosted-changelog) before destroying for any notes on data migration or export.

--- a/modules/gcp/TROUBLESHOOTING.md
+++ b/modules/gcp/TROUBLESHOOTING.md
@@ -1,3 +1,10 @@
+---
+title: "Troubleshooting Guide"
+description: "Common issues, diagnostics, and fixes for LangSmith deployments on GCP."
+provider: "gcp"
+type: "troubleshooting"
+---
+
 # LangSmith on GCP — Troubleshooting Guide
 
 > Check the [LangSmith Self-Hosted Changelog](https://docs.langchain.com/langsmith/self-hosted-changelog) before upgrading for breaking changes and required variable updates.

--- a/modules/ocp/ARCHITECTURE.md
+++ b/modules/ocp/ARCHITECTURE.md
@@ -1,3 +1,10 @@
+---
+title: "Architecture Reference"
+description: "Platform layers, component overview, and infrastructure architecture for LangSmith on OpenShift."
+provider: "ocp"
+type: "reference"
+---
+
 # LangSmith on OCP — Architecture
 
 ## POC: Single Node OpenShift on Azure Baremetal Host

--- a/modules/ocp/QUICK_REFERENCE.md
+++ b/modules/ocp/QUICK_REFERENCE.md
@@ -1,3 +1,10 @@
+---
+title: "Quick Reference"
+description: "Essential commands and shortcuts for managing a LangSmith deployment on OpenShift."
+provider: "ocp"
+type: "reference"
+---
+
 # LangSmith on OCP — Quick Reference
 
 > **Status: Coming Soon** — Commands will be added when the OCP module is available.

--- a/modules/ocp/TEARDOWN.md
+++ b/modules/ocp/TEARDOWN.md
@@ -1,3 +1,10 @@
+---
+title: "Teardown Guide"
+description: "Step-by-step instructions for safely destroying a LangSmith deployment on OpenShift."
+provider: "ocp"
+type: "teardown"
+---
+
 # LangSmith on OCP — Teardown Guide
 
 > **Status: Coming Soon** — This guide will be updated when the OCP module is available.

--- a/modules/ocp/TROUBLESHOOTING.md
+++ b/modules/ocp/TROUBLESHOOTING.md
@@ -1,3 +1,10 @@
+---
+title: "Troubleshooting Guide"
+description: "Common issues, diagnostics, and fixes for LangSmith deployments on OpenShift."
+provider: "ocp"
+type: "troubleshooting"
+---
+
 # LangSmith on OCP — Troubleshooting Guide
 
 > **Status: Coming Soon** — This guide will be updated as the OCP module is developed.


### PR DESCRIPTION
## Summary

Prepends YAML frontmatter (`title`, `description`, `provider`, `type`) to the 16 per-provider module READMEs:

- `modules/{aws,azure,gcp,ocp}/ARCHITECTURE.md`
- `modules/{aws,azure,gcp,ocp}/QUICK_REFERENCE.md`
- `modules/{aws,azure,gcp,ocp}/TROUBLESHOOTING.md`
- `modules/{aws,azure,gcp,ocp}/TEARDOWN.md`

Body content is unchanged — this is a pure metadata addition. Frontmatter is invisible in GitHub's markdown preview (rendered as a metadata table).

## Why

Required by the internal `langchain-ai/ps-ops-center` docs site sync, which mirrors these module READMEs into the documentation site at build time. The sync script on branch [`feat/docs-terraform-mirror`](https://github.com/langchain-ai/ps-ops-center/tree/feat/docs-terraform-mirror) fails loudly when required frontmatter is missing, and cannot deploy until this PR merges.

The frontmatter fields drive:
- `title` — the page title in the docs site nav
- `description` — meta description / search snippet
- `provider` — used to group pages by cloud
- `type` — used to categorize pages (`reference` / `troubleshooting` / `teardown`)

## Test plan

- [x] All 16 frontmatter blocks parse with a standard YAML parser (verified locally with PyYAML)
- [x] Each block contains exactly the four expected keys with correct provider-label substitutions (aws→AWS, azure→Azure, gcp→GCP, ocp→OpenShift)
- [x] No body content modified — diff is exactly +7 lines per file (frontmatter + blank line)
- [x] H1 still present immediately after the frontmatter block
- [ ] Confirm GitHub markdown preview still renders the H1 correctly (reviewer)
- [ ] Once merged, confirm the `ps-ops-center` `feat/docs-terraform-mirror` sync builds successfully