### PR TITLE
feat(azure): provision Azure Managed Redis (AMR) instead of classic Azure Cache for Redis

### DIFF
--- a/modules/azure/helm/scripts/init-values.sh
+++ b/modules/azure/helm/scripts/init-values.sh
@@ -100,6 +100,8 @@ NAMESPACE=$(terraform -chdir="$INFRA_DIR" output -raw langsmith_namespace 2>/dev
 ADMIN_EMAIL=$(terraform -chdir="$INFRA_DIR" output -raw langsmith_admin_email 2>/dev/null) || ADMIN_EMAIL=""
 CLUSTER_NAME=$(terraform -chdir="$INFRA_DIR" output -raw aks_cluster_name 2>/dev/null) || CLUSTER_NAME=""
 RG_NAME=$(terraform -chdir="$INFRA_DIR" output -raw resource_group_name 2>/dev/null) || RG_NAME=""
+# AMR (Azure Managed Redis) needs clusterSafeMode; classic cache does not. Driven by the TF output.
+REDIS_SAFE_MODE=$(terraform -chdir="$INFRA_DIR" output -raw redis_cluster_safe_mode 2>/dev/null) || REDIS_SAFE_MODE="false"
 
 echo ""
 pass "Terraform outputs read"
@@ -271,6 +273,13 @@ if [[ "$_redis_source" == "external" ]]; then
     enabled: true
     existingSecretName: "langsmith-redis-secret"
     connectionUrlSecretKey: "connection_url"'
+  # AMR is an OSS cluster reached over TLS by hostname — LangSmith must use a
+  # standalone client (clusterSafeMode), not a cluster client (whose node-IP TLS
+  # verification fails). Classic cache leaves this false.
+  if [[ "$REDIS_SAFE_MODE" == "true" ]]; then
+    _redis_block="${_redis_block}
+    clusterSafeMode: true"
+  fi
 else
   _redis_block='# redis: in-cluster (managed by Helm chart)'
 fi

--- a/modules/azure/infra/main.tf
+++ b/modules/azure/infra/main.tf
@@ -182,8 +182,10 @@ module "redis" {
   name                = local.redis_name
   location            = var.location
   resource_group_name = azurerm_resource_group.resource_group.name
-  subnet_id           = local.redis_subnet_id
-  capacity            = var.redis_capacity # P2 = 13 GB (default)
+  resource_group_id   = azurerm_resource_group.resource_group.id # azapi parent_id for AMR
+  subnet_id           = local.redis_subnet_id                    # private endpoint goes here
+  vnet_id             = local.vnet_id                            # private DNS zone link
+  amr_sku             = var.amr_sku
 
   tags = local.common_tags
 }

--- a/modules/azure/infra/modules/redis/main.tf
+++ b/modules/azure/infra/modules/redis/main.tf
@@ -1,43 +1,109 @@
 # ══════════════════════════════════════════════════════════════════════════════
 # Module: redis
-# Purpose: Azure Redis Cache (Premium) for LangSmith — private access only.
+# Purpose: Azure Managed Redis (AMR) for LangSmith — private access only.
 #
-# LangSmith uses Redis for:
-#   • Run/trace ingestion queues (async processing pipeline)
-#   • Pub/sub for real-time streaming responses (SSE to frontend)
-#   • Short-lived caching of API responses and session state
-#   • KEDA queue-depth scaling: KEDA reads queue lengths to scale workers
+# Replaces classic Azure Cache for Redis (azurerm_redis_cache), which is retiring
+# ("Creation of new Azure Cache for Redis Enterprise resources is no longer
+# supported"). AMR = Microsoft.Cache/redisEnterprise, provisioned via azapi because
+# the Balanced_* SKUs aren't reliably exposed by the azurerm provider yet.
 #
-# Why Premium SKU?
-#   • Only Premium supports VNet injection (subnet_id).
-#   • Premium provides persistence, geo-replication, and clustering (future).
-#   • Capacity 2 = P2 = 13 GB RAM — adequate for moderate LangSmith workloads.
-#     Scale to capacity 3 (P3, 26 GB) for heavy trace ingestion.
+# Networking parity with the old classic module ("private access only"):
+#   classic used VNet subnet INJECTION; AMR doesn't support that, so the private
+#   equivalent is a Private Endpoint into the same redis subnet + a private DNS zone.
 #
-# Connection: rediss://:primary_access_key@host:6380  (TLS port 6380)
+# Connection: rediss://:<url-encoded key>@<host>:10000 (TLS, OSS clustering policy).
+# LangSmith connects via redis.external.clusterSafeMode (standalone client to the
+# endpoint hostname — the cert matches the hostname; cluster node IPs would not).
 # ══════════════════════════════════════════════════════════════════════════════
 
-# Azure Redis Cache — Premium tier with VNet injection.
-# public_network_access_enabled = false ensures Redis is only reachable
-# from within the VNet; no internet exposure even if firewall rules exist.
-# TLS is enforced on port 6380 (non-TLS port 6379 is disabled by default
-# on Premium). The connection URL in outputs uses rediss:// (TLS scheme).
-resource "azurerm_redis_cache" "redis" {
-  name                = var.name
+# AMR cluster — Balanced SKU, TLS 1.2, no public access (private endpoint only).
+resource "azapi_resource" "amr" {
+  type      = "Microsoft.Cache/redisEnterprise@2025-07-01"
+  name      = var.name
+  location  = var.location
+  parent_id = var.resource_group_id
+
+  body = {
+    sku = { name = var.amr_sku }
+    properties = {
+      minimumTlsVersion = "1.2"
+      # Required at API 2025-07-01. Private-endpoint-only — no public access.
+      publicNetworkAccess = "Disabled"
+      # HA (zone redundancy) is unsupported on the smallest (B0) SKU.
+      highAvailability = var.high_availability ? "Enabled" : "Disabled"
+    }
+  }
+
+  response_export_values = ["properties.hostName"]
+  tags                   = merge(var.tags, { module = "redis" })
+
+  # azapi's bundled schema lags behind AMR (Balanced SKU / highAvailability). The
+  # body matches what `az redisenterprise create` accepts — let ARM validate at apply.
+  schema_validation_enabled = false
+}
+
+# AMR database — OSS clustering policy, TLS (Encrypted) on port 10000, key auth on.
+resource "azapi_resource" "amr_db" {
+  type      = "Microsoft.Cache/redisEnterprise/databases@2025-07-01"
+  name      = "default"
+  parent_id = azapi_resource.amr.id
+
+  body = {
+    properties = {
+      clientProtocol           = "Encrypted"
+      port                     = 10000
+      clusteringPolicy         = var.clustering_policy
+      accessKeysAuthentication = "Enabled"
+    }
+  }
+
+  schema_validation_enabled = false
+}
+
+# Primary access key — used to build the connection URL.
+resource "azapi_resource_action" "amr_keys" {
+  type        = "Microsoft.Cache/redisEnterprise/databases@2025-07-01"
+  resource_id = azapi_resource.amr_db.id
+  action      = "listKeys"
+
+  response_export_values = ["primaryKey"]
+}
+
+# ── Private access (parity with classic's "private only") ─────────────────────
+# AMR can't inject into a subnet, so a Private Endpoint in the same redis subnet +
+# a private DNS zone give equivalent VNet-only reachability. The endpoint hostname
+# (*.redis.azure.net) resolves to the PE's private IP via this zone.
+resource "azurerm_private_dns_zone" "redis" {
+  name                = "privatelink.redis.azure.net"
+  resource_group_name = var.resource_group_name
+  tags                = merge(var.tags, { module = "redis" })
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "redis" {
+  name                  = "${var.name}-dnslink"
+  resource_group_name   = var.resource_group_name
+  private_dns_zone_name = azurerm_private_dns_zone.redis.name
+  virtual_network_id    = var.vnet_id
+  tags                  = merge(var.tags, { module = "redis" })
+}
+
+resource "azurerm_private_endpoint" "redis" {
+  name                = "${var.name}-pe"
   location            = var.location
   resource_group_name = var.resource_group_name
+  subnet_id           = var.subnet_id
 
-  # Premium P-family: capacity maps to P1=6GB, P2=13GB, P3=26GB, P4=53GB
-  capacity = var.capacity # default: 2 (P2, 13 GB)
-  family   = var.family   # "P" = Premium (required for VNet injection)
-  sku_name = var.sku_name # "Premium"
+  private_service_connection {
+    name                           = "${var.name}-psc"
+    private_connection_resource_id = azapi_resource.amr.id
+    subresource_names              = ["redisEnterprise"]
+    is_manual_connection           = false
+  }
 
-  # Inject Redis into its dedicated subnet (Premium requirement).
-  # The subnet must be exclusive to Redis — no other resources allowed.
-  subnet_id = var.subnet_id
-
-  # Disable public access: all connections must originate within the VNet.
-  public_network_access_enabled = false
+  private_dns_zone_group {
+    name                 = "redis"
+    private_dns_zone_ids = [azurerm_private_dns_zone.redis.id]
+  }
 
   tags = merge(var.tags, { module = "redis" })
 }

--- a/modules/azure/infra/modules/redis/outputs.tf
+++ b/modules/azure/infra/modules/redis/outputs.tf
@@ -1,5 +1,14 @@
 output "connection_url" {
-  value       = "rediss://:${azurerm_redis_cache.redis.primary_access_key}@${azurerm_redis_cache.redis.hostname}:6380"
-  description = "Redis connection string using TLS"
+  # AMR endpoint over TLS, OSS cluster, port 10000. Key is URL-encoded because AMR
+  # access keys contain +, /, = which would otherwise break the rediss:// URL.
+  value       = "rediss://:${urlencode(azapi_resource_action.amr_keys.output.primaryKey)}@${azapi_resource.amr.output.properties.hostName}:10000"
+  description = "Redis (AMR) connection string using TLS"
   sensitive   = true
+}
+
+output "cluster_safe_mode" {
+  # AMR is always an OSS cluster — LangSmith must connect as a standalone client to
+  # the endpoint (redis.external.clusterSafeMode: true), not a cluster client.
+  value       = true
+  description = "Whether LangSmith should set redis.external.clusterSafeMode (true for AMR)"
 }

--- a/modules/azure/infra/modules/redis/variables.tf
+++ b/modules/azure/infra/modules/redis/variables.tf
@@ -1,6 +1,6 @@
 variable "name" {
   type        = string
-  description = "Name of the Redis instance"
+  description = "Name of the Azure Managed Redis cluster"
 }
 
 variable "location" {
@@ -10,31 +10,40 @@ variable "location" {
 
 variable "resource_group_name" {
   type        = string
-  description = "Resource group name of the Redis instance"
+  description = "Resource group name (for the private endpoint + DNS zone)"
+}
+
+variable "resource_group_id" {
+  type        = string
+  description = "Resource group ID — azapi parent_id for the AMR cluster"
 }
 
 variable "subnet_id" {
   type        = string
-  description = "Subnet ID of the Redis instance"
+  description = "Subnet ID for the AMR private endpoint (the dedicated redis subnet)"
 }
 
-variable "sku_name" {
+variable "vnet_id" {
   type        = string
-  description = "SKU name of the Redis instance"
-  default     = "Premium"
+  description = "VNet ID — linked to the private DNS zone so the hostname resolves to the PE"
 }
 
-variable "family" {
+variable "amr_sku" {
   type        = string
-  description = "Family of the Redis instance"
-  default     = "P"
+  description = "Azure Managed Redis SKU. Balanced_B0 is the smallest. See `az redisenterprise create -h` for the list."
+  default     = "Balanced_B0"
 }
 
-# You can see the capacity options here: https://azure.microsoft.com/en-us/pricing/details/cache/?cdn=disable
-variable "capacity" {
-  type        = number
-  description = "Capacity of the Redis instance"
-  default     = 2
+variable "clustering_policy" {
+  type        = string
+  description = "AMR clustering policy. OSSCluster is what LangSmith expects."
+  default     = "OSSCluster"
+}
+
+variable "high_availability" {
+  type        = bool
+  description = "Zone-redundant HA. NOT supported on the smallest (B0) SKU — keep false there."
+  default     = false
 }
 
 variable "tags" {

--- a/modules/azure/infra/modules/redis/versions.tf
+++ b/modules/azure/infra/modules/redis/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    # AMR cluster/database are provisioned via azapi (Balanced SKUs not in azurerm yet).
+    # Source must be declared here — it's Azure/azapi, not the default hashicorp/azapi.
+    azapi = {
+      source  = "Azure/azapi"
+      version = "~> 2.0"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+  }
+}

--- a/modules/azure/infra/outputs.tf
+++ b/modules/azure/infra/outputs.tf
@@ -10,6 +10,11 @@ output "redis_connection_url" {
   value       = var.redis_source == "external" ? module.redis[0].connection_url : ""
 }
 
+output "redis_cluster_safe_mode" {
+  description = "Whether LangSmith should set redis.external.clusterSafeMode (true for AMR). init-values.sh reads this."
+  value       = var.redis_source == "external" ? module.redis[0].cluster_safe_mode : false
+}
+
 output "storage_account_name" {
   description = "Azure Blob Storage account name used for LangSmith traces and assets"
   value       = module.blob.storage_account_name

--- a/modules/azure/infra/terraform.tfvars.example
+++ b/modules/azure/infra/terraform.tfvars.example
@@ -32,9 +32,10 @@ postgres_admin_username      = "langsmith"
 postgres_database_name       = "langsmith"    # database name on the server
 postgres_deletion_protection = false          # set true for production
 
-# ── Redis ─────────────────────────────────────────────────────────────────────
-redis_capacity = 1   # P1 = 6 GB RAM (sufficient for most deployments)
-                     # P2 = 13 GB RAM (required for high write load ≥26 GiB)
+# ── Redis (Azure Managed Redis / AMR) ─────────────────────────────────────────
+# redis_source = "external" provisions Azure Managed Redis (Microsoft.Cache/redisEnterprise,
+# Redis 7.x, OSS clustering, private endpoint). amr_sku picks the size.
+amr_sku = "Balanced_B0"   # smallest. Bump (Balanced_B1/B3/...) if the region reports AllocationFailed.
 
 # ── AKS ───────────────────────────────────────────────────────────────────────
 # Node sizing: Standard_D8s_v3 (8 vCPU, 32 GiB) — AKS reserves ~1.7 vCPU/node,

--- a/modules/azure/infra/variables.tf
+++ b/modules/azure/infra/variables.tf
@@ -168,10 +168,10 @@ variable "postgres_subnet_address_prefix" {
   default     = ["10.0.32.0/20"] # 4k IP addresses
 }
 
-variable "redis_capacity" {
-  type        = number
-  description = "The capacity of the Redis server. This maps to a certain memory and CPU combination."
-  default     = 2
+variable "amr_sku" {
+  type        = string
+  description = "Azure Managed Redis SKU. Balanced_B0 is the smallest. Bump (Balanced_B1/B3/...) if the region reports AllocationFailed. (Replaces the classic redis_capacity.)"
+  default     = "Balanced_B0"
 }
 
 variable "blob_ttl_enabled" {

--- a/modules/azure/infra/versions.tf
+++ b/modules/azure/infra/versions.tf
@@ -6,6 +6,12 @@ terraform {
       source  = "hashicorp/azurerm"
       version = "~> 4.0"
     }
+    # Azure Managed Redis (Microsoft.Cache/redisEnterprise) Balanced SKUs aren't
+    # reliably exposed by azurerm yet — the redis module provisions AMR via azapi.
+    azapi = {
+      source  = "Azure/azapi"
+      version = "~> 2.0"
+    }
     kubernetes = {
       source  = "hashicorp/kubernetes"
       version = "~> 2.0"


### PR DESCRIPTION
## What
Replace the classic **Azure Cache for Redis** (Premium) in the `redis` module with **Azure Managed Redis (AMR)** — `Microsoft.Cache/redisEnterprise`, Redis 7.x, OSS clustering policy — provisioned via the `azapi` provider.

Classic Azure Cache for Redis is retiring (*"Creation of new Azure Cache for Redis Enterprise resources is no longer supported"*), so this moves the module to the supported path for Redis 7.x on Azure.

## Changes
- **`modules/redis`** — replaces `azurerm_redis_cache` with: AMR cluster + database (OSSCluster, TLS/`Encrypted`, port 10000, access-key auth) + `listKeys`, plus a **Private Endpoint + private DNS zone** for VNet-only access.
- **`versions.tf` + `modules/redis/versions.tf`** — add the `azapi` provider (Balanced SKUs aren't reliably exposed by `azurerm` yet; `schema_validation_enabled = false` lets ARM validate the body).
- **outputs** — `connection_url` → `rediss://:<url-encoded key>@<host>:10000`; new `cluster_safe_mode`.
- **`amr_sku`** variable replaces `redis_capacity`.
- **`init-values.sh`** — auto-emits `redis.external.clusterSafeMode: true` for AMR. LangSmith must connect as a standalone client to the endpoint hostname (the cert matches the hostname); a cluster client fails TLS verification against AMR's IP-advertised nodes.

## Networking
AMR can't do classic's subnet injection, so private access = **Private Endpoint into the existing redis subnet + `privatelink.redis.azure.net` private DNS zone** — equivalent VNet-only reachability.

## ⚠️ Breaking change
Replaces classic Azure Cache for Redis. **Existing deployments must migrate state before applying:**
```
terraform state rm 'module.redis[0].azurerm_redis_cache.redis'
```
then `terraform apply` to provision AMR. The classic cache is not auto-destroyed.

## Validation
Applied on a live eastus deployment: AMR `Balanced_B0` cluster (`Succeeded`) + **Approved** Private Endpoint; backend `REDIS_DATABASE_URI = rediss://…@…redis.azure.net:10000`, `REDIS_CLUSTER_SAFE_MODE=true` (auto from `init-values`), app returns HTTP 200.

## Reviewer notes
- API `2025-07-01` requires `publicNetworkAccess` → set `Disabled`.
- `Balanced_B0` can't do zone-redundant HA → `highAvailability = "Disabled"` (toggle via `high_availability`).
- If a region reports `AllocationFailed`, bump `amr_sku` (`Balanced_B1`/`B3`/…).
