### PR TITLE
fix(azure): repair invalid HCL in app/locals.tf and fmt whole repo

### DIFF
--- a/modules/aws/app/locals.tf
+++ b/modules/aws/app/locals.tf
@@ -26,8 +26,8 @@ locals {
   # Derived
   ssm_prefix = "/langsmith/${local.name_prefix}-${local.environment}"
   # hostname: explicit var.hostname wins, then custom domain from infra, then ALB DNS name
-  hostname   = coalesce(var.hostname, var.langsmith_domain, local.alb_dns_name, "")
-  protocol   = local.tls_certificate_source == "none" ? "http" : "https"
+  hostname = coalesce(var.hostname, var.langsmith_domain, local.alb_dns_name, "")
+  protocol = local.tls_certificate_source == "none" ? "http" : "https"
 
   tls_enabled_for_deploys = var.tls_enabled_for_deploys != null ? var.tls_enabled_for_deploys : (local.tls_certificate_source != "none")
 

--- a/modules/aws/app/main.tf
+++ b/modules/aws/app/main.tf
@@ -237,14 +237,14 @@ resource "helm_release" "langsmith" {
     # 2. Dynamic overrides (hostname, IRSA annotations, S3 bucket, region)
     [yamlencode(local.overrides_values)],
     # 3. Sizing
-    var.sizing == "production"       ? [file("${local.values_path}/langsmith-values-sizing-production.yaml")] : [],
+    var.sizing == "production" ? [file("${local.values_path}/langsmith-values-sizing-production.yaml")] : [],
     var.sizing == "production-large" ? [file("${local.values_path}/langsmith-values-sizing-production-large.yaml")] : [],
-    var.sizing == "dev"              ? [file("${local.values_path}/langsmith-values-sizing-dev.yaml")] : [],
+    var.sizing == "dev" ? [file("${local.values_path}/langsmith-values-sizing-dev.yaml")] : [],
     # 4. Product addons
     var.enable_agent_deploys ? [file("${local.values_path}/langsmith-values-agent-deploys.yaml"), yamlencode(local.agent_deploys_overrides)] : [],
     var.enable_agent_builder ? [file("${local.values_path}/langsmith-values-agent-builder.yaml")] : [],
-    var.enable_insights      ? [file("${local.values_path}/langsmith-values-insights.yaml"), yamlencode(local.insights_overrides)] : [],
-    var.enable_polly         ? [file("${local.values_path}/langsmith-values-polly.yaml")] : [],
+    var.enable_insights ? [file("${local.values_path}/langsmith-values-insights.yaml"), yamlencode(local.insights_overrides)] : [],
+    var.enable_polly ? [file("${local.values_path}/langsmith-values-polly.yaml")] : [],
   )
 }
 
