### PR TITLE
Keep BYOC IAM policies under size limit

### DIFF
--- a/modules/byoc/aws/langsmith-byoc-role/policies/iam-karpenter-eks-profiles.json
+++ b/modules/byoc/aws/langsmith-byoc-role/policies/iam-karpenter-eks-profiles.json
@@ -87,5 +87,34 @@
         "aws:ResourceTag/managed_by": "langsmith"
       }
     }
+  },
+  {
+    "Sid": "IAMPassRole",
+    "Effect": "Allow",
+    "Action": ["iam:PassRole"],
+    "Resource": [
+      "arn:aws:iam::${account_id}:role/*-smith-postgres-monitoring-role",
+      "arn:aws:iam::${account_id}:role/*-smith-eks-cluster-role",
+      "arn:aws:iam::${account_id}:role/*-smith-ebs-csi-role",
+      "arn:aws:iam::${account_id}:role/*-smith-eks-node-role",
+      "arn:aws:iam::${account_id}:role/*-smith-workload-iam-role",
+      "arn:aws:iam::${account_id}:role/*-smith-external-secrets-iam-role",
+      "arn:aws:iam::${account_id}:role/*-smith-karpenter-node-role",
+      "arn:aws:iam::${account_id}:role/*-smith-karpenter-controller-role",
+      "arn:aws:iam::${account_id}:role/*-smith-privatelink-lambda-role",
+      "arn:aws:iam::${account_id}:role/*-smith-lbc-role",
+      "arn:aws:iam::${account_id}:role/*-smith-ch-backup-role"
+    ],
+    "Condition": {
+      "StringEquals": {
+        "iam:PassedToService": [
+          "eks.amazonaws.com",
+          "ec2.amazonaws.com",
+          "pods.eks.amazonaws.com",
+          "monitoring.rds.amazonaws.com",
+          "lambda.amazonaws.com"
+        ]
+      }
+    }
   }
 ]

--- a/modules/byoc/aws/langsmith-byoc-role/policies/iam.json
+++ b/modules/byoc/aws/langsmith-byoc-role/policies/iam.json
@@ -121,34 +121,5 @@
         ]
       }
     }
-  },
-  {
-    "Sid": "IAMPassRole",
-    "Effect": "Allow",
-    "Action": ["iam:PassRole"],
-    "Resource": [
-      "arn:aws:iam::${account_id}:role/*-smith-postgres-monitoring-role",
-      "arn:aws:iam::${account_id}:role/*-smith-eks-cluster-role",
-      "arn:aws:iam::${account_id}:role/*-smith-ebs-csi-role",
-      "arn:aws:iam::${account_id}:role/*-smith-eks-node-role",
-      "arn:aws:iam::${account_id}:role/*-smith-workload-iam-role",
-      "arn:aws:iam::${account_id}:role/*-smith-external-secrets-iam-role",
-      "arn:aws:iam::${account_id}:role/*-smith-karpenter-node-role",
-      "arn:aws:iam::${account_id}:role/*-smith-karpenter-controller-role",
-      "arn:aws:iam::${account_id}:role/*-smith-privatelink-lambda-role",
-      "arn:aws:iam::${account_id}:role/*-smith-lbc-role",
-      "arn:aws:iam::${account_id}:role/*-smith-ch-backup-role"
-    ],
-    "Condition": {
-      "StringEquals": {
-        "iam:PassedToService": [
-          "eks.amazonaws.com",
-          "ec2.amazonaws.com",
-          "pods.eks.amazonaws.com",
-          "monitoring.rds.amazonaws.com",
-          "lambda.amazonaws.com"
-        ]
-      }
-    }
   }
 ]


### PR DESCRIPTION
## Summary
- move the BYOC IAMPassRole statement into the already-attached karpenter/EKS profiles IAM policy
- keep PassRole scoped with iam:PassedToService while reducing the main IAM managed policy size
- avoid AWS's 6,144 character managed-policy size limit for the main IAM policy

## Validation
- jq empty modules/byoc/aws/langsmith-byoc-role/policies/iam.json
- jq empty modules/byoc/aws/langsmith-byoc-role/policies/iam-karpenter-eks-profiles.json
- rendered size check: iam ~4,410 chars, iam-karpenter-eks-profiles ~2,867 chars