### PR TITLE
ci(all): line-pin chart version, add auto-tag release workflow, docum…

### DIFF
--- a/.github/scripts/chart-line.sh
+++ b/.github/scripts/chart-line.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Release guard: parse and validate the pinned chart MAJOR.MINOR line from
+# every provider's deploy.sh.
+#
+# Prints the agreed line (e.g. "0.15") to stdout on success.
+# Exits non-zero if any provider is unpinned or the providers disagree.
+#
+# The pinned line is the single source of truth for the release tag's
+# MAJOR.MINOR, so this guard ensures a tag can never ship a deploy.sh that
+# targets a different chart line than the tag claims.
+set -euo pipefail
+
+# Resolve repo root from this script's location (.github/scripts/ -> repo root).
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PROVIDERS=(aws gcp azure ocp)
+
+line=""
+for p in "${PROVIDERS[@]}"; do
+  f="$REPO_ROOT/modules/$p/helm/scripts/deploy.sh"
+  if [[ ! -f "$f" ]]; then
+    echo "::error::missing deploy.sh for provider '$p' ($f)" >&2
+    exit 1
+  fi
+
+  # Match the pinned default: CHART_VERSION="${CHART_VERSION:-~0.15.1}"
+  pin="$(grep -oE 'CHART_VERSION:-~[0-9]+\.[0-9]+\.[0-9]+' "$f" | head -1 || true)"
+  if [[ -z "$pin" ]]; then
+    echo "::error::$p deploy.sh is not line-pinned (expected CHART_VERSION:-~MAJOR.MINOR.PATCH)" >&2
+    exit 1
+  fi
+
+  mm="$(printf '%s' "$pin" | grep -oE '[0-9]+\.[0-9]+' | head -1)"
+  if [[ -z "$line" ]]; then
+    line="$mm"
+  elif [[ "$line" != "$mm" ]]; then
+    echo "::error::chart line mismatch: providers disagree ('$line' vs '$mm' in $p deploy.sh)" >&2
+    exit 1
+  fi
+done
+
+printf '%s\n' "$line"

