### PR TITLE
fix(aws): source ALB ingress hostname from controller-provisioned ALB

### DIFF
--- a/modules/aws/helm/scripts/deploy.sh
+++ b/modules/aws/helm/scripts/deploy.sh
@@ -110,12 +110,44 @@ _enable_insights=false
 _enable_polly=false
 _enable_envoy_gateway=false
 _enable_istio_gateway=false
+_enable_nginx_ingress=false
 _tfvar_is_true "enable_deployments"   && _enable_deployments=true
 _tfvar_is_true "enable_agent_builder" && _enable_agent_builder=true
 _tfvar_is_true "enable_insights"      && _enable_insights=true
 _tfvar_is_true "enable_polly"         && _enable_polly=true
 _tfvar_is_true "enable_envoy_gateway" && _enable_envoy_gateway=true
 _tfvar_is_true "enable_istio_gateway" && _enable_istio_gateway=true
+_tfvar_is_true "enable_nginx_ingress" && _enable_nginx_ingress=true
+
+# Classic ALB Ingress mode = none of the gateway/nginx routing modes are enabled.
+# In that mode the AWS Load Balancer Controller creates and owns the ALB, so the
+# external hostname must be read from the Ingress status — not the Terraform ALB
+# (alb_dns_name), which is a separate, unused ALB in this mode.
+_alb_ingress_mode=false
+if [[ "$_enable_envoy_gateway" != "true" && "$_enable_istio_gateway" != "true" && "$_enable_nginx_ingress" != "true" ]]; then
+  _alb_ingress_mode=true
+fi
+
+# Resolve the external entry hostname for the hostname-sync logic below.
+#   $1 = max attempts (1 = single best-effort read, no waiting between attempts).
+# In ALB Ingress mode the controller-owned ALB's DNS is published on the Ingress
+# status; it appears a couple minutes after the first helm upgrade, so callers
+# that run post-deploy pass a retry count. In NGINX/Envoy/Istio modes the
+# Terraform-provisioned ALB is the entry point and is read from its output.
+_resolve_entry_hostname() {
+  local _retries="${1:-1}" _h="" _i
+  if [[ "$_alb_ingress_mode" == "true" ]]; then
+    for (( _i = 1; _i <= _retries; _i++ )); do
+      _h=$(kubectl get ingress "${RELEASE_NAME}-ingress" -n "$NAMESPACE" \
+        -o jsonpath='{.status.loadBalancer.ingress[0].hostname}' 2>/dev/null) || _h=""
+      [[ -n "$_h" ]] && break
+      (( _i < _retries )) && sleep "${INGRESS_HOSTNAME_RETRY_INTERVAL:-15}"
+    done
+    printf '%s' "$_h"
+  else
+    terraform -chdir="$INFRA_DIR" output -raw alb_dns_name 2>/dev/null || true
+  fi
+}
 
 # Validate addon dependencies
 if [[ "$_enable_agent_builder" == "true" && "$_enable_deployments" != "true" ]]; then
@@ -191,12 +223,15 @@ else
 fi
 
 # ── Pre-deploy hostname check ────────────────────────────────────────────────
-# On upgrades verify config.hostname matches the ALB DNS name.
-# In all modes (ALB, Envoy Gateway, Istio) the ALB is the external entry point.
-# A stale hostname causes the operator to set unreachable agent endpoints, which
-# keeps the bootstrap hook stuck at DEPLOYING and times out the release.
+# On upgrades verify config.hostname matches the external entry hostname.
+# The entry point is the ALB in all modes, but in classic ALB Ingress mode that
+# ALB is controller-owned and its DNS is read from the Ingress status (single
+# best-effort attempt here — on a first deploy the Ingress doesn't exist yet and
+# there is nothing to sync). A stale hostname causes the operator to set
+# unreachable agent endpoints, which keeps the bootstrap hook stuck at DEPLOYING
+# and times out the release.
 _live_lb=""
