### PR TITLE
fix(aws): replace em-dash in bastion SG description with ASCII hyphen

### DIFF
--- a/modules/aws/infra/modules/bastion/main.tf
+++ b/modules/aws/infra/modules/bastion/main.tf
@@ -70,7 +70,7 @@ resource "aws_iam_instance_profile" "bastion" {
 
 resource "aws_security_group" "bastion" {
   name_prefix = "${var.name}-bastion-"
-  description = "Bastion host — SSM + optional SSH ingress"
+  description = "Bastion host - SSM + optional SSH ingress"
   vpc_id      = var.vpc_id
   tags        = var.tags
 


### PR DESCRIPTION
## Summary
- One-line fix: `modules/aws/infra/modules/bastion/main.tf:73` — replace em-dash (`—`, U+2014) with ASCII hyphen in the security group description.
- Unblocks `make apply` when `create_bastion = true` (the default).

## Why
AWS EC2 `CreateSecurityGroup` returns `InvalidParameterValue: Character sets beyond ASCII are not supported` when `GroupDescription` contains non-ASCII characters. The bastion module's description field used an em-dash, so every `make apply` with `create_bastion = true` failed at the bastion SG creation step:

```
Error: creating Security Group (...-bastion-bastion-...): InvalidParameterValue:
  Value (Bastion host — SSM + optional SSH ingress) for parameter GroupDescription is invalid.
  Character sets beyond ASCII are not supported.
```

Full context, scope check across other AWS modules, and root cause are documented in the companion PR adding `modules/aws/DEPLOYMENT_NOTES.md` (#42), under "Bug: Bastion security group create fails — em-dash in description rejected by EC2".

## Scope check
`grep -rn $'[^\x00-\x7F]' modules/aws/infra/modules/ --include='*.tf'` surfaces em-dashes in five other places, but all are Terraform `variable` block descriptions — documentation only, not sent to any AWS API. The bastion security group `description` is the only AWS-facing string, so this is the only place that breaks apply.

## Test plan
- [ ] `terraform plan` against a fresh AWS account with `create_bastion = true` shows the SG update
- [ ] `terraform apply` reaches and succeeds at the bastion SG creation step (previously failed here)
- [ ] No regression when `create_bastion = false` (module is conditional)