--- a/.github/workflows/chart-line-check.yml
+++ b/.github/workflows/chart-line-check.yml
@@ -1,0 +1,34 @@
+name: Chart Line Check
+
+# Fails a PR (or push to main) if the chart line pin in any provider's deploy.sh
+# is missing or the providers disagree. This catches a bad/divergent pin before
+# it can reach the release workflow, which derives the tag MAJOR.MINOR from it.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - 'modules/**/helm/scripts/deploy.sh'
+      - '.github/scripts/chart-line.sh'
+      - '.github/workflows/chart-line-check.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'modules/**/helm/scripts/deploy.sh'
+      - '.github/scripts/chart-line.sh'
+
+permissions:
+  contents: read
+
+jobs:
+  chart-line:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate chart line pins
+        run: |
+          chmod +x .github/scripts/chart-line.sh
+          line="$(.github/scripts/chart-line.sh)"
+          echo "All providers pinned to chart line: $line"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,148 @@
+name: Release (auto-tag on merge)
+
+# Cuts a global tag on every merge to main that touches modules/**.
+#
+# Versioning: MAJOR.MINOR is the supported LangSmith chart line (parsed from the
+# deploy.sh pins, see .github/scripts/chart-line.sh). PATCH is a module revision
+# counter that increments on any repo change, regardless of provider. The tag
+# PATCH is NOT the chart version - the chart is resolved as the latest patch in
+# the pinned line (e.g. ~0.15.1).
+#
+# Skip a release for a given merge by including "[skip release]" in the commit
+# message. Run manually with dry_run=true to preview the computed version.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'modules/**'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Compute the version and run checks without creating/pushing a tag"
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+# Serialize runs so two quick merges can't race on version computation.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (full history + tags)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check for [skip release]
+        id: skipcheck
+        run: |
+          msg="$(git log -1 --pretty=%B)"
+          if printf '%s' "$msg" | grep -qiF '[skip release]'; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "Commit requests [skip release]; no tag will be cut."
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Resolve chart line (release guard)
+        if: steps.skipcheck.outputs.skip != 'true'
+        id: line
+        run: |
+          chmod +x .github/scripts/chart-line.sh
+          line="$(.github/scripts/chart-line.sh)"
+          echo "line=$line" >> "$GITHUB_OUTPUT"
+          echo "Chart line: $line"
+
+      - name: Compute next tag
+        if: steps.skipcheck.outputs.skip != 'true'
+        id: ver
+        env:
+          LINE: ${{ steps.line.outputs.line }}
+        run: |
+          latest="$(git tag --list "v${LINE}.*" --sort=-v:refname | head -1)"
+          if [[ -z "$latest" ]]; then
+            # First cut on this line (e.g. v0.15.0).
+            next="v${LINE}.0"
+          else
+            patch="${latest##*.}"
+            next="v${LINE}.$((patch + 1))"
+          fi
+          if git rev-parse -q --verify "refs/tags/${next}" >/dev/null; then
+            echo "::error::computed tag ${next} already exists" >&2
+            exit 1
+          fi
+          echo "next=$next" >> "$GITHUB_OUTPUT"
+          echo "prev=$latest" >> "$GITHUB_OUTPUT"
+          echo "Next tag: ${next} (previous: ${latest:-none})"
+
+      - name: Build release message
+        if: steps.skipcheck.outputs.skip != 'true'
+        id: msg
+        env:
+          LINE: ${{ steps.line.outputs.line }}
+          PREV: ${{ steps.ver.outputs.prev }}
+        run: |
+          changed=""
+          for p in aws gcp azure ocp byoc; do
+            if [[ -n "$PREV" ]]; then
+              diff="$(git diff --name-only "${PREV}..HEAD" -- "modules/${p}" || true)"
+            else
+              diff="$(git ls-files -- "modules/${p}" | head -1)"
+            fi
+            [[ -n "$diff" ]] && changed="${changed:+$changed, }${p}"
+          done
+          [[ -z "$changed" ]] && changed="repo"
+          subject="$(git log -1 --pretty=%s)"
+          # Untrusted commit subject is captured here and only ever consumed via
+          # env in later steps - never interpolated into a shell command.
+          {
+            echo "providers=$changed"
+            echo "subject=$subject"
+          } >> "$GITHUB_OUTPUT"
+          echo "Changed providers: $changed"
+
+      - name: Create and push tag
+        if: steps.skipcheck.outputs.skip != 'true' && !(github.event_name == 'workflow_dispatch' && inputs.dry_run)
+        env:
+          NEXT: ${{ steps.ver.outputs.next }}
+          LINE: ${{ steps.line.outputs.line }}
+          PROVIDERS: ${{ steps.msg.outputs.providers }}
+          SUBJECT: ${{ steps.msg.outputs.subject }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$NEXT" -m "${PROVIDERS}: ${SUBJECT} (chart line ${LINE})"
+          git push origin "$NEXT"
+
+      - name: Create GitHub Release
+        if: steps.skipcheck.outputs.skip != 'true' && !(github.event_name == 'workflow_dispatch' && inputs.dry_run)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEXT: ${{ steps.ver.outputs.next }}
+          LINE: ${{ steps.line.outputs.line }}
+          PROVIDERS: ${{ steps.msg.outputs.providers }}
+          SUBJECT: ${{ steps.msg.outputs.subject }}
+        run: |
+          notes="Changed: ${PROVIDERS}
+          ${SUBJECT}
+
+          Chart line: ${LINE} (deploys latest ${LINE}.x via ~${LINE}.1)."
+          gh release create "$NEXT" --title "$NEXT" --notes "$notes"
+
+      - name: Dry-run summary
+        if: steps.skipcheck.outputs.skip != 'true' && github.event_name == 'workflow_dispatch' && inputs.dry_run
+        env:
+          NEXT: ${{ steps.ver.outputs.next }}
+          LINE: ${{ steps.line.outputs.line }}
+          PROVIDERS: ${{ steps.msg.outputs.providers }}
+        run: |
+          echo "DRY RUN - would create tag: $NEXT"
+          echo "Chart line: $LINE"
+          echo "Changed providers: $PROVIDERS"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+The per-release history lives in
+**[GitHub Releases](https://github.com/langchain-ai/terraform/releases)**, which
+are created automatically on every merge to `main` by
+[`.github/workflows/release.yml`](.github/workflows/release.yml). This file is not
+maintained by hand.
+
+## Versioning
+
+Releases are global tags `vMAJOR.MINOR.PATCH`:
+
+- `MAJOR.MINOR` tracks the supported LangSmith Helm chart line. `deploy.sh`
+  installs the latest patch within that line (`~0.15.1` => latest `0.15.x`,
+  never `0.16`).
+- `PATCH` is a module revision counter. It increments on any change to this
+  repo, regardless of provider, and is **not** the chart version (`v0.15.4`
+  does not mean chart `0.15.4`).
+
+Deploy from a tag (`git checkout v0.15.0`), never from `main`.

--- a/README.md
+++ b/README.md
@@ -47,12 +47,38 @@ Each provider directory is a self-contained deployment with a `Makefile`, a two-
 
 ## Getting started
 
-1. Pick the provider folder above and read its `README.md`.
-2. Install the prerequisites it lists (Terraform ≥ 1.5, `kubectl`, `helm`, and your cloud CLI).
-3. Run the interactive wizard (`make quickstart` on AWS; equivalent setup on Azure / GCP).
-4. `make apply` → `make deploy`.
+1. **Check out the latest release tag, not `main`** — see [Versioning and releases](#versioning-and-releases) for the one-line command. `main` is the development branch and may move under you.
+2. Pick the provider folder above and read its `README.md`.
+3. Install the prerequisites it lists (Terraform ≥ 1.5, `kubectl`, `helm`, and your cloud CLI).
+4. Run the interactive wizard (`make quickstart` on AWS; equivalent setup on Azure / GCP).
+5. `make apply` → `make deploy`.
 
 A typical first deployment takes 20–30 minutes end-to-end.
+
+## Versioning and releases
+
+This repository is released as **global tags** `vMAJOR.MINOR.PATCH`. Always deploy from a tag — never from `main`.
+
+- **`MAJOR.MINOR` is the supported LangSmith Helm chart line.** The deploy scripts pin the chart to that line (for example `~0.15.1`, meaning the latest `0.15.x`), so a deployment never silently jumps across a breaking minor (e.g. to `0.16`). You always get the newest patch within the line.
+- **`PATCH` is the module revision.** It increments on any change to this repository, regardless of provider, and is **not** the chart version — `v0.15.4` does not mean chart `0.15.4`.
+
+Check out the latest tag on the line (don't hardcode a patch — `git checkout` needs a real tag, and ranges like `v0.15.x` are not valid):
+
+```bash
+git fetch --tags
+git checkout "$(git tag -l 'v0.15.*' --sort=-v:refname | head -1)"
+```
+
+What this means for you:
+
+- Pin to a tag for reproducible infrastructure; re-run the command above to move to a newer patch within the line as fixes land.
+- Moving to a new chart line (e.g. `0.16` / SmithDB) is an explicit switch to a `v0.16.*` tag (`git tag -l 'v0.16.*'`).
+- Browse all releases in [GitHub Releases](https://github.com/langchain-ai/terraform/releases).
+- Advanced override: set the `CHART_VERSION` environment variable to pin an exact chart patch.
+
+The per-release history is published in [GitHub Releases](https://github.com/langchain-ai/terraform/releases).
+
+> Tags are immutable. Use `pre-terraform-migration` only for the legacy pre-`0.15` state (see [History](#history)).
 
 ## Documentation
 

--- a/modules/aws/README.md
+++ b/modules/aws/README.md
@@ -2,6 +2,8 @@
 
 Self-hosted LangSmith on Amazon EKS, managed with Terraform.
 
+> **Deploy from a release tag, not `main`.** Check out the latest `v0.15.*` tag before deploying (don't hardcode a patch): `git fetch --tags && git checkout "$(git tag -l 'v0.15.*' --sort=-v:refname | head -1)"`. Tags pin the LangSmith chart line (`~0.15.1` = latest `0.15.x`, never `0.16`). See [Versioning and releases](../../README.md#versioning-and-releases).
+
 ---
 
 ## Overview

--- a/modules/aws/helm/scripts/deploy.sh
+++ b/modules/aws/helm/scripts/deploy.sh
@@ -31,7 +31,9 @@ source "$INFRA_DIR/scripts/_common.sh"
 
 RELEASE_NAME="${RELEASE_NAME:-langsmith}"
 NAMESPACE="${NAMESPACE:-langsmith}"
-CHART_VERSION="${CHART_VERSION:-}"
+# Pin the chart *line*: deploy the latest 0.15.x, never auto-jump to 0.16.
+# Override with the CHART_VERSION env var for an exact patch if needed.
+CHART_VERSION="${CHART_VERSION:-~0.15.1}"
 
 # ── Resolve environment from terraform.tfvars ─────────────────────────────────
 _environment=$(_parse_tfvar "environment") || _environment="${LANGSMITH_ENV:-}"

--- a/modules/azure/README.md
+++ b/modules/azure/README.md
@@ -2,6 +2,8 @@
 
 Self-hosted LangSmith on Azure Kubernetes Service (AKS), managed with Terraform.
 
+> **Deploy from a release tag, not `main`.** Check out the latest `v0.15.*` tag before deploying (don't hardcode a patch): `git fetch --tags && git checkout "$(git tag -l 'v0.15.*' --sort=-v:refname | head -1)"`. Tags pin the LangSmith chart line (`~0.15.1` = latest `0.15.x`, never `0.16`). See [Versioning and releases](../../README.md#versioning-and-releases).
+
 ---
 
 ## Overview

--- a/modules/azure/helm/scripts/deploy.sh
+++ b/modules/azure/helm/scripts/deploy.sh
@@ -372,26 +372,13 @@ done
 echo ""
 
 # ── Chart version ─────────────────────────────────────────────────────────
-# Read from terraform.tfvars first, then env var, then prompt (interactive only)
+# Precedence: CHART_VERSION env var > terraform.tfvars > pinned line default.
+# We pin the chart *line* (~0.15.1 => latest 0.15.x, never 0.16) so an
+# un-pinned deploy can't silently jump a breaking minor.
 if [[ -z "$CHART_VERSION" ]]; then
   CHART_VERSION=$(_parse_tfvar "langsmith_helm_chart_version") || CHART_VERSION=""
 fi
-
-if [[ -z "$CHART_VERSION" ]]; then
-  helm repo add langchain https://langchain-ai.github.io/helm 2>/dev/null || true
-  helm repo update langchain &>/dev/null
-  echo "Available chart versions:"
-  helm search repo langchain/langsmith --versions | head -6
-  echo ""
-  if [[ -t 0 ]]; then
-    # Interactive terminal — prompt for version
-    printf "  Chart version to deploy (e.g. 0.13.29, or press Enter for latest): "
-    read -r CHART_VERSION
-  else
-    # Non-interactive — default to latest
-    info "Non-interactive mode: deploying latest chart version"
-  fi
-fi
+CHART_VERSION="${CHART_VERSION:-~0.15.1}"
 
 # ── Pending-upgrade guard ─────────────────────────────────────────────────
 _release_status=$(helm list -n "$NAMESPACE" --filter "^${RELEASE_NAME}$" --output json 2>/dev/null \

--- a/modules/gcp/README.md
+++ b/modules/gcp/README.md
@@ -2,6 +2,8 @@
 
 Self-hosted LangSmith on Google Kubernetes Engine (GKE), managed with Terraform.
 
+> **Deploy from a release tag, not `main`.** Check out the latest `v0.15.*` tag before deploying (don't hardcode a patch): `git fetch --tags && git checkout "$(git tag -l 'v0.15.*' --sort=-v:refname | head -1)"`. Tags pin the LangSmith chart line (`~0.15.1` = latest `0.15.x`, never `0.16`). See [Versioning and releases](../../README.md#versioning-and-releases).
+
 ---
 
 ## Overview

--- a/modules/gcp/helm/scripts/deploy.sh
+++ b/modules/gcp/helm/scripts/deploy.sh
@@ -29,7 +29,9 @@ VALUES_DIR="$HELM_DIR/values"
 
 RELEASE_NAME="${RELEASE_NAME:-langsmith}"
 NAMESPACE="${NAMESPACE:-langsmith}"
-CHART_VERSION="${CHART_VERSION:-}"
+# Pin the chart *line*: deploy the latest 0.15.x, never auto-jump to 0.16.
+# Override with the CHART_VERSION env var for an exact patch if needed.
+CHART_VERSION="${CHART_VERSION:-~0.15.1}"
 
 # ── tfvars helpers ────────────────────────────────────────────────────────────
 _parse_tfvar() {

--- a/modules/ocp/README.md
+++ b/modules/ocp/README.md
@@ -4,6 +4,8 @@
 
 This folder will contain Terraform modules to deploy a self-hosted version of LangSmith on OpenShift Container Platform (OCP), including ROSA (Red Hat OpenShift Service on AWS) and on-premises OpenShift deployments.
 
+> **Releases:** when this module ships, deploy from the latest `v0.15.*` release tag, not `main`. Tags pin the LangSmith chart line (`~0.15.1` = latest `0.15.x`). See [Versioning and releases](../../README.md#versioning-and-releases).
+
 ## Planned modules
 
 - LangSmith (root module)

--- a/modules/ocp/helm/scripts/deploy.sh
+++ b/modules/ocp/helm/scripts/deploy.sh
@@ -12,7 +12,9 @@ HELM_DIR="$SCRIPT_DIR/.."
 
 RELEASE_NAME="${RELEASE_NAME:-langsmith}"
 NAMESPACE="${NAMESPACE:-langsmith}"
-CHART_VERSION="${CHART_VERSION:-}"
+# Pin the chart *line*: deploy the latest 0.15.x, never auto-jump to 0.16.
+# Override with the CHART_VERSION env var for an exact patch if needed.
+CHART_VERSION="${CHART_VERSION:-~0.15.1}"
 OVERRIDES_FILE="$HELM_DIR/values/values-overrides.yaml"
 
 if [[ ! -f "$OVERRIDES_FILE" ]]; then


### PR DESCRIPTION
## Summary

Introduces repo tagging + Helm chart pinning so deployments are reproducible and can never silently jump across a breaking chart minor. Implements the line-pin proposal: global `vMAJOR.MINOR.PATCH` tags where `MAJOR.MINOR` tracks the supported LangSmith chart line and `PATCH` is a module revision counter.

Problem this fixes: `deploy.sh` left `CHART_VERSION` empty, so Helm resolved to the newest published chart at deploy time. Combined with customers tracking `main`, the same command could deploy a different LangSmith version day-to-day, including across a breaking minor (e.g. a `0.14.x`-era module pulling `0.15.0` and failing).

## What changed

- **Chart line pinned** in every provider's `deploy.sh` to `~0.15.1` (latest `0.15.x`, never `0.16`):
  - `aws` / `gcp` / `ocp`: env-only default change.
  - `azure`: pin applied after the `tfvars` read (precedence env > tfvars > pin); removed the float-to-latest fallback.
- **Release guard** `.github/scripts/chart-line.sh`: parses the `~MAJOR.MINOR` pin from all four providers and fails on a missing or divergent pin.
- **Auto-tag release workflow** `.github/workflows/release.yml`: on push to `main` touching `modules/**` (plus `workflow_dispatch` dry-run), runs the guard, computes the next tag `v<line>.<patch+1>` (seeds `v0.15.0`), tags from a fresh `main`, and publishes a GitHub Release. `concurrency: release` serializes runs; `[skip release]` opts out.
- **PR guard** `.github/workflows/chart-line-check.yml`: runs the guard on every PR so a bad/divergent pin is caught before merge.
- **Docs**: top-level and per-provider READMEs now instruct deploying from the latest `v0.15.*` tag, not `main`. `CHANGELOG.md` is a pointer to GitHub Releases (the automated per-tag history).
- `.gitignore`: ignore local `terraform.tfvars.*` sandbox files.

## Versioning model

- `MAJOR.MINOR` = supported chart line; `deploy.sh` installs the latest patch within it (`~0.15.1` => latest `0.15.x`).
- `PATCH` = module revision; increments on any repo change, regardless of provider. Not the chart version.
- Source of truth: the `deploy.sh` pin drives the tag `MAJOR.MINOR`; any repo change drives the tag `PATCH`. The guard runs at both the PR and release gates, so a tag can never claim a line its `deploy.sh` doesn't ship.

## Behavior after merge

Merging this PR triggers the release workflow; since no `v0.15.*` tag exists, it cuts the first tag `v0.15.0`. To make the first cut manually instead, include `[skip release]` in the merge commit and tag by hand.

## Test plan

- [ ] PR check `chart-line-check` is green.
- [ ] Confirm repo Actions setting = "Read and write permissions" (so the workflow can push tags / create releases).
- [ ] (Optional) Run the release workflow with `dry_run: true` to preview the computed version.
- [ ] After merge: `v0.15.0` tag and GitHub Release are created.
- [ ] `git checkout v0.15.0` then a deploy resolves the chart via `~0.15.1` (latest `0.15.x`).