-_live_lb=$(terraform -chdir="$INFRA_DIR" output -raw alb_dns_name 2>/dev/null) || true
+_live_lb=$(_resolve_entry_hostname 1) || true
 if [[ -n "$_live_lb" && -z "$_langsmith_domain" ]]; then
   _configured_hostname=$(grep -E '^\s*hostname:' "$ENV_FILE" 2>/dev/null \
     | head -1 | sed 's/.*:[[:space:]]*"\{0,1\}\([^"]*\)"\{0,1\}/\1/' | tr -d '[:space:]') || _configured_hostname=""
@@ -328,13 +363,14 @@ kubectl rollout restart deployment/"$RELEASE_NAME"-frontend -n "$NAMESPACE"
 kubectl rollout status deployment/"$RELEASE_NAME"-frontend -n "$NAMESPACE" --timeout=2m
 
 # ── Detect active hostname (ALB — always the external entry point) ─────────────
-# In all modes (ALB, Envoy Gateway, Istio) the ALB is the external entry point.
-# Read the ALB DNS name from Terraform output, which is always available once
-# terraform apply completes (ALB is provisioned before Helm deploy).
+# The ALB is the external entry point in all modes. In classic ALB Ingress mode
+# the controller owns the ALB and publishes its DNS on the Ingress status, which
+# appears a couple minutes after the first helm upgrade — so we retry. In
+# NGINX/Envoy/Istio modes the Terraform-provisioned ALB output is used.
 # Patch config.hostname + deployment.url in the overrides file if stale, then
 # re-run helm upgrade so HTTPRoute hostname filters and deployment URLs are correct.
 _active_host=""
-_active_host=$(terraform -chdir="$INFRA_DIR" output -raw alb_dns_name 2>/dev/null) || true
+_active_host=$(_resolve_entry_hostname 10) || true
 [[ -n "$_active_host" ]] && echo "ALB hostname: $_active_host"
 
 if [[ -n "$_active_host" ]]; then

--- a/modules/aws/helm/scripts/init-values.sh
+++ b/modules/aws/helm/scripts/init-values.sh
@@ -70,6 +70,11 @@ if (( _gateway_modes > 1 )); then
   exit 1
 fi
 
+# Classic ALB Ingress mode = none of the gateway/nginx routing modes enabled.
+# In that mode the AWS Load Balancer Controller creates and owns the ALB.
+_alb_ingress_mode=false
+(( _gateway_modes == 0 )) && _alb_ingress_mode=true
+
 if [[ -z "$_name_prefix" || -z "$_environment" || -z "$_region" ]]; then
   echo "ERROR: Could not read name_prefix, environment, and/or region from $INFRA_DIR/terraform.tfvars." >&2
   echo "       Ensure terraform.tfvars has these values set." >&2
@@ -122,7 +127,22 @@ echo "  acm_certificate_arn    = ${ACM_CERT_ARN:-(not set)}"
 echo ""
 
 # ── Hostname ──────────────────────────────────────────────────────────────────
