### PR TITLE
Grant S3 bucket versioning and object lock config to BYOC role

### DIFF
--- a/modules/byoc/aws/langsmith-byoc-role/policies/s3.json
+++ b/modules/byoc/aws/langsmith-byoc-role/policies/s3.json
@@ -56,7 +56,9 @@
       "s3:PutBucketOwnershipControls",
       "s3:PutEncryptionConfiguration",
       "s3:PutLifecycleConfiguration",
-      "s3:PutBucketPolicy"
+      "s3:PutBucketPolicy",
+      "s3:PutBucketVersioning",
+      "s3:PutBucketObjectLockConfiguration"
     ],
     "Resource": [
       "arn:aws:s3:::*-smith-blob",


### PR DESCRIPTION
## Summary

Adds `s3:PutBucketVersioning` and `s3:PutBucketObjectLockConfiguration` to the `S3BucketConfig` statement of the BYOC langsmith role S3 policy (`modules/byoc/aws/langsmith-byoc-role/policies/s3.json`).

This is the role-policy prerequisite for enabling object lock and bucket versioning on the BYOC data plane buckets (`*-smith-blob`, `*-smith-clickhouse-backups`, `*-smith-vpc-flow-logs`). Split out so the IAM grant can land and propagate first.

- Additive, scoped to the same existing bucket ARNs.
- The existing `S3DenyObjectDataAccess` explicit Deny on object-level access (`arn:aws:s3:::*/*`) is unchanged.
- The matching `s3:GetBucketVersioning` / `s3:GetBucketObjectLockConfiguration` read actions already exist in `S3BucketRead`.

## Test plan

- `terraform plan` shows only the IAM policy document update; no resource replacement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)