### PR TITLE
fix(gcp): use envoy-gateway-system namespace for gateway lookups

### DIFF
--- a/modules/gcp/QUICK_REFERENCE.md
+++ b/modules/gcp/QUICK_REFERENCE.md
@@ -169,7 +169,7 @@ helm status langsmith -n langsmith
 kubectl get pods -n langsmith
 
 # Get Gateway IP for DNS
-kubectl get gateway -n langsmith \
+kubectl get gateway -n envoy-gateway-system \
   -o jsonpath='{.items[0].status.addresses[0].value}'
 ```
 
@@ -363,7 +363,7 @@ kubectl logs <pod-name> -n langsmith --previous --tail=50
 kubectl logs -n langsmith deploy/langsmith-backend --tail=100 -f
 
 # Gateway / HTTPRoute
-kubectl get gateway -n langsmith
+kubectl get gateway -n envoy-gateway-system
 kubectl get httproute -n langsmith
 kubectl get svc -n envoy-gateway-system
 

--- a/modules/gcp/TEST_CYCLE.md
+++ b/modules/gcp/TEST_CYCLE.md
@@ -151,7 +151,7 @@ Both must be non-null if `enable_gcp_iam_module = true` (default).
 
 ### Gateway
 ```bash
-kubectl get gateway -n langsmith
+kubectl get gateway -n envoy-gateway-system
 ```
 Expected: `PROGRAMMED = True`. External IP may show as `pending` until a `HTTPRoute` (Helm) is deployed.
 
@@ -255,7 +255,7 @@ terraform -chdir=infra output keda_installed   # true
 | Cloud SQL private IP allocation fails | `Error: servicenetworking.services.addPeering ... quota exceeded` | The project may have hit the default limit for VPC peering connections. Check in GCP Console → VPC Network → VPC Network Peering. |
 | GKE node pool not ready during apply | Pods `Pending`, StorageClass creation fails | Wait for node pool to become active — typically resolves on re-apply. |
 | `redis_prevent_destroy = true` blocks destroy | `Error: Instance is protected from destroy` | Set `redis_prevent_destroy = false` in terraform.tfvars and re-apply before destroying. |
-| Envoy Gateway `Gateway` stuck Pending | `kubectl get gateway -n langsmith` shows no address | No HTTPRoute deployed yet — install LangSmith via Helm (Pass 2) to trigger route creation and external IP assignment. |
+| Envoy Gateway `Gateway` stuck Pending | `kubectl get gateway -n envoy-gateway-system` shows no address | No HTTPRoute deployed yet — install LangSmith via Helm (Pass 2) to trigger route creation and external IP assignment. |
 | GKE cluster deletion protection | `Error: Cluster has deletion protection enabled` | Set `gke_deletion_protection = false` in terraform.tfvars and re-apply before destroying. |
 
 ---

--- a/modules/gcp/TROUBLESHOOTING.md
+++ b/modules/gcp/TROUBLESHOOTING.md
@@ -221,7 +221,7 @@ kubectl get svc -n envoy-gateway-system \
 
 ```bash
 # Get the new IP
-kubectl get gateway -n langsmith -o jsonpath='{.items[0].status.addresses[0].value}'
+kubectl get gateway -n envoy-gateway-system -o jsonpath='{.items[0].status.addresses[0].value}'
 
 # Update your DNS record (Cloud DNS example)
 gcloud dns record-sets update <your-domain>. \
@@ -431,7 +431,7 @@ kubectl get clusterissuer
 ### Gateway and load balancer
 
 ```bash
-kubectl get gateway -n langsmith
+kubectl get gateway -n envoy-gateway-system
 kubectl get httproute -n langsmith
 kubectl get svc -n envoy-gateway-system -o wide
 kubectl get pods -n envoy-gateway-system
@@ -505,7 +505,7 @@ echo "=== Context ===" && kubectl config current-context
 echo "=== Nodes ===" && kubectl get nodes
 echo "=== Pods ===" && kubectl get pods -n langsmith
 echo "=== Certificate ===" && kubectl get certificate -n langsmith
-echo "=== Gateway ===" && kubectl get gateway -n langsmith
+echo "=== Gateway ===" && kubectl get gateway -n envoy-gateway-system
 echo "=== Secrets ===" && kubectl get secrets -n langsmith | grep -E "langsmith-postgres|langsmith-redis"
 echo "=== Helm ===" && helm status langsmith -n langsmith 2>/dev/null | grep -E "STATUS|LAST DEPLOYED"
 ```

--- a/modules/gcp/helm/scripts/deploy.sh
+++ b/modules/gcp/helm/scripts/deploy.sh
@@ -80,7 +80,7 @@ echo ""
 # If the Envoy Gateway IP has changed since last deploy (e.g. after Gateway
 # resource recreation), warn the operator and update values-overrides.yaml
 # to prevent the Deployments operator from hitting stale endpoints.
