### PR TITLE
docs(azure,aws): fix node-pool sizing and admin-password accuracy

### DIFF
--- a/modules/aws/README.md
+++ b/modules/aws/README.md
@@ -532,7 +532,7 @@ For each secret it follows this priority order:
 | `langsmith-api-key-salt` | Auto-generated (`openssl rand -base64 32`) | **Never change** — invalidates all API keys |
 | `langsmith-jwt-secret` | Auto-generated (`openssl rand -base64 32`) | **Never change** — invalidates all sessions |
 | `langsmith-license-key` | You enter it | From your LangChain account |
-| `langsmith-admin-password` | You enter it | Must contain `!#$%()+,-./:?@[\]^_{~}` |
+| `langsmith-admin-password` | You enter it | Min 12 chars; must include a lowercase letter, an uppercase letter, and a symbol (`!#$%()+,-./:?@[\]^_{~}`) |
 | `deployments-encryption-key` | Auto-generated (Fernet key) | For Deployments/LangGraph Platform feature |
 | `agent-builder-encryption-key` | Auto-generated (Fernet key) | For Agent Builder feature |
 | `insights-encryption-key` | Auto-generated (Fernet key) | For Insights feature |

--- a/modules/azure/ARCHITECTURE.md
+++ b/modules/azure/ARCHITECTURE.md
@@ -37,6 +37,8 @@ Adds to Pass 3 — 3 static + 4 dynamic pods:
 
 **[LangSmith Azure — Pass 3 Platform Containers (v0.13.28)](https://app.eraser.io/workspace/6renzZO9DtNdvLuqO0Aa)**
 
+![LangSmith Azure Pass 3 Platform Containers](diagrams/lang_smith_deployment_pass_3.png)
+
 Adds 3 pods to the Pass 2 topology:
 - `langsmith-host-backend` — LangGraph control plane API (WI)
 - `langsmith-listener` — watches host-backend, creates LangGraphPlatform CRDs (WI)
@@ -46,6 +48,8 @@ Adds 3 pods to the Pass 2 topology:
 ### Pass 2 — Platform Containers (External Postgres + Redis, verified)
 
 **[LangSmith Azure — Pass 2 Platform Containers (v0.13.28)](https://app.eraser.io/workspace/CTA7dtpxBysehdXeYOHu)**
+
+![LangSmith Azure Pass 2 Platform Containers](diagrams/lang_smith_deployment_pass_2.png)
 
 Exact pod topology from `kubectl get pods -n langsmith` after successful Pass 2 deploy:
 - 7 Deployments: frontend, backend (×3), platform-backend, playground, ace-backend, queue (×3), ingest-queue (×3)

--- a/modules/azure/infra/modules/k8s-cluster/main.tf
+++ b/modules/azure/infra/modules/k8s-cluster/main.tf
@@ -11,9 +11,10 @@
 #     pods to authenticate to Azure Blob Storage without static keys.
 #   • System-assigned Managed Identity: AKS manages its own identity for
 #     pulling images, accessing node resource group, and VMSS operations.
-#   • Default node pool: Standard_DS3_v2 (4 vCPU, 14 GB RAM) — DSv2 family
-#     has broad quota availability across subscriptions.
-#   • Additional "large" pool: Standard_DS4_v2 (8 vCPU, 28 GB) for ClickHouse
+#   • Default node pool: Standard_D8s_v3 (8 vCPU, 32 GB RAM) — Dsv3 family,
+#     the production baseline (matches the root module default). DSv2
+#     (DS3_v2 / DS4_v2) is the documented fallback when Dsv3 quota is short.
+#   • Additional "large" pool: Standard_D16s_v3 (16 vCPU, 64 GB) for ClickHouse
 #     and other stateful/memory-intensive workloads.
 #   • NGINX ingress: deployed via Helm, exposes a single Azure Load Balancer
 #     IP that routes to all LangSmith services by path/host.
@@ -86,7 +87,7 @@ resource "azurerm_kubernetes_cluster" "main" {
   default_node_pool {
     name = "default"
 
-    # Standard_DS3_v2: 4 vCPU, 14 GB RAM — DSv2 family has broad quota availability.
+    # Default Standard_D8s_v3: 8 vCPU, 32 GB RAM — Dsv3 family, the production baseline.
     # LangSmith backend requests 100m CPU / 500Mi; all pods use lightweight mode.
     vm_size = var.default_node_pool_vm_size
 
@@ -193,7 +194,7 @@ resource "azurerm_kubernetes_cluster" "main" {
 }
 
 # Additional node pools for workloads that need different compute profiles.
-# Default: one "large" pool (Standard_DS4_v2, 8 vCPU / 28 GB) for ClickHouse
+# Default: one "large" pool (Standard_D16s_v3, 16 vCPU / 64 GB) for ClickHouse
 # and other memory-intensive services. Scales 0→2 (scales to zero when idle).
 resource "azurerm_kubernetes_cluster_node_pool" "node_pool" {
   for_each = var.additional_node_pools

--- a/modules/azure/infra/modules/k8s-cluster/variables.tf
+++ b/modules/azure/infra/modules/k8s-cluster/variables.tf
@@ -27,7 +27,7 @@ variable "kubernetes_version" {
 variable "default_node_pool_vm_size" {
   type        = string
   description = "VM size of the default node pool"
-  default     = "Standard_DS3_v2" # 4 vCPU, 14GB RAM — DSv2 family (60 free vCPUs in eastus)
+  default     = "Standard_D8s_v3" # 8 vCPU, 32GB RAM — Dsv3 family; matches the root module's production default
 }
 
 variable "default_node_pool_min_count" {
@@ -69,7 +69,7 @@ variable "additional_node_pools" {
   description = "Node pools to be created"
   default = {
     large = {
-      vm_size   = "Standard_DS4_v2" # 8 vCPU, 28GB RAM — DSv2 family
+      vm_size   = "Standard_D16s_v3" # 16 vCPU, 64GB RAM — Dsv3 family; matches the root module's production default
       min_count = 0
       max_count = 2
     }


### PR DESCRIPTION
Corrects four inaccuracies surfaced in a review of the module docs and config. All were re-verified against the current `main` before opening this PR.

## Changes

**aws:** the `langsmith-admin-password` row in the SSM secrets table (`modules/aws/README.md`) implied the only requirement was containing a symbol. It now states the full chart rule: minimum 12 characters, plus a lowercase letter, an uppercase letter, and a symbol.

**azure:** the `k8s-cluster` submodule node-pool defaults said `Standard_DS3_v2` / `Standard_DS4_v2` (DSv2), while the root module and the variable descriptions reference the `Dsv3` production baseline. Aligned the submodule defaults to `Standard_D8s_v3` (default pool) and `Standard_D16s_v3` (large pool). The root module already overrides these on every standard deploy, so deployed clusters are unchanged. This only affects standalone submodule calls and removes the self-contradicting comments.

**azure:** updated the three `k8s-cluster` comment blocks (`main.tf`) to match the `Dsv3` defaults.

**azure:** embedded the previously orphaned Pass 2 and Pass 3 architecture diagrams (`diagrams/lang_smith_deployment_pass_2.png`, `pass_3.png`) in `ARCHITECTURE.md`, matching how the Pass 4/5 and Light Deploy diagrams are already referenced. Both files exist in the repo but were not shown.

## Notes

- No runtime impact. The AWS change is doc text, the Azure default change is masked by root-module overrides on standard deploys, and the remaining changes are comments and diagram embeds.
- `terraform fmt -check` on the `k8s-cluster` module reports two pre-existing alignment issues at `main.tf:246` and `main.tf:259` (federated-credential `name` fields). These exist on `main` and are outside the scope of this change, so they are left untouched. This PR introduces no new formatting diffs.
