### PR TITLE
fix(aws): tear down Envoy Gateway/GatewayClass on disable or destroy

### DIFF
--- a/modules/aws/infra/modules/k8s-bootstrap/main.tf
+++ b/modules/aws/infra/modules/k8s-bootstrap/main.tf
@@ -33,7 +33,7 @@ resource "kubernetes_secret" "postgres" {
     postgres_db       = var.postgres_in_cluster_db
     postgres_user     = var.postgres_in_cluster_user
     postgres_password = var.postgres_in_cluster_pass
-  } : {
+    } : {
     connection_url = var.postgres_connection_url
   }
   type = "Opaque"
@@ -267,7 +267,7 @@ MANIFEST
     interpreter = ["bash", "-c"]
     # Update kubeconfig before deleting — destroy provisioners cannot use
     # var.* so cluster_name and region are read from self.input.
-    command     = <<-EOT
+    command = <<-EOT
       _ctx=$(kubectl config current-context 2>/dev/null || echo "")
       if ! echo "$_ctx" | grep -qF '${self.input.cluster_name}'; then
         aws eks update-kubeconfig --name ${self.input.cluster_name} --region ${self.input.region} 2>/dev/null || true
@@ -406,7 +406,7 @@ MANIFEST
     # Restore Gateway to HTTP-only on destroy (don't delete — may be referenced
     # by other resources). self.input holds namespace and domain since
     # destroy provisioners cannot reference var.*.
-    command     = <<-EOT
+    command = <<-EOT
       kubectl patch gateway langsmith-gateway -n ${self.input.namespace} \
         --type=json \
         -p='[{"op":"replace","path":"/spec/servers","value":[{"port":{"number":80,"name":"http","protocol":"HTTP"},"hosts":["${self.input.domain}"]}]}]' \
@@ -454,6 +454,12 @@ resource "helm_release" "envoy_gateway" {
 resource "terraform_data" "envoy_gateway_resource" {
   count = var.enable_envoy_gateway ? 1 : 0
 
+  input = {
+    namespace    = var.namespace
+    cluster_name = var.cluster_name
+    region       = var.region
+  }
+
   triggers_replace = [
     var.namespace,
   ]
@@ -492,6 +498,25 @@ spec:
       namespaces:
         from: All
 MANIFEST
+    EOT
+  }
+
+  # Delete the Gateway + GatewayClass while the Envoy Gateway controller is still
+  # installed so it can reclaim the controller-spawned Envoy proxy and its NLB.
+  # Runs before helm_release.envoy_gateway is uninstalled (reverse dependency
+  # order). --wait blocks until the controller finishes teardown, avoiding an
+  # orphaned NLB. Mirrors the destroy provisioners on envoy_target_group_binding
+  # and istio_gateway_resource.
+  provisioner "local-exec" {
+    when        = destroy
+    interpreter = ["bash", "-c"]
+    command     = <<-EOT
+      _ctx=$(kubectl config current-context 2>/dev/null || echo "")
+      if ! echo "$_ctx" | grep -qF '${self.input.cluster_name}'; then
+        aws eks update-kubeconfig --name ${self.input.cluster_name} --region ${self.input.region} 2>/dev/null || true
+      fi
+      kubectl delete gateway langsmith-gateway -n ${self.input.namespace} --ignore-not-found=true --wait=true --timeout=180s 2>/dev/null || true
+      kubectl delete gatewayclass eg --ignore-not-found=true 2>/dev/null || true
     EOT
   }
 


### PR DESCRIPTION
## Summary
- `terraform_data.envoy_gateway_resource` created the `eg` GatewayClass and `langsmith-gateway` Gateway via a create-only `local-exec`, so disabling `enable_envoy_gateway` (or `terraform destroy`) dropped the resource from state without deleting those objects. The orphaned Gateway/GatewayClass and the controller-spawned Envoy proxy + its NLB were left behind, and the idle NLB keeps billing.
- Adds a `when = destroy` provisioner that deletes the Gateway (waiting for the still-installed controller to reclaim the proxy and NLB) and the cluster-scoped GatewayClass. An `input` block carries `namespace`/`cluster_name`/`region` so the destroy provisioner can re-establish kube context via `self`.
- Mirrors the existing destroy provisioners on `envoy_target_group_binding` and `istio_gateway_resource`. Destroy ordering is correct: `envoy_target_group_binding` -> `envoy_gateway_resource` (new provisioner) -> `helm_release.envoy_gateway`, so the Gateway is deleted while the controller is still running, then `--wait` blocks until teardown completes before the controller is uninstalled - avoiding the orphaned-NLB race.
- Destroy-only change; no create-path behavior changes.

## Test plan
- [x] Enable Envoy (`enable_envoy_gateway = true`), `terraform apply` -> Gateway + GatewayClass + Envoy NLB created.
- [x] Switch to nginx (`enable_envoy_gateway = false`, `enable_nginx_ingress = true`), `terraform apply` -> destroy provisioner runs `kubectl delete gateway langsmith-gateway ...`.
- [x] Verified after apply: `kubectl get gateway,gatewayclass -A` empty, no Service of type LoadBalancer in `envoy-gateway-system`, and no `k8s-envoygat-...` NLB remaining.
- [x] LangSmith continues serving via nginx afterward.