### PR TITLE
fix(aws): read region from terraform.tfvars in preflight modes

### DIFF
--- a/modules/aws/infra/scripts/preflight.sh
+++ b/modules/aws/infra/scripts/preflight.sh
@@ -137,9 +137,13 @@ run_post_infra_checks() {
   info "Validating cluster access, SSM params, Helm values, and TLS config."
   printf "\n"
 
-  # Resolve region (same logic as the default mode)
+  # Resolve region — terraform.tfvars is the source of truth (matches
+  # secrets-status.sh, manage-ssm.sh, etc.). Falls back to env vars and
+  # `aws configure` when tfvars is absent or has no `region`.
   local region
-  region=$(aws configure get region 2>/dev/null || true)
+  region=$(_tfvars_get "region" "$tfvars")
+  region=${region:-${AWS_REGION:-}}
+  region=${region:-$(aws configure get region 2>/dev/null || true)}
   region=${region:-${AWS_DEFAULT_REGION:-us-east-2}}
   info "Region : $region"
   printf "\n"
@@ -245,13 +249,18 @@ if [[ "$MODE" == "ssm-only" ]]; then
     error "Not authenticated. Run 'aws configure' or set AWS_* environment variables."
     exit 1
   fi
-  _REGION=$(aws configure get region 2>/dev/null || true)
-  _REGION=${_REGION:-${AWS_DEFAULT_REGION:-us-east-2}}
   _TFVARS="${_SCRIPT_DIR_EARLY}/../terraform.tfvars"
   if [[ ! -f "$_TFVARS" ]]; then
     error "terraform.tfvars not found at $_TFVARS"
     exit 1
   fi
+  # Resolve region — terraform.tfvars is the source of truth (matches
+  # secrets-status.sh, manage-ssm.sh, etc.). Falls back to env vars and
+  # `aws configure` when tfvars has no `region`.
+  _REGION=$(_tfvars_get "region" "$_TFVARS")
+  _REGION=${_REGION:-${AWS_REGION:-}}
+  _REGION=${_REGION:-$(aws configure get region 2>/dev/null || true)}
+  _REGION=${_REGION:-${AWS_DEFAULT_REGION:-us-east-2}}
   printf "\n"
   info "=== LangSmith AWS Preflight (SSM-only) ==="
   printf "\n"
@@ -332,7 +341,12 @@ fi
 
 ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
 USER_ARN=$(aws sts get-caller-identity --query Arn --output text)
-REGION=$(aws configure get region 2>/dev/null || true)
+# Resolve region — terraform.tfvars is the source of truth (matches
+# secrets-status.sh, manage-ssm.sh, etc.). Falls back to env vars and
+# `aws configure` when tfvars has no `region`.
+REGION=$(_tfvars_get "region" "$TFVARS")
+REGION=${REGION:-${AWS_REGION:-}}
+REGION=${REGION:-$(aws configure get region 2>/dev/null || true)}
 REGION=${REGION:-${AWS_DEFAULT_REGION:-us-east-2}}
 
 info "Account ID : $ACCOUNT_ID"


### PR DESCRIPTION
## Summary

Align `preflight.sh` region resolution with the rest of the AWS scripts so that `terraform.tfvars` is the source of truth, fixing a foot-gun where `make preflight-ssm` reports SSM params missing even though `make secrets` reports them set.

## Problem

`preflight.sh` resolved region via `aws configure get region`, falling back to `AWS_DEFAULT_REGION`, then `us-east-2`. Every other script in `modules/aws/` (`secrets-status.sh`, `manage-ssm.sh`, `migrate-ssm.sh`, `deploy.sh`, `init-values.sh`, `apply-eso.sh`, `setup-tls.sh`, `tls.sh`, `uninstall.sh`, `test-permutations.sh`, `test-orchestrator.sh`) reads region from `terraform.tfvars` first via `_parse_tfvar`.

The drift produces contradictory results when the AWS CLI default region differs from the deployment region. Reproduced on a deployment in `eu-central-1` with no AWS CLI region set:


```
$ make secrets

.. langsmith-license-key ✓ 
SET langsmith-api-key-salt ✓ 
SET (auto-generated) langsmith-jwt-secret ✓ 
SET (auto-generated) langsmith-admin-password ✓ 
SET postgres-password ✓ 
SET redis-auth-token ✓ 
SET (auto-generated) ✓
```

```
$ make preflight-ssm 

[INFO] SSM path prefix : /langsmith/-dev [ERROR] 
SSM param missing : /langsmith/-dev/langsmith-license-key [ERROR] 
SSM param missing : /langsmith/-dev/langsmith-api-key-salt [ERROR] 
SSM param missing : /langsmith/-dev/langsmith-jwt-secret [ERROR] 
SSM param missing : /langsmith/-dev/langsmith-admin-password [ERROR]
```

Both scripts query SSM, but in different regions.

## Fix

Use the existing local `_tfvars_get` helper in `preflight.sh` (already defined at the top of the file and used elsewhere in `run_post_infra_checks`) to read `region` from `terraform.tfvars` first. New resolution order:

1. `terraform.tfvars`
2. `AWS_REGION`
3. `aws configure get region`
4. `AWS_DEFAULT_REGION`
5. `us-east-2` (existing fallback)

Applied in all three region-resolution spots in `preflight.sh`:

- `ssm-only` mode
- `post-infra` mode (inside `run_post_infra_checks`)
- default Pass-1 mode

No new dependency: `_tfvars_get` is local to `preflight.sh` and already used in this file. `_common.sh` is intentionally not sourced (preflight.sh defines its own colors/helpers).

## Test plan

- [ ] `terraform.tfvars` `region = "eu-central-1"`, AWS CLI region unset -> `make preflight-ssm` finds SSM params (was failing)
- [ ] `terraform.tfvars` `region = "eu-central-1"`, AWS CLI region = `us-west-2` -> tfvars wins, preflight checks eu-central-1
- [ ] `terraform.tfvars` missing `region` line, AWS CLI region = `us-west-2` -> falls back to AWS CLI region (legacy behavior preserved)
- [ ] All other modes (`make preflight`, `make preflight-post`) still resolve region correctly
- [ ] `bash -n modules/aws/infra/scripts/preflight.sh` passes