@@ -258,8 +258,8 @@ resource "kubernetes_service_account_v1" "langsmith_ksa" {
   count = var.enable_agent_deploys ? 1 : 0
 
   metadata {
-    name      = "langsmith-ksa"
-    namespace = local.namespace
+    name        = "langsmith-ksa"
+    namespace   = local.namespace
     annotations = local.irsa_annotations
   }
 

--- a/modules/aws/infra/locals.tf
+++ b/modules/aws/infra/locals.tf
@@ -13,15 +13,15 @@ resource "random_id" "bucket_suffix" {
 }
 
 locals {
-  base_name      = "${var.name_prefix}-${var.environment}"
-  vpc_name       = "${local.base_name}-vpc"
-  cluster_name   = "${local.base_name}-eks"
-  redis_name     = "${local.base_name}-redis"
-  bucket_name    = "${local.base_name}-traces-${random_id.bucket_suffix.hex}"
-  postgres_name  = "${local.base_name}-pg"
-  alb_name       = "${local.base_name}-alb"
-  bastion_name   = "${local.base_name}-bastion"
-  firewall_name  = "${local.base_name}-fw"
+  base_name     = "${var.name_prefix}-${var.environment}"
+  vpc_name      = "${local.base_name}-vpc"
+  cluster_name  = "${local.base_name}-eks"
+  redis_name    = "${local.base_name}-redis"
+  bucket_name   = "${local.base_name}-traces-${random_id.bucket_suffix.hex}"
+  postgres_name = "${local.base_name}-pg"
+  alb_name      = "${local.base_name}-alb"
+  bastion_name  = "${local.base_name}-bastion"
+  firewall_name = "${local.base_name}-fw"
 
   common_tags = merge(
     {

--- a/modules/aws/infra/modules/cert-manager/main.tf
+++ b/modules/aws/infra/modules/cert-manager/main.tf
@@ -41,9 +41,9 @@ resource "aws_iam_policy" "cert_manager_route53" {
         Resource = "arn:aws:route53:::hostedzone/${var.hosted_zone_id}"
       },
       {
-        Sid      = "ListZones"
-        Effect   = "Allow"
-        Action   = "route53:ListHostedZonesByName"
+        Sid    = "ListZones"
+        Effect = "Allow"
+        Action = "route53:ListHostedZonesByName"
         # Route 53 does not support resource-level permissions for
         # ListHostedZonesByName — must be * per AWS and cert-manager docs.
         Resource = "*"

--- a/modules/aws/infra/outputs.tf
+++ b/modules/aws/infra/outputs.tf
@@ -260,21 +260,21 @@ output "gateway_target_group_arn" {
 output "resource_summary" {
   description = "Summary of provisioned resources"
   value = {
-    cluster            = module.eks.cluster_name
-    postgres_source    = var.postgres_source
-    postgres           = var.postgres_source == "external" ? "external (RDS)" : "in-cluster (Helm)"
-    redis_source       = var.redis_source
-    redis              = var.redis_source == "external" ? "external (ElastiCache)" : "in-cluster (Helm)"
-    storage_bucket     = local.bucket_name
-    namespace          = var.langsmith_namespace
-    tls                = var.tls_certificate_source
-    alb                = module.alb.alb_dns_name
-    bastion            = var.create_bastion ? module.bastion[0].instance_id : "not created"
-    firewall           = var.create_firewall ? "enabled (allowed: ${join(", ", var.firewall_allowed_fqdns)})" : "not created"
-    deployments        = var.enable_deployments
-    agent_builder      = var.enable_agent_builder
-    insights           = var.enable_insights
-    polly              = var.enable_polly
+    cluster         = module.eks.cluster_name
+    postgres_source = var.postgres_source
+    postgres        = var.postgres_source == "external" ? "external (RDS)" : "in-cluster (Helm)"
+    redis_source    = var.redis_source
+    redis           = var.redis_source == "external" ? "external (ElastiCache)" : "in-cluster (Helm)"
+    storage_bucket  = local.bucket_name
+    namespace       = var.langsmith_namespace
+    tls             = var.tls_certificate_source
+    alb             = module.alb.alb_dns_name
+    bastion         = var.create_bastion ? module.bastion[0].instance_id : "not created"
+    firewall        = var.create_firewall ? "enabled (allowed: ${join(", ", var.firewall_allowed_fqdns)})" : "not created"
+    deployments     = var.enable_deployments
+    agent_builder   = var.enable_agent_builder
+    insights        = var.enable_insights
+    polly           = var.enable_polly
   }
 }
 
@@ -283,7 +283,7 @@ output "resource_summary" {
 #------------------------------------------------------------------------------
 output "next_steps" {
   description = "Next steps after terraform apply"
-  value       = <<-EOT
+  value = <<-EOT
 
     ============================================
     LangSmith Infrastructure Provisioned (AWS)
@@ -327,7 +327,7 @@ ${local.dns_enabled && var.tls_certificate_source != "acm" ? <<-DNS
        http://${module.alb.alb_dns_name}  (HTTP — until you complete step 3)
 
 DNS
-: local.dns_enabled && var.tls_certificate_source == "acm" ? <<-ACMDONE
+  : local.dns_enabled && var.tls_certificate_source == "acm" ? <<-ACMDONE
 
     2. Deploy LangSmith (pick one):
 
@@ -347,7 +347,7 @@ DNS
        https://${var.langsmith_domain}
 
 ACMDONE
-: <<-NODNS
+  : <<-NODNS
 
     2. Run the Helm deployment:
        cd ../helm && source ../infra/setup-env.sh --deploy && ./scripts/deploy.sh

--- a/modules/azure/app/locals.tf
+++ b/modules/azure/app/locals.tf
@@ -77,10 +77,10 @@ locals {
           url = "${local.protocol}://${local.hostname}"
         }
         blobStorage = {
-          enabled        = true
-          bucketName     = local.storage_container_name
-          storageAccount = local.storage_account_name
-          connectionString = ""  # empty — Workload Identity handles auth, no key needed
+          enabled          = true
+          bucketName       = local.storage_container_name
+          storageAccount   = local.storage_account_name
+          connectionString = "" # empty — Workload Identity handles auth, no key needed
         }
       }
       commonEnv = concat(
@@ -89,7 +89,11 @@ locals {
         ],
         var.enable_usage_telemetry ? [{ name = "PHONE_HOME_USAGE_REPORTING_ENABLED", value = "true" }] : [],
       )
-      # Workload Identity annotations on each component's service account
+    },
+    # Workload Identity annotations on each component's service account.
+    # Separate merge() argument — a for-expression cannot share an object
+    # constructor with static attributes like config/commonEnv above.
+    {
       for component in local.wi_components : component => {
         serviceAccount = {
           annotations = local.wi_annotations

--- a/modules/azure/app/main.tf
+++ b/modules/azure/app/main.tf
@@ -111,10 +111,10 @@ resource "kubernetes_secret_v1" "langsmith_config" {
 
   data = merge(
     {
-      langsmith_license_key       = data.azurerm_key_vault_secret.license_key.value
-      initial_org_admin_password  = data.azurerm_key_vault_secret.admin_password.value
-      api_key_salt                = data.azurerm_key_vault_secret.api_key_salt.value
-      jwt_secret                  = data.azurerm_key_vault_secret.jwt_secret.value
+      langsmith_license_key      = data.azurerm_key_vault_secret.license_key.value
+      initial_org_admin_password = data.azurerm_key_vault_secret.admin_password.value
+      api_key_salt               = data.azurerm_key_vault_secret.api_key_salt.value
+      jwt_secret                 = data.azurerm_key_vault_secret.jwt_secret.value
     },
     var.enable_agent_deploys ? {
       deployments_encryption_key = data.azurerm_key_vault_secret.deployments_key[0].value
@@ -170,8 +170,8 @@ resource "kubernetes_service_account_v1" "langsmith_ksa" {
   count = var.enable_agent_deploys ? 1 : 0
 
   metadata {
-    name      = "langsmith-ksa"
-    namespace = local.namespace
+    name        = "langsmith-ksa"
+    namespace   = local.namespace
     annotations = local.wi_annotations
     labels = {
       "azure.workload.identity/use" = "true"
@@ -211,14 +211,14 @@ resource "helm_release" "langsmith" {
     # 2. Dynamic overrides (hostname, WI annotations, storage account)
     [yamlencode(local.overrides_values)],
     # 3. Sizing
-    var.sizing == "production"       ? [file("${local.values_path}/langsmith-values-sizing-production.yaml")] : [],
+    var.sizing == "production" ? [file("${local.values_path}/langsmith-values-sizing-production.yaml")] : [],
     var.sizing == "production-large" ? [file("${local.values_path}/langsmith-values-sizing-production-large.yaml")] : [],
-    var.sizing == "dev"              ? [file("${local.values_path}/langsmith-values-sizing-dev.yaml")] : [],
+    var.sizing == "dev" ? [file("${local.values_path}/langsmith-values-sizing-dev.yaml")] : [],
     # 4. Product addons
     var.enable_agent_deploys ? [file("${local.values_path}/langsmith-values-agent-deploys.yaml"), yamlencode(local.agent_deploys_overrides)] : [],
     var.enable_agent_builder ? [file("${local.values_path}/langsmith-values-agent-builder.yaml")] : [],
-    var.enable_insights      ? [file("${local.values_path}/langsmith-values-insights.yaml"), yamlencode(local.insights_overrides)] : [],
-    var.enable_polly         ? [file("${local.values_path}/langsmith-values-polly.yaml")] : [],
+    var.enable_insights ? [file("${local.values_path}/langsmith-values-insights.yaml"), yamlencode(local.insights_overrides)] : [],
+    var.enable_polly ? [file("${local.values_path}/langsmith-values-polly.yaml")] : [],
   )
 }
 

--- a/modules/azure/infra/main.tf
+++ b/modules/azure/infra/main.tf
@@ -250,7 +250,7 @@ module "keyvault" {
   # ── Secrets ─────────────────────────────────────────────────────────────────
   # Values come from TF_VAR_* on first apply. setup-env.sh reads from Key Vault
   # on subsequent applies, eliminating local .secret files.
-  postgres_admin_password = var.postgres_admin_password
+  postgres_admin_password  = var.postgres_admin_password
   langsmith_admin_password = var.langsmith_admin_password
   langsmith_license_key    = var.langsmith_license_key
   langsmith_api_key_salt   = var.langsmith_api_key_salt
@@ -370,16 +370,16 @@ module "diagnostics" {
 # Enable with: create_bastion = true in terraform.tfvars
 
 module "bastion" {
-  count               = var.create_bastion ? 1 : 0
-  source              = "./modules/bastion"
-  name                = "langsmith-bastion${local.identifier}"
-  resource_group_name = azurerm_resource_group.resource_group.name
-  location            = var.location
-  subnet_id           = module.vnet.subnet_bastion_id
-  vm_size             = var.bastion_vm_size
+  count                = var.create_bastion ? 1 : 0
+  source               = "./modules/bastion"
+  name                 = "langsmith-bastion${local.identifier}"
+  resource_group_name  = azurerm_resource_group.resource_group.name
+  location             = var.location
+  subnet_id            = module.vnet.subnet_bastion_id
+  vm_size              = var.bastion_vm_size
   admin_ssh_public_key = var.bastion_admin_ssh_public_key
-  allowed_ssh_cidrs   = var.bastion_allowed_ssh_cidrs
-  tags                = local.common_tags
+  allowed_ssh_cidrs    = var.bastion_allowed_ssh_cidrs
+  tags                 = local.common_tags
 
   depends_on = [module.vnet]
 }

--- a/modules/azure/infra/modules/k8s-bootstrap/main.tf
+++ b/modules/azure/infra/modules/k8s-bootstrap/main.tf
@@ -188,7 +188,7 @@ resource "kubernetes_secret_v1" "postgres" {
   }
 
   data = {
-    connection_url    = var.postgres_connection_url
+    connection_url = var.postgres_connection_url
     # POSTGRES_URI and POSTGRES_PASSWORD are required by the listener's deploy_image
     # task (host.platforms.k8s_operator.database_k8s.add_postgres_uri_secret) to
     # provision per-deployment databases for LangSmith Deployments (Pass 3+).

--- a/modules/azure/infra/modules/k8s-cluster/main.tf
+++ b/modules/azure/infra/modules/k8s-cluster/main.tf
@@ -245,7 +245,7 @@ resource "azurerm_user_assigned_identity" "cert_manager" {
 # Allows cert-manager pod to exchange its K8s OIDC token for an Azure AD token
 # so it can call the Azure DNS API without a static service principal secret.
 resource "azurerm_federated_identity_credential" "cert_manager" {
-  name      = "${var.cluster_name}-cert-manager-federated"
+  name                      = "${var.cluster_name}-cert-manager-federated"
   user_assigned_identity_id = azurerm_user_assigned_identity.cert_manager.id
 
   audience = ["api://AzureADTokenExchange"]
@@ -258,7 +258,7 @@ resource "azurerm_federated_identity_credential" "cert_manager" {
 resource "azurerm_federated_identity_credential" "k8s_app" {
   for_each = toset(local.service_accounts_for_workload_identity)
 
-  name      = "langsmith-federated-${each.value}"
+  name                      = "langsmith-federated-${each.value}"
   user_assigned_identity_id = azurerm_user_assigned_identity.k8s_app.id
 
   audience = ["api://AzureADTokenExchange"]

--- a/modules/azure/infra/outputs.tf
+++ b/modules/azure/infra/outputs.tf
@@ -77,7 +77,7 @@ output "langsmith_url" {
   description = "URL where LangSmith is accessible."
   value = (
     var.langsmith_domain != "" ? "https://${var.langsmith_domain}" :
-    var.dns_label != ""  ? "https://${var.dns_label}.${var.location}.cloudapp.azure.com" :
+    var.dns_label != "" ? "https://${var.dns_label}.${var.location}.cloudapp.azure.com" :
     var.ingress_controller == "agic" && module.aks.agw_public_ip_fqdn != null && module.aks.agw_public_ip_fqdn != "" ? "https://${module.aks.agw_public_ip_fqdn}" :
     "No domain configured — set dns_label or langsmith_domain in terraform.tfvars"
   )

--- a/modules/gcp/app/main.tf
+++ b/modules/gcp/app/main.tf
@@ -98,15 +98,15 @@ resource "helm_release" "langsmith" {
     # 2. Dynamic overrides (hostname, Workload Identity annotations, GCS bucket)
     [yamlencode(local.overrides_values)],
     # 3. Sizing
-    var.sizing == "production"       ? [file("${local.values_path}/langsmith-values-sizing-production.yaml")] : [],
+    var.sizing == "production" ? [file("${local.values_path}/langsmith-values-sizing-production.yaml")] : [],
     var.sizing == "production-large" ? [file("${local.values_path}/langsmith-values-sizing-production-large.yaml")] : [],
-    var.sizing == "dev"              ? [file("${local.values_path}/langsmith-values-sizing-dev.yaml")] : [],
-    var.sizing == "minimum"          ? [file("${local.values_path}/langsmith-values-sizing-minimum.yaml")] : [],
+    var.sizing == "dev" ? [file("${local.values_path}/langsmith-values-sizing-dev.yaml")] : [],
+    var.sizing == "minimum" ? [file("${local.values_path}/langsmith-values-sizing-minimum.yaml")] : [],
     # 4. Product addons
     var.enable_agent_deploys ? [file("${local.values_path}/langsmith-values-agent-deploys.yaml"), yamlencode(local.agent_deploys_overrides)] : [],
     var.enable_agent_builder ? [file("${local.values_path}/langsmith-values-agent-builder.yaml")] : [],
-    var.enable_insights      ? [file("${local.values_path}/langsmith-values-insights.yaml"), yamlencode(local.insights_overrides)] : [],
-    var.enable_polly         ? [file("${local.values_path}/langsmith-values-polly.yaml")] : [],
+    var.enable_insights ? [file("${local.values_path}/langsmith-values-insights.yaml"), yamlencode(local.insights_overrides)] : [],
+    var.enable_polly ? [file("${local.values_path}/langsmith-values-polly.yaml")] : [],
   )
 }
 
@@ -120,8 +120,8 @@ resource "kubernetes_service_account_v1" "langsmith_ksa" {
   count = var.enable_agent_deploys && length(local.wi_annotations) > 0 ? 1 : 0
 
   metadata {
-    name      = "langsmith-ksa"
-    namespace = local.namespace
+    name        = "langsmith-ksa"
+    namespace   = local.namespace
     annotations = local.wi_annotations
   }
 

--- a/modules/ocp/infra/modules/dns/main.tf
+++ b/modules/ocp/infra/modules/dns/main.tf
@@ -29,7 +29,7 @@ resource "kubernetes_manifest" "langsmith_route" {
         targetPort = "http"
       }
       tls = var.tls_enabled ? {
-        termination                = "edge"
+        termination                   = "edge"
         insecureEdgeTerminationPolicy = "Redirect"
       } : null
     }


### PR DESCRIPTION
## Summary

Repairs a pre-existing invalid-HCL bug and clears whole-repo `terraform fmt` drift, so the **Terraform Format** CI check goes green. The check runs `terraform fmt -recursive -check` from the repo root, so it currently fails on **every** PR touching `modules/**`.

## Two problems, both pre-existing on `main`

1. **Invalid HCL in `modules/azure/app/locals.tf`.** A `for`-expression shared one object constructor with static attributes (`config`, `commonEnv`) inside a `merge()` call. That is not valid HCL, so `terraform fmt` and `terraform validate` error on the entire `azure/app` root. Fixed by splitting the mixed object into two `merge()` arguments.
2. **Whitespace/alignment drift** across `aws`, `gcp`, `ocp`, and `azure` modules that never got a `terraform fmt` pass.

## What's in the diff

- `modules/azure/app/locals.tf` — the syntax repair (the only non-whitespace change in the PR) plus fmt.
- 12 other files — `terraform fmt -recursive` alignment only. `git diff -w` on those is empty.

## Verification

- `terraform fmt -recursive -check` from repo root now exits **0**.
- `modules/azure/app` parses again (previously errored before `terraform init`).

## Why separate

Keeps the reformat and the syntax fix as one reviewable repo-health change instead of burying aws/gcp/ocp churn inside a feature PR. Unblocks the Format check for all open PRs (#73, #62, #66, #74, #75). Those PRs will need a rebase to pick up the reformatted lines.
