### PR TITLE
fix(byoc): grant Route53 VPC associate/disassociate on private zones

### DIFF
--- a/modules/byoc/aws/langsmith-byoc-role/policies/route53.json
+++ b/modules/byoc/aws/langsmith-byoc-role/policies/route53.json
@@ -8,7 +8,11 @@
   {
     "Sid": "Route53CreatePrivateHostedZone",
     "Effect": "Allow",
-    "Action": ["route53:CreateHostedZone"],
+    "Action": [
+      "route53:CreateHostedZone",
+      "route53:AssociateVPCWithHostedZone",
+      "route53:DisassociateVPCFromHostedZone"
+    ],
     "Resource": "*",
     "Condition": {
       "Null": {


### PR DESCRIPTION
## Summary
- Add `route53:AssociateVPCWithHostedZone` and `route53:DisassociateVPCFromHostedZone` to the customer BYOC role's private Route53 statement
- Uses the existing `route53:VPCs` null=false condition alongside `CreateHostedZone` (private-zone-only API behavior)
- Mirrors deployments `crossplane_customer_role` change (langchain-ai/deployments#32533)

## Context
Crossplane reconciles private hosted zone VPC associations on update and needs disassociate permission; without it customers see `AccessDenied` on `route53:DisassociateVPCFromHostedZone`.

## Test plan
- [ ] Customer re-applies `langsmith-byoc-role` module (or updates `langsmith-byoc-dns` policy) in their AWS account
- [ ] Confirm Crossplane Route53 Zone resources reconcile without 403 on VPC disassociate

Made with [Cursor](https://cursor.com)