### PR TITLE
fix(gcp): correct WI ServiceAccount names for chart 0.15 fleet rename

### DIFF
--- a/modules/gcp/ARCHITECTURE.md
+++ b/modules/gcp/ARCHITECTURE.md
@@ -18,7 +18,7 @@ LangSmith is deployed in three passes. Each pass adds a capability layer on top 
 | 1 | GCP Infrastructure | VPC, GKE, Cloud SQL, Memorystore, GCS, K8s bootstrap, cert-manager, KEDA, Envoy Gateway |
 | 2 | LangSmith Base | frontend, backend, platform-backend, queue, ace-backend, clickhouse, playground |
 | 3 | LangSmith Deployments | host-backend, listener, operator + per-deployment pods |
-| 4 | Agent Builder | agent-builder-tool-server, agent-builder-trigger-server + deep-agent LGP |
+| 4 | Agent Builder | fleet-tool-server, fleet-trigger-server + deep-agent LGP |
 | 5 | Insights + Polly | Clio analytics (ClickHouse-backed), Polly eval agent |
 
 ---

--- a/modules/gcp/ARCHITECTURE.md
+++ b/modules/gcp/ARCHITECTURE.md
@@ -18,7 +18,7 @@ LangSmith is deployed in three passes. Each pass adds a capability layer on top 
 | 1 | GCP Infrastructure | VPC, GKE, Cloud SQL, Memorystore, GCS, K8s bootstrap, cert-manager, KEDA, Envoy Gateway |
 | 2 | LangSmith Base | frontend, backend, platform-backend, queue, ace-backend, clickhouse, playground |
 | 3 | LangSmith Deployments | host-backend, listener, operator + per-deployment pods |
-| 4 | Agent Builder | fleet-tool-server, fleet-trigger-server + deep-agent LGP |
+| 4 | Agent Builder | fleet-tool-server, fleet-trigger-server (agent-builder-tool-server/trigger-server on chart < 0.15) + deep-agent LGP |
 | 5 | Insights + Polly | Clio analytics (ClickHouse-backed), Polly eval agent |
 
 ---

--- a/modules/gcp/infra/main.tf
+++ b/modules/gcp/infra/main.tf
@@ -348,7 +348,12 @@ module "iam" {
     "langsmith-listener",
     # Chart 0.15 renamed these Deployments (agentBuilderToolServer/TriggerServer ->
     # fleetToolServer/fleetTriggerServer), which also renamed the ServiceAccount the
-    # chart creates for them. Must track the chart's SA name or WI binding silently no-ops.
+    # chart creates for them. Keep both old and new names — CHART_VERSION can still
+    # be pinned below 0.15 (see deploy.sh), where the chart creates the old-named SA
+    # instead. Harmless either way: WI binds only to whichever SA the chart actually
+    # creates for the pinned version.
+    "langsmith-agent-builder-tool-server",
+    "langsmith-agent-builder-trigger-server",
     "langsmith-fleet-tool-server",
     "langsmith-fleet-trigger-server",
     "langsmith-ace-backend",

--- a/modules/gcp/infra/main.tf
+++ b/modules/gcp/infra/main.tf
@@ -346,8 +346,11 @@ module "iam" {
     "langsmith-queue",
     "langsmith-ingest-queue",
     "langsmith-listener",
-    "langsmith-agent-builder-tool-server",
-    "langsmith-agent-builder-trigger-server",
+    # Chart 0.15 renamed these Deployments (agentBuilderToolServer/TriggerServer ->
+    # fleetToolServer/fleetTriggerServer), which also renamed the ServiceAccount the
+    # chart creates for them. Must track the chart's SA name or WI binding silently no-ops.
+    "langsmith-fleet-tool-server",
+    "langsmith-fleet-trigger-server",
     "langsmith-ace-backend",
     "langsmith-frontend",
     "langsmith-playground",


### PR DESCRIPTION
## Summary

Chart 0.15 renamed `agentBuilderToolServer`/`agentBuilderTriggerServer` to `fleetToolServer`/`fleetTriggerServer`, which also renamed the underlying ServiceAccount the chart creates for them — now `fleet-tool-server`/`fleet-trigger-server`, regardless of whether the component is enabled via the legacy `config.agentBuilder` path or the new top-level `fleet` block.

`modules/gcp/infra/main.tf`'s `workload_identity_service_accounts` list still referenced the old `langsmith-agent-builder-tool-server`/`langsmith-agent-builder-trigger-server` names, so GCP Workload Identity federation silently no-ops for these two components — same class of bug already found and fixed for Azure (see PR #75 / the follow-up ltree fix).

## What's changed

- `modules/gcp/infra/main.tf` — add the new `fleet-tool-server`/`fleet-trigger-server` SA entries **alongside** the old `agent-builder-tool-server`/`agent-builder-trigger-server` ones, rather than replacing them. `deploy.sh`'s `CHART_VERSION` defaults to `~0.15.1` but can still be overridden to pin an older chart, where the chart creates the old-named SA instead — keeping both is harmless (Workload Identity only binds to whichever SA the chart actually creates for the pinned version) and preserves support for chart < 0.15.
- `modules/gcp/ARCHITECTURE.md` — update the Pass 4 table row to note both names, tied to chart version.

## Verification

Confirmed by reading the chart's `_helpers.tpl`/service-account templates directly (same chart used across all three cloud providers) — the ServiceAccount name is derived from `fleetToolServer.name`/`fleetTriggerServer.name` unconditionally once on chart >= 0.15.0, not tied to which enablement flag is set. AWS was checked too and found already clean — no equivalent bug there.