### PR TITLE
[fix] azure: chart 0.15.x compatibility (fleet rename, insights/polly, NetworkPolicy, LimitRange)

### DIFF
--- a/modules/azure/README.md
+++ b/modules/azure/README.md
@@ -592,7 +592,7 @@ Enables the LangGraph Platform: the Deployments nav item in the UI, the `listene
 
 **`langsmith-values-agent-builder.yaml`** — Pass 4 (`enable_agent_builder = true`)
 
-Enables the visual agent builder UI and its two supporting services: `agentBuilderToolServer` (exposes the tool registry) and `agentBuilderTriggerServer` (handles agent execution triggers). Also enables `backend.agentBootstrap` — a post-install job that registers Agent Builder as an LGP deployment and creates the required ConfigMap. Without this job, the Agent Builder nav item does not appear in the UI. Sets conservative agent worker pod resources (1 CPU / 1 Gi) instead of the chart's default 4 CPU / 8 Gi.
+Enables the visual agent builder UI and its two supporting services: `fleetToolServer` (exposes the tool registry) and `fleetTriggerServer` (handles agent execution triggers). Also enables `backend.agentBootstrap` — a post-install job that registers Agent Builder as an LGP deployment and creates the required ConfigMap. Without this job, the Agent Builder nav item does not appear in the UI. Sets conservative agent worker pod resources (1 CPU / 1 Gi) instead of the chart's default 4 CPU / 8 Gi.
 
 > Requires `enable_deployments = true`.
 

--- a/modules/azure/helm/scripts/init-values.sh
+++ b/modules/azure/helm/scripts/init-values.sh
@@ -357,7 +357,7 @@ listener:
     annotations:
       azure.workload.identity/client-id: "${WI_CLIENT_ID}"
 
-agentBuilderToolServer:
+fleetToolServer:
   deployment:
     labels:
       azure.workload.identity/use: "true"
@@ -365,7 +365,7 @@ agentBuilderToolServer:
     annotations:
       azure.workload.identity/client-id: "${WI_CLIENT_ID}"
 
-agentBuilderTriggerServer:
+fleetTriggerServer:
   deployment:
     labels:
       azure.workload.identity/use: "true"
@@ -463,9 +463,10 @@ if [[ "$_enable_insights" == "true" ]]; then
 # Insights — ClickHouse-backed analytics (in-cluster ClickHouse).
 # clickhouse_source = "in-cluster" — the Helm chart manages ClickHouse.
 # No external ClickHouse configuration needed.
-config:
-  insights:
-    enabled: true
+# Chart 0.15.1 removed config.insights → top-level insights block. encryptionKey read from
+# langsmith-config-secret (insights_encryption_key) via config.existingSecretName.
+insights:
+  enabled: true
 INSIGHTS_EOF
     pass "Generated: langsmith-values-insights.yaml (in-cluster ClickHouse mode)"
   else

--- a/modules/azure/helm/values/examples/SIZING.md
+++ b/modules/azure/helm/values/examples/SIZING.md
@@ -41,8 +41,8 @@ Absolute floor. Keeps LangSmith alive at the lowest possible cost. Fits on a sin
 | listener | 1 | 250m | 1,000m | 768Mi | 1,536Mi |
 | operator | 1 | 100m | 250m | 256Mi | 512Mi |
 | **Agent Builder** | | | | | |
-| agentBuilderToolServer | 1 | 500m | 1,000m | 768Mi | 1,536Mi |
-| agentBuilderTriggerServer | 1 | 100m | 250m | 256Mi | 384Mi |
+| fleetToolServer | 1 | 500m | 1,000m | 768Mi | 1,536Mi |
+| fleetTriggerServer | 1 | 100m | 250m | 256Mi | 384Mi |
 | **Operator-Managed Agents** | | | | | |
 | polly agent | 1 | 100m | 500m | 256Mi | 512Mi |
 | insights agent | 1 | 100m | 500m | 256Mi | 512Mi |
@@ -80,8 +80,8 @@ Enough headroom for a developer to run traces, test agents, and use the playgrou
 | listener | 1 | 500m | 1,000m | 1,024Mi | 2,048Mi |
 | operator | 1 | 250m | 500m | 512Mi | 1,024Mi |
 | **Agent Builder** | | | | | |
-| agentBuilderToolServer | 1 | 500m | 1,000m | 1,024Mi | 2,048Mi |
-| agentBuilderTriggerServer | 1 | 250m | 500m | 512Mi | 1,024Mi |
+| fleetToolServer | 1 | 500m | 1,000m | 1,024Mi | 2,048Mi |
+| fleetTriggerServer | 1 | 250m | 500m | 512Mi | 1,024Mi |
 | **Operator-Managed Agents** | | | | | |
 | polly agent | 1 | 250m | 500m | 512Mi | 1,024Mi |
 | insights agent | 1 | 250m | 500m | 512Mi | 1,024Mi |
@@ -121,8 +121,8 @@ All autoscaled components target **50% CPU** and **80% memory** utilization.
 | listener | 2 | 10 | 500m | 1,000m | 1,024Mi | 2,048Mi |
 | operator | 1 | 1 | 500m | 1,000m | 1,024Mi | 2,048Mi |
 | **Agent Builder** | | | | | | |
-| agentBuilderToolServer | 1 | 1 | 500m | 1,000m | 1,024Mi | 2,048Mi |
-| agentBuilderTriggerServer | 1 | 1 | 500m | 1,000m | 1,024Mi | 2,048Mi |
+| fleetToolServer | 1 | 1 | 500m | 1,000m | 1,024Mi | 2,048Mi |
+| fleetTriggerServer | 1 | 1 | 500m | 1,000m | 1,024Mi | 2,048Mi |
 | **Operator-Managed Agents (chart defaults)** | | | | | | |
 | polly agent | 1 | 5 | 2,000m | 4,000m | 4,096Mi | 8,192Mi |
 | insights agent | 1 | 5 | 2,000m | 4,000m | 4,096Mi | 8,192Mi |
@@ -164,8 +164,8 @@ All autoscaled components target **50% CPU** and **80% memory** utilization.
 | listener | 4 | 10 | 500m | 2,000m | 1,024Mi | 4,096Mi |
 | operator | 1 | 1 | 500m | 2,000m | 1,024Mi | 4,096Mi |
 | **Agent Builder** | | | | | | |
-| agentBuilderToolServer | 1 | 1 | 500m | 2,000m | 1,024Mi | 4,096Mi |
-| agentBuilderTriggerServer | 1 | 1 | 500m | 2,000m | 1,024Mi | 4,096Mi |
+| fleetToolServer | 1 | 1 | 500m | 2,000m | 1,024Mi | 4,096Mi |
+| fleetTriggerServer | 1 | 1 | 500m | 2,000m | 1,024Mi | 4,096Mi |
 | **Operator-Managed Agents (chart defaults)** | | | | | | |
 | polly agent | 1 | 5 | 2,000m | 4,000m | 4,096Mi | 8,192Mi |
 | insights agent | 1 | 5 | 2,000m | 4,000m | 4,096Mi | 8,192Mi |

--- a/modules/azure/helm/values/examples/langsmith-values-agent-builder.yaml
+++ b/modules/azure/helm/values/examples/langsmith-values-agent-builder.yaml
@@ -31,8 +31,11 @@ backend:
     # nav item to appear in the UI. The job is idempotent — safe to run on every upgrade.
     enabled: true
 
-agentBuilderToolServer:
+# Renamed in chart 0.15.0 (was agentBuilderToolServer / agentBuilderTriggerServer).
+# config.agentBuilder + backend.agentBootstrap above remain the (deprecated-but-functional)
+# enablement path in 0.15.x; the tool/trigger server component keys are now fleet*.
+fleetToolServer:
   enabled: true
 
-agentBuilderTriggerServer:
+fleetTriggerServer:
   enabled: true

--- a/modules/azure/helm/values/examples/langsmith-values-insights.yaml
+++ b/modules/azure/helm/values/examples/langsmith-values-insights.yaml
@@ -4,22 +4,24 @@
 #   - enable_insights = true AND clickhouse_source != "in-cluster"
 #
 # For in-cluster ClickHouse (dev/POC), init-values.sh generates a minimal file automatically:
-#   config:
-#     insights:
-#       enabled: true
+#   insights:
+#     enabled: true
 # Manual: cp examples/langsmith-values-insights.yaml ../langsmith-values-insights.yaml
 #
 # Prerequisites:
 #   - External ClickHouse instance (LangChain Managed, Azure Marketplace, or self-hosted)
 #   - ClickHouse must be reachable from the AKS cluster
+#
+# NOTE: chart 0.15.1 removed config.insights → top-level insights block (migrated below).
+# The external-ClickHouse path below has NOT been validated on 0.15.x (only in-cluster was) —
+# verify the clickhouse block against the 0.15.x insights schema before using.
 
-config:
-  insights:
-    enabled: true
-    # encryptionKey is stored in Azure Key Vault and delivered via langsmith-config-secret.
-    # Terraform creates the key automatically in Key Vault during `make apply`.
-    # deploy.sh / make k8s-secrets pulls it and adds it to the langsmith-config-secret.
-    # Do not set encryptionKey inline here — it is already in existingSecretName.
+insights:
+  enabled: true
+  # encryptionKey is stored in Azure Key Vault and delivered via langsmith-config-secret.
+  # Terraform creates the key automatically in Key Vault during `make apply`.
+  # deploy.sh / make k8s-secrets pulls it and adds it to the langsmith-config-secret.
+  # Do not set encryptionKey inline here — it is already in existingSecretName.
 
 clickhouse:
   external:

--- a/modules/azure/helm/values/examples/langsmith-values-polly.yaml
+++ b/modules/azure/helm/values/examples/langsmith-values-polly.yaml
@@ -2,14 +2,8 @@
 # Requires config.deployment.enabled = true (LangGraph Platform).
 # Encryption key is read from langsmith-config-secret (polly_encryption_key).
 # Do NOT set it inline — it is already in the secret via config.existingSecretName.
-config:
-  polly:
-    enabled: true
-    agent:
-      resources:
-        cpu: 2
-        cpuLimit: 4
-        memoryMb: 4096
-        memoryLimitMb: 8192
-        minScale: 1
-        maxScale: 5
+# Chart 0.15.1 removed config.polly (bundled-agent bootstrap path) → top-level polly block.
+# encryptionKey read from langsmith-config-secret (polly_encryption_key) via config.existingSecretName.
+# (config.polly.agent.resources had no direct top-level equivalent — operator-managed now.)
+polly:
+  enabled: true

--- a/modules/azure/helm/values/examples/langsmith-values-sizing-dev.yaml
+++ b/modules/azure/helm/values/examples/langsmith-values-sizing-dev.yaml
@@ -128,9 +128,9 @@ operator:
         cpu: "500m"
         memory: "1Gi"
 
-# -- Agent Builder infrastructure ----------------------------------------------
+# -- Fleet infrastructure (was Agent Builder; renamed in chart 0.15.0) ---------
 
-agentBuilderToolServer:
+fleetToolServer:
   deployment:
     replicas: 1
     resources:
@@ -141,7 +141,7 @@ agentBuilderToolServer:
         cpu: "1"
         memory: "2Gi"
 
-agentBuilderTriggerServer:
+fleetTriggerServer:
   deployment:
     replicas: 1
     resources:

--- a/modules/azure/helm/values/examples/langsmith-values-sizing-minimum.yaml
+++ b/modules/azure/helm/values/examples/langsmith-values-sizing-minimum.yaml
@@ -135,9 +135,9 @@ operator:
         cpu: "250m"
         memory: "512Mi"
 
-# -- Agent Builder infrastructure ----------------------------------------------
+# -- Fleet infrastructure (was Agent Builder; renamed in chart 0.15.0) ---------
 
-agentBuilderToolServer:
+fleetToolServer:
   deployment:
     replicas: 1
     resources:
@@ -148,7 +148,7 @@ agentBuilderToolServer:
         cpu: "1"
         memory: "1536Mi"
 
-agentBuilderTriggerServer:
+fleetTriggerServer:
   deployment:
     replicas: 1
     resources:

--- a/modules/azure/helm/values/examples/langsmith-values-sizing-production-large.yaml
+++ b/modules/azure/helm/values/examples/langsmith-values-sizing-production-large.yaml
@@ -182,9 +182,9 @@ operator:
         cpu: "2"
         memory: "4Gi"
 
-# -- Agent Builder infrastructure ----------------------------------------------
+# -- Fleet infrastructure (was Agent Builder; renamed in chart 0.15.0) ---------
 
-agentBuilderToolServer:
+fleetToolServer:
   deployment:
     resources:
       requests:
@@ -194,7 +194,7 @@ agentBuilderToolServer:
         cpu: "2"
         memory: "4Gi"
 
-agentBuilderTriggerServer:
+fleetTriggerServer:
   deployment:
     resources:
       requests:

--- a/modules/azure/helm/values/examples/langsmith-values-sizing-production.yaml
+++ b/modules/azure/helm/values/examples/langsmith-values-sizing-production.yaml
@@ -175,9 +175,9 @@ operator:
         cpu: "1"
         memory: "2Gi"
 
-# -- Agent Builder infrastructure ----------------------------------------------
+# -- Fleet infrastructure (was Agent Builder; renamed in chart 0.15.0) ---------
 
-agentBuilderToolServer:
+fleetToolServer:
   deployment:
     resources:
       requests:
@@ -187,7 +187,7 @@ agentBuilderToolServer:
         cpu: "1"
         memory: "2Gi"
 
-agentBuilderTriggerServer:
+fleetTriggerServer:
   deployment:
     resources:
       requests:

--- a/modules/azure/infra/main.tf
+++ b/modules/azure/infra/main.tf
@@ -295,6 +295,9 @@ module "k8s_bootstrap" {
   # K8s namespace for LangSmith workloads
   langsmith_namespace = var.langsmith_namespace
 
+  # Ingress controller — drives the NetworkPolicy's allowed source namespace.
+  ingress_controller = var.ingress_controller
+
   # Backing services — connection URLs are injected as K8s secrets.
   # generate-secrets.sh also writes these secrets with the full URL from KV.
   use_external_postgres   = var.postgres_source == "external"

--- a/modules/azure/infra/modules/k8s-bootstrap/main.tf
+++ b/modules/azure/infra/modules/k8s-bootstrap/main.tf
@@ -70,6 +70,34 @@ resource "kubernetes_resource_quota_v1" "langsmith" {
   }
 }
 
+# ── Limit Range ───────────────────────────────────────────────────────────────
+# Required companion to the ResourceQuota above: because the quota's `hard` includes
+# requests/limits, Kubernetes forces EVERY pod to declare them. Some chart components
+# (e.g. the bundled Postgres/Redis StatefulSets for the standalone insights/polly/fleet
+# agent features) ship without resource stanzas, so without defaults they're rejected
+# with "failed quota: must specify limits.cpu/... for: <container>" and never schedule.
+# This LimitRange supplies defaults so those pods inherit sane values and satisfy the quota.
+resource "kubernetes_limit_range_v1" "langsmith" {
+  metadata {
+    name      = "langsmith-defaults"
+    namespace = kubernetes_namespace_v1.langsmith.metadata[0].name
+  }
+
+  spec {
+    limit {
+      type = "Container"
+      default = {
+        cpu    = "1"
+        memory = "1Gi"
+      }
+      default_request = {
+        cpu    = "100m"
+        memory = "256Mi"
+      }
+    }
+  }
+}
+
 # ── Network Policy ────────────────────────────────────────────────────────────
 # Default-deny blocks all ingress to LangSmith pods unless explicitly allowed.
 # This is defense-in-depth: even if a pod is compromised, it cannot receive
@@ -87,24 +115,43 @@ resource "kubernetes_network_policy_v1" "langsmith_default_deny" {
   }
 }
 
-# Allows ingress from the ingress-nginx namespace (external traffic via LB)
-# and from within the langsmith namespace itself (inter-service calls).
-# Both rules are required: without the intra-namespace rule, backend pods
-# cannot call each other (e.g. queue workers calling the internal API).
+# Namespace the selected ingress controller's data plane runs in. The
+# NetworkPolicy below must allow ingress from this namespace, or the controller's
+# proxy cannot reach LangSmith pods (default-deny drops it → 503 with ~10s
+# connection timeout). AGIC is intentionally excluded: Application Gateway routes
+# from its dedicated subnet (an ip_block), not an in-cluster pod namespace.
+locals {
+  ingress_namespace = lookup({
+    "nginx"         = "ingress-nginx"
+    "envoy-gateway" = "envoy-gateway-system"
+    "istio"         = "istio-system"
+    "istio-addon"   = "aks-istio-ingress"
+  }, var.ingress_controller, "")
+}
+
+# Allows ingress from the selected ingress controller's namespace (external
+# traffic via LB) and from within the langsmith namespace itself (inter-service
+# calls). The intra-namespace rule is required on its own: without it, backend
+# pods cannot call each other (e.g. queue workers calling the internal API).
 resource "kubernetes_network_policy_v1" "langsmith_allow_internal" {
   metadata {
-    name      = "allow-from-ingress-nginx"
+    name      = "allow-from-ingress"
     namespace = kubernetes_namespace_v1.langsmith.metadata[0].name
   }
 
   spec {
     pod_selector {}
 
-    ingress {
-      from {
-        namespace_selector {
-          match_labels = {
-            "kubernetes.io/metadata.name" = "ingress-nginx"
+    # Ingress controller namespace — skipped for controllers that do not run as
+    # in-cluster pods (e.g. agic), where ingress_namespace resolves to "".
+    dynamic "ingress" {
+      for_each = local.ingress_namespace != "" ? [local.ingress_namespace] : []
+      content {
+        from {
+          namespace_selector {
+            match_labels = {
+              "kubernetes.io/metadata.name" = ingress.value
+            }
           }
         }
       }

--- a/modules/azure/infra/modules/k8s-bootstrap/variables.tf
+++ b/modules/azure/infra/modules/k8s-bootstrap/variables.tf
@@ -94,6 +94,12 @@ variable "cert_manager_version" {
   default     = "v1.14.4"
 }
 
+variable "ingress_controller" {
+  type        = string
+  description = "Ingress controller in use. Determines which namespace the NetworkPolicy allows ingress from (nginx → ingress-nginx, envoy-gateway → envoy-gateway-system, istio → istio-system, istio-addon → aks-istio-ingress)."
+  default     = "nginx"
+}
+
 variable "tls_certificate_source" {
   type        = string
   description = "TLS certificate source. 'letsencrypt' = HTTP-01 via cert-manager (ClusterIssuer created by apply-cluster-issuers.sh). 'dns01' = DNS-01 via Azure DNS + Workload Identity (ClusterIssuer created by Terraform). 'none' = skip."

--- a/modules/azure/infra/terraform.tfvars.example
+++ b/modules/azure/infra/terraform.tfvars.example
@@ -154,7 +154,7 @@ sizing_profile = "production"
 # Required before enabling agent_builder, insights, or polly.
 # enable_deployments = true
 
-# Pass 4 — Agent Builder UI (agentBuilderToolServer, agentBuilderTriggerServer, agentBootstrap Job)
+# Pass 4 — Agent Builder UI (fleetToolServer, fleetTriggerServer, agentBootstrap Job)
 # enable_agent_builder = true
 
 # Pass 5 — Insights / Clio (ClickHouse-backed trace analytics — deploys via operator)


### PR DESCRIPTION
[fix]

## What
Make the azure module deploy and run on the latest LangSmith chart (0.15.x). Without these, `make deploy` on chart >= 0.15 fails `validate.yaml`, and the envoy-gateway / addon paths don't come up.

## Changes
**1. Fleet rename (chart 0.15.0)** — `agentBuilderToolServer`/`agentBuilderTriggerServer` → `fleetToolServer`/`fleetTriggerServer` in `init-values.sh` + the sizing-minimum and agent-builder example values. The old keys hard-fail `validate.yaml` on 0.15.x.

**2. `config.insights` / `config.polly` → top-level blocks (chart 0.15.1)** — those bundled-agent paths were removed; moved to top-level `insights:` / `polly:` (`init-values.sh` in-cluster heredoc + insights/polly examples).

**3. NetworkPolicy** — the ingress allow-rule namespace now tracks `ingress_controller` (nginx→ingress-nginx, envoy-gateway→envoy-gateway-system, istio→istio-system, istio-addon→aks-istio-ingress) instead of being hardcoded to `ingress-nginx`. Fixes a silent **503** (default-deny dropping cross-namespace traffic) for non-nginx controllers.

**4. LimitRange** — companion to the existing ResourceQuota. The quota forces every pod to declare requests/limits; resource-less chart pods (the bundled insights/polly/fleet Postgres/Redis StatefulSets) were quota-rejected and never scheduled. The LimitRange supplies defaults so they schedule.

## Validation
End-to-end on a live deployment (chart 0.15.5, envoy-gateway): full Pass 2–5 (core + Deployments + Fleet + Insights + Polly) healthy, app returns HTTP 200.

## Related
Unblocks #54 (Azure Managed Redis). On chart 0.15.x, `make deploy` fails on the deprecated `agentBuilderToolServer` keys until this lands — recommend merging this **first or alongside** #54. (Alternatively, #54 can be tested standalone by pinning `CHART_VERSION` ≤ 0.14.x.)
