### PR TITLE
fix(gcp): don't write deprecated config.* keys when only standalone f…

### DIFF
--- a/modules/gcp/helm/scripts/init-values.sh
+++ b/modules/gcp/helm/scripts/init-values.sh
@@ -530,13 +530,17 @@ if [[ "$_enable_agent_builder" == "true" || "$_enable_fleet" == "true" || \
     exit 1
   fi
 
-  _addon_keys_block="
+  # Only write the legacy config.* keys when the old bundled-path flags are set.
+  # chart >= 0.15.1 blocks config.agentBuilder/insights/polly via validate.yaml.
+  if [[ "$_enable_agent_builder" == "true" || "$_enable_insights" == "true" || "$_enable_polly" == "true" ]]; then
+    _addon_keys_block="
   agentBuilder:
     encryptionKey: \"${_agent_builder_key}\"
   insights:
     encryptionKey: \"${_insights_key}\"
   polly:
     encryptionKey: \"${_polly_key}\""
+  fi
 
   if [[ "$_enable_fleet" == "true" ]]; then
     _fleet_key_block="


### PR DESCRIPTION
…lags are set

init-values.sh was unconditionally writing config.agentBuilder/insights/polly encryptionKey into values-overrides.yaml whenever any addon flag was enabled. Chart >= 0.15.1 blocks these keys via validate.yaml, causing helm upgrade to fail with 'config.insights is no longer supported'.

Gate _addon_keys_block on the legacy bundled-path flags only; standalone flags (enable_fleet, enable_standalone_polly, enable_standalone_insights) write the correct top-level fleet/polly/insights blocks instead.

Tested on Helm chart version 0.15.4. 