### PR TITLE
docs(gcp): update README and QUICK_REFERENCE for chart v0.15 standalo…

### DIFF
--- a/modules/gcp/QUICK_REFERENCE.md
+++ b/modules/gcp/QUICK_REFERENCE.md
@@ -18,9 +18,9 @@ All commands run from `modules/gcp/`. Run `make help` to see all targets.
 | **1** | VPC + GKE + Cloud SQL + Memorystore + GCS + IAM + cert-manager + KEDA + Envoy Gateway | `make apply` |
 | **1.5** | Cluster credentials | `make kubeconfig` |
 | **2** | LangSmith base — frontend, backend, ingest, queue, clickhouse | `make init-values && make deploy` |
-| **3** | LangSmith Deployments — host-backend, listener, operator | `make apply && make init-values && make deploy` |
-| **4** | Agent Builder — tool-server, trigger-server + deep-agent LGP | `make init-values && make deploy` |
-| **5** | Insights + Polly — Clio analytics, Polly eval agent | `make init-values && make deploy` |
+| **3** | LangSmith Deployments — host-backend, listener, operator (optional LGP) | `make apply && make init-values && make deploy` |
+| **4** | Fleet standalone — api-server, queue, tool-server, trigger-server (chart v0.15+, no LGP required) | `make apply && make init-values && make deploy` |
+| **5** | Standalone Polly + Insights — dedicated api-server + queue each (chart v0.15+, no LGP required) | `make apply && make init-values && make deploy` |
 
 Each pass builds on the previous. Verify pods are healthy before enabling the next pass.
 
@@ -83,22 +83,28 @@ Set the feature flags in `terraform.tfvars`, then `make init-values && make depl
 
 ```hcl
 # terraform.tfvars
-enable_deployments   = true
-enable_agent_builder = true   # requires enable_deployments = true
-enable_insights      = true
-enable_polly         = true   # requires enable_deployments = true + Polly license entitlement
+
+# LangGraph Platform (optional — not required for Fleet, Polly, or Insights in v0.15+)
+enable_deployments = true
+
+# Chart v0.15+ standalone addons (do NOT require enable_deployments)
+enable_fleet               = true   # standalone Agent Builder (replaces enable_agent_builder)
+enable_standalone_polly    = true   # standalone Polly        (replaces enable_polly)
+enable_standalone_insights = true   # standalone Insights     (replaces enable_insights)
 
 # Usage telemetry (optional)
 enable_usage_telemetry = true
 ```
 
+> **Chart v0.15+:** `config.agentBuilder.*`, `config.polly.*`, and `config.insights.*` are deprecated in favor of the top-level standalone blocks. Use the standalone flags above instead.
+
 To add an addon after initial install without re-running `init-values.sh`, copy manually from `examples/`:
 
 ```bash
-cp helm/values/examples/langsmith-values-agent-deploys.yaml helm/values/
-cp helm/values/examples/langsmith-values-agent-builder.yaml helm/values/
-cp helm/values/examples/langsmith-values-insights.yaml      helm/values/
-cp helm/values/examples/langsmith-values-polly.yaml         helm/values/
+cp helm/values/examples/langsmith-values-agent-deploys.yaml    helm/values/
+cp helm/values/examples/langsmith-values-fleet.yaml            helm/values/
+cp helm/values/examples/langsmith-values-standalone-polly.yaml helm/values/
+cp helm/values/examples/langsmith-values-standalone-insights.yaml helm/values/
 
 make deploy
 ```
@@ -217,72 +223,68 @@ kubectl get pods -n keda          # KEDA running
 
 ---
 
-## Pass 4 — Agent Builder
+## Pass 4 — Fleet (v0.15+ Standalone Agent Builder)
 
-**Prerequisite:** Pass 3 healthy — `listener` and `operator` pods Running.
+**Prerequisite:** Pass 2 healthy. Does **not** require Pass 3 (LangSmith Deployments).
 
-Adds `agent-builder-tool-server`, `agent-builder-trigger-server`, and an `agentBootstrap` Job that registers the Polly agent URL.
+Fleet is the standalone replacement for the bundled Agent Builder (removed in chart v0.15). It runs as its own microservice with dedicated Cloud SQL and Memorystore provisioned by Terraform.
+
+> **Chart v0.15+.** `config.agentBuilder.*` is deprecated — use the top-level `fleet.*` block via `enable_fleet` instead.
 
 **Step 1 — enable flag in `infra/terraform.tfvars`:**
 
 ```hcl
-enable_agent_builder = true
+enable_fleet = true   # replaces enable_agent_builder (deprecated in chart v0.15+)
 ```
 
-**Step 2 — deploy:**
+**Step 2 — apply and deploy:**
 
 ```bash
-make init-values    # picks up enable_agent_builder = true
-make deploy
+make apply          # provisions fleet Cloud SQL DB + K8s secrets
+make init-values    # copies langsmith-values-fleet.yaml; injects encryptionKey
+make deploy         # rolls out fleet api-server, queue, tool-server, trigger-server
 ```
 
 **Verify:**
 
 ```bash