-_live_gateway_ip=$(kubectl get gateway -n "$NAMESPACE" \
+_live_gateway_ip=$(kubectl get gateway -n envoy-gateway-system \
   -o jsonpath='{.items[0].status.addresses[0].value}' 2>/dev/null || true)
 if [[ -n "$_live_gateway_ip" ]]; then
   _configured_hostname=$(grep -E '^\s*hostname:' "$OVERRIDES_FILE" 2>/dev/null \
@@ -309,7 +309,7 @@ fi
 # ── Post-deploy access info ───────────────────────────────────────────────────
 _hostname=$(grep -E '^\s*hostname:' "$OVERRIDES_FILE" 2>/dev/null \
   | sed 's/.*:[[:space:]]*"\(.*\)".*/\1/' | tr -d '[:space:]') || _hostname=""
-_gateway_ip=$(kubectl get gateway -n "$NAMESPACE" \
+_gateway_ip=$(kubectl get gateway -n envoy-gateway-system \
   -o jsonpath='{.items[0].status.addresses[0].value}' 2>/dev/null || true)
 
 echo "Access LangSmith:"

--- a/modules/gcp/helm/scripts/init-values.sh
+++ b/modules/gcp/helm/scripts/init-values.sh
@@ -535,7 +535,7 @@ cat > "$OUT_FILE" << YAML
 
 config:
   # Envoy Gateway IP — required for OAuth and Deployments features.
-  # Find it with: kubectl get gateway -n langsmith -o jsonpath='{.items[0].status.addresses[0].value}'
+  # Find it with: kubectl get gateway -n envoy-gateway-system -o jsonpath='{.items[0].status.addresses[0].value}'
   hostname: "${HOSTNAME}"
   langsmithLicenseKey: "${LANGSMITH_LICENSE_KEY}"
   apiKeySalt: "${API_KEY_SALT}"
@@ -570,7 +570,7 @@ echo "Written: $OUT_FILE"
 if [[ -z "$HOSTNAME" ]]; then
   echo ""
   echo "WARNING: hostname is empty. Run again after the Envoy Gateway has an external IP:"
-  echo "  kubectl get gateway -n langsmith -o jsonpath='{.items[0].status.addresses[0].value}'"
+  echo "  kubectl get gateway -n envoy-gateway-system -o jsonpath='{.items[0].status.addresses[0].value}'"
   echo "  Then set langsmith_domain in terraform.tfvars and re-run this script."
 fi
 echo ""

--- a/modules/gcp/helm/values/examples/langsmith-values-agent-deploys.yaml
+++ b/modules/gcp/helm/values/examples/langsmith-values-agent-deploys.yaml
@@ -12,7 +12,7 @@ config:
   deployment:
     # Enables the Deployments nav item in the UI. Also requires config.hostname to be
     # set in values-overrides.yaml — find the Envoy Gateway IP with:
-    #   kubectl get gateway -n langsmith -o jsonpath='{.items[0].status.addresses[0].value}'
+    #   kubectl get gateway -n envoy-gateway-system -o jsonpath='{.items[0].status.addresses[0].value}'
     enabled: true
     # Set to true if TLS is configured (tls_certificate_source = "letsencrypt" or "existing").
     # false = HTTP-only (tls_certificate_source = "none"). The operator uses this to

--- a/modules/gcp/infra/terraform.tfvars.example
+++ b/modules/gcp/infra/terraform.tfvars.example
@@ -196,7 +196,7 @@ langsmith_helm_chart_version = ""
 # Pass 1 — HTTP only (get the Gateway IP):
 #   tls_certificate_source = "none"
 #   terraform apply
-#   # Note the gateway IP from terraform output or: kubectl get gateway -n langsmith
+#   # Note the gateway IP from terraform output or: kubectl get gateway -n envoy-gateway-system
 #   # Point your DNS A record to the gateway IP, then wait for DNS to propagate.
 #
 # Pass 2 — Enable TLS:


### PR DESCRIPTION
The Envoy Gateway resource lives in the `envoy-gateway-system` namespace, not the `langsmith` application namespace. All `kubectl get gateway` commands were incorrectly using `-n langsmith` (or `-n $NAMESPACE`), causing IP lookups to silently return empty and staleness checks to be skipped.

Files updated:
  helm/scripts/deploy.sh          — pre-deploy staleness check + post-deploy IP display
  helm/scripts/init-values.sh     — gateway IP lookup instructions
  TROUBLESHOOTING.md              — diagnostic commands
  QUICK_REFERENCE.md              — reference commands
  TEST_CYCLE.md                   — test procedure commands
  infra/terraform.tfvars.example  — inline comment
  examples/langsmith-values-agent-deploys.yaml — inline comment