-# Hostname priority: custom domain > existing value > ALB DNS name
+# Hostname priority: custom domain > existing value > entry-ALB hostname.
+# The entry-ALB hostname depends on the routing mode:
+#   - Classic ALB Ingress mode: the AWS Load Balancer Controller creates and owns
+#     the ALB; its DNS name is only known from the Ingress status after the Ingress
+#     is reconciled. Do NOT use the Terraform alb_dns_name here — that is a
+#     separate, unused ALB in this mode, and pointing at it strands all routing.
+#     On first run the Ingress doesn't exist yet, so this resolves to blank and
+#     deploy.sh patches config.hostname/deployment.url once the controller
+#     provisions the ALB.
+#   - NGINX / Envoy / Istio modes: the Terraform-provisioned ALB is the entry
+#     point (it fronts the in-cluster controller/gateway via a TargetGroupBinding).
+_ingress_alb_hostname() {
+  kubectl get ingress langsmith-ingress -n "${NAMESPACE:-langsmith}" \
+    -o jsonpath='{.status.loadBalancer.ingress[0].hostname}' 2>/dev/null || true
+}
+
 EXISTING_HOSTNAME=""
 if [[ -f "$OUT_FILE" ]]; then
   EXISTING_HOSTNAME=$(grep -E '^\s*hostname:' "$OUT_FILE" 2>/dev/null \
@@ -132,6 +152,8 @@ if [[ -n "$_langsmith_domain" ]]; then
   HOSTNAME="$_langsmith_domain"
 elif [[ -n "$EXISTING_HOSTNAME" ]]; then
   HOSTNAME="$EXISTING_HOSTNAME"
+elif [[ "$_alb_ingress_mode" == "true" ]]; then
+  HOSTNAME="$(_ingress_alb_hostname)"
 elif [[ -n "$ALB_DNS_NAME" ]]; then
   HOSTNAME="$ALB_DNS_NAME"
 else
@@ -410,19 +432,19 @@ frontend:
   service:
     type: ClusterIP"
 else
-  # Classic ALB Ingress mode
+  # Classic ALB Ingress mode — the AWS Load Balancer Controller creates and owns
+  # the ALB for this Ingress. There is no supported annotation to bind an Ingress
+  # to a pre-provisioned ALB: the old `load-balancer-arn` annotation is not a real
+  # controller annotation and was silently ignored, which produced a second,
+  # orphaned ALB and stranded all routing. We therefore let the controller own the
+  # ALB. `group.name` keeps the controller reusing a single stable ALB across
+  # Ingress reconciliations (including the operator's dynamic /lgp/* deployment
+  # paths). The hostname is read back from the Ingress status (see deploy.sh).
   _ingress_annotations=()
 
   # Always set scheme — the base values file no longer hardcodes it.
   _ingress_annotations+=("    alb.ingress.kubernetes.io/scheme: \"${ALB_SCHEME}\"")
-
-  if [[ -n "$ALB_ARN" ]]; then
-    _ingress_annotations+=("    alb.ingress.kubernetes.io/load-balancer-arn: \"${ALB_ARN}\"")
-    # group.name tells the ALB controller to bind to the existing pre-provisioned ALB
-    # instead of creating a new one on each ingress reconciliation. Without this,
-    # ingress recreation provisions a new ALB with a different hostname.
-    _ingress_annotations+=("    alb.ingress.kubernetes.io/group.name: \"${_name_prefix}-${_environment}\"")
-  fi
+  _ingress_annotations+=("    alb.ingress.kubernetes.io/group.name: \"${_name_prefix}-${_environment}\"")
 
   if [[ "$_tls_source" == "acm" || "$_tls_source" == "letsencrypt" ]]; then
     _ingress_annotations+=("    alb.ingress.kubernetes.io/listen-ports: '[{\"HTTP\": 80}, {\"HTTPS\": 443}]'")


### PR DESCRIPTION
## Summary
- In classic ALB Ingress mode the AWS Load Balancer Controller creates and owns the ALB; the scripts previously pointed config.hostname/deployment.url at the Terraform `alb_dns_name` (a separate, orphaned ALB) and emitted a non-existent `load-balancer-arn` annotation, stranding all routing (agent `/lgp/*` returned 404, deployments stuck DEPLOYING, bootstrap timed out).
- init-values.sh and deploy.sh now detect ALB Ingress mode and source the hostname from the controller-provisioned Ingress status; the no-op annotation is removed and group.name is always emitted. NGINX/Envoy/Istio modes are unchanged.

## Test plan
- [x] make init-values regenerates overrides without load-balancer-arn (group.name retained)
- [x] make deploy self-heals stale hostname to the controller ALB
- [x] Ingress rules (/ and /lgp/*) consolidated on the controller ALB host
- [x] curl http://<controller-ALB>/lgp/<agent>/ok returns 200 (no Host spoof)
- [x] langsmith-agent-bootstrap completes (no timeout)