-kubectl get pods -n langsmith | grep -E "tool-server|trigger-server|bootstrap"
-# Expected: tool-server Running, trigger-server Running, agentBootstrap Completed
+kubectl get pods -n langsmith | grep -E "fleet|tool-server|trigger-server"
+# Expected: fleet api-server, queue, tool-server, trigger-server Running
 ```
-
-**Roll frontend** after `agentBootstrap` completes (picks up the `langsmith-polly-config` ConfigMap):
-
-```bash
-kubectl rollout restart deployment langsmith-frontend -n langsmith
-```
-
-> **Watchout:** If you skip the frontend restart, Polly shows "Unable to connect to LangGraph server".
 
 ---
 
-## Pass 5 — Insights + Polly
+## Pass 5 — Standalone Polly + Insights (v0.15+)
 
-**Prerequisite:** Pass 4 healthy — Agent Builder pods Running, `agentBootstrap` Completed.
+**Prerequisite:** Pass 2 healthy. Does **not** require Pass 3 or Pass 4.
 
-Insights enables ClickHouse-backed trace analytics. Polly is the AI eval/monitoring agent. Enable both together.
+In chart v0.15+, Polly and Insights run as standalone microservices with dedicated Cloud SQL and Memorystore provisioned by Terraform. The bundled `config.polly.*` and `config.insights.*` paths are deprecated in favor of the top-level standalone blocks.
+
+> **Chart v0.15+.** `config.polly.*` and `config.insights.*` are deprecated — use the top-level `polly.*` and `insights.*` blocks via the standalone flags below instead.
 
 **Step 1 — enable flags in `infra/terraform.tfvars`:**
 
 ```hcl
-enable_insights = true
-enable_polly    = true   # requires Polly license entitlement
+enable_standalone_polly    = true   # replaces enable_polly    (deprecated in chart v0.15+)
+enable_standalone_insights = true   # replaces enable_insights (deprecated in chart v0.15+)
 ```
 
-**Step 2 — deploy:**
+**Step 2 — apply and deploy:**
 
 ```bash
-make init-values    # picks up both flags
+make apply          # provisions polly + insights Cloud SQL DBs + K8s secrets
+make init-values    # copies langsmith-values-standalone-polly.yaml + langsmith-values-standalone-insights.yaml
 make deploy
 ```
 
 **Verify:**
 
 ```bash
-kubectl get pods -n langsmith | grep -E "clio|polly"
-# Expected: clio Running, smith-polly Running (operator-spawned)
-
-kubectl get pods -n langsmith -w   # watch until all new pods stabilize
+kubectl get pods -n langsmith | grep -E "polly|insights"
+# Expected: standalone-polly api-server + queue Running, standalone-insights api-server + queue Running
 ```
 
-> **Watchout:** `insights_encryption_key` and `polly_encryption_key` **must never change** after first enable — rotating either key permanently breaks existing encrypted data.
+> **Encryption keys must never change after first enable.** `polly_encryption_key` and `insights_encryption_key` are write-once — rotating either permanently breaks existing encrypted data.
 
 ---
 
@@ -311,21 +313,22 @@ langsmith-listener-xxx             1/1  Running    0
 langsmith-operator-xxx             1/1  Running    0
 ```
 
-**Pass 4 adds:**
+**Pass 4 adds (Fleet standalone, chart v0.15+):**
 
 ```
-langsmith-agent-builder-tool-server-xxx      1/1  Running    0
-langsmith-agent-builder-trigger-server-xxx   1/1  Running    0
-langsmith-agent-builder-bootstrap-xxx        0/1  Completed  0
-agent-builder-<hash>-xxx                     1/1  Running    0   # operator-spawned
+langsmith-fleet-api-server-xxx         1/1  Running    0
+langsmith-fleet-queue-xxx              1/1  Running    0
+langsmith-fleet-tool-server-xxx        1/1  Running    0
+langsmith-fleet-trigger-server-xxx     1/1  Running    0
 ```
 
-**Pass 5 adds:**
+**Pass 5 adds (Standalone Polly + Insights, chart v0.15+):**
 
 ```
-clio-<hash>-xxx                    1/1  Running    0   # Insights analytics
-smith-polly-<hash>-xxx             1/1  Running    0   # Polly eval agent
-lg-<hash>-0                        1/1  Running    0   # LangGraph StatefulSet
+langsmith-standalone-polly-api-server-xxx      1/1  Running    0
+langsmith-standalone-polly-queue-xxx           1/1  Running    0
+langsmith-standalone-insights-api-server-xxx   1/1  Running    0
+langsmith-standalone-insights-queue-xxx        1/1  Running    0
 ```
 
 ---
@@ -338,9 +341,9 @@ lg-<hash>-0                        1/1  Running    0   # LangGraph StatefulSet
 
 > **`config.deployment.enabled: true` is required for Pass 3.** Setting only the URL without `enabled: true` causes the chart to silently skip `listener` and `operator`.
 
-> **Encryption keys must never change after first enable.** `insights_encryption_key` and `polly_encryption_key` are write-once — rotating either permanently breaks existing encrypted data.
+> **Encryption keys must never change after first enable.** `polly_encryption_key` and `insights_encryption_key` are write-once — rotating either permanently breaks existing encrypted data.
 
-> **Roll frontend after first Polly enable.** `agentBootstrap` creates the `langsmith-polly-config` ConfigMap after registering. Frontend pods started before bootstrap completed won't pick it up automatically.
+> **Chart v0.15+ schema change.** `config.agentBuilder.*`, `config.polly.*`, and `config.insights.*` are deprecated. Use the top-level `fleet.*`, `polly.*`, and `insights.*` standalone blocks instead — enabled via `enable_fleet`, `enable_standalone_polly`, and `enable_standalone_insights`.
 
 > **Envoy Gateway IP changes on teardown.** GCP releases the external IP when the Gateway is deleted. After `terraform destroy` + re-apply, a new IP is issued — update your DNS A record.
 

--- a/modules/gcp/README.md
+++ b/modules/gcp/README.md
@@ -244,10 +244,6 @@ Or run manually — generate secrets first:
 ```bash
 export API_KEY_SALT=$(openssl rand -base64 32)
 export JWT_SECRET=$(openssl rand -base64 32)
-export AGENT_BUILDER_ENCRYPTION_KEY=$(python3 -c \
-  "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())")
-export INSIGHTS_ENCRYPTION_KEY=$(python3 -c \
-  "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())")
 export ADMIN_EMAIL="admin@example.com"
 export ADMIN_PASSWORD="<strong-password>"
 
@@ -271,8 +267,6 @@ helm upgrade --install langsmith langchain/langsmith \
   --set config.hostname="<your-langsmith-domain>" \
   --set config.basicAuth.initialOrgAdminEmail="$ADMIN_EMAIL" \
   --set config.basicAuth.initialOrgAdminPassword="$ADMIN_PASSWORD" \
-  --set config.agentBuilder.encryptionKey="$AGENT_BUILDER_ENCRYPTION_KEY" \
-  --set config.insights.encryptionKey="$INSIGHTS_ENCRYPTION_KEY" \
   --set config.blobStorage.bucketName="$(terraform output -raw storage_bucket_name)" \
   --set config.blobStorage.accessKey="$GCS_ACCESS_KEY" \
   --set config.blobStorage.accessKeySecret="$GCS_ACCESS_SECRET" \
@@ -377,6 +371,13 @@ helm upgrade langsmith langchain/langsmith \
 | `letsencrypt_email` | `""` | when letsencrypt | Email for Let's Encrypt notifications |
 | `tls_secret_name` | `langsmith-tls` | no | Name for the TLS secret in Kubernetes |
 | `enable_langsmith_deployment` | `true` | no | Enable LangSmith Deployments — installs KEDA |
+| `enable_deployments` | `false` | no | Enable LangGraph Platform (host-backend, listener, operator) |
+| `enable_fleet` | `false` | no | Enable Fleet standalone (chart v0.15+) — replaces `enable_agent_builder`; does not require `enable_deployments` |
+| `enable_standalone_polly` | `false` | no | Enable Polly standalone (chart v0.15+) — replaces `enable_polly`; does not require `enable_deployments` |
+| `enable_standalone_insights` | `false` | no | Enable Insights standalone (chart v0.15+) — replaces `enable_insights`; does not require `enable_deployments` |
+| `enable_agent_builder` | `false` | no | Deprecated (chart v0.15+) — `config.agentBuilder.*` is superseded by `enable_fleet` (`fleet.*`) |
+| `enable_insights` | `false` | no | Deprecated (chart v0.15+) — `config.insights.*` is superseded by `enable_standalone_insights` (`insights.*`) |
+| `enable_polly` | `false` | no | Deprecated (chart v0.15+) — `config.polly.*` is superseded by `enable_standalone_polly` (`polly.*`) |
 | `owner` | `platform-team` | no | Owner label applied to all resources |
 | `cost_center` | `""` | no | Cost center label for billing attribution |
 | `labels` | `{}` | no | Additional labels applied to all resources |


### PR DESCRIPTION
…ne paths

Replace bundled Agent Builder / Insights / Polly references with the v0.15 standalone equivalents (fleet.*, polly.*, insights.*). Key changes:

- Pass 4: Agent Builder → Fleet standalone (enable_fleet, no LGP dependency)
- Pass 5: Insights + Polly → standalone paths (enable_standalone_polly/insights)
- Deployment overview table updated to reflect no Pass 3 prerequisite for 4/5
- Enable Optional Addons section updated with new flags and deprecation callout
- Expected Pods updated to standalone pod name patterns
- Key Watchouts: replaced agentBootstrap note with v0.15 schema deprecation note
- Variable reference: added enable_fleet/standalone_polly/standalone_insights, marked old flags as deprecated (config.* sub-blocks superseded, not blocked)
- Pass 2 manual helm command: removed deprecated config.agentBuilder/insights --set flags and export lines