### PR TITLE
Azure Private Landing Zone Module

### DIFF
--- a/modules/azure-private/.gitignore
+++ b/modules/azure-private/.gitignore
@@ -1,0 +1,29 @@
+# Secret-bearing files — never commit.
+# (*.tfvars and *.tfstate are already covered repo-wide by the root .gitignore;
+#  these close the remaining gaps for this module. *.tfvars.example is tracked
+#  and is not matched by the *.tfvars rule.)
+
+# Environment / credential files
+.env
+.env.*
+credentials.json
+token.json
+
+# TLS material / private keys (e.g. certs supplied to create-tls-secret.sh --cert/--key)
+*.pem
+*.key
+*.crt
+*.p12
+*.pfx
+
+# Local secret seed files written by infra/scripts/setup-env.sh before Key Vault exists
+.api_key_salt
+.jwt_secret
+.deployments_key
+.agent_builder_key
+.insights_key
+.polly_key
+
+# Kubeconfig that may be dumped locally
+kubeconfig
+*.kubeconfig

--- a/modules/azure-private/DEPLOYMENT.md
+++ b/modules/azure-private/DEPLOYMENT.md
@@ -1,0 +1,548 @@
+# Deploying LangSmith with `modules/azure-private`
+
+A practical runbook for the **private / hub-and-spoke** LangSmith landing zone. Read this
+alongside [README.md](README.md) (which is the reference for every input variable and the
+three DNS / identity modes). This document answers three questions:
+
+1. **What must the customer have in place first?** (hub-and-spoke? firewall? — yes; details below)
+2. **Is there an example tfvars file?** (yes — [`infra/terraform.tfvars.example`](infra/terraform.tfvars.example))
+3. **What are the actual steps to deploy LangSmith?**
+
+> **Two ways in — same phases, different starting point:**
+> - **Path A — Test-drive from scratch.** No enterprise VNet handy? Stand up a throwaway
+>   hub-spoke landing zone + Azure Firewall with the [`test/hub-spoke/`](test/hub-spoke/) scaffold,
+>   paste its `azure_private_tfvars` output into `infra/terraform.tfvars`, then follow the phases
+>   below from [Phase 1](#phase-1--azure-infrastructure-run-from-anywhere).
+> - **Path B — Bring your own VNet (production).** You already own the RG + VNet + firewall. Start
+>   at [Customer prerequisites](#customer-prerequisites-provision-before-terraform-apply), then the
+>   phases.
+>
+> Prefer a picture? [architecture.html](architecture.html) is a one-page visual of what's built,
+> what's a prerequisite, and the deploy order.
+
+> **Two Terraform roots — two apply runs.** `modules/azure-private` is split into two roots:
+> - **`infra/`** — azurerm-only. Creates the AKS cluster, Postgres, Redis, Blob, Key Vault,
+>   bastion, and diagnostics. Has **no** Kubernetes or Helm providers. Run it from anywhere
+>   (your laptop, a CI runner) — it is **never blocked by the private API server**.
+> - **`bootstrap/`** — in-cluster. Installs KEDA, NGINX, the `langsmith` namespace,
+>   and K8s secrets (read from Key Vault). Must run **from the jumpbox** (inside the VNet) after
+>   the cluster is up.
+>
+> You do **not** need to be in the VNet for the `infra/` apply. You **do** need to be in the
+> VNet (on the jumpbox) for the `bootstrap/` apply.
+
+> **This module does not use the `make` workflow** that `modules/azure` uses. There is no
+> `Makefile`, no bundled Helm chart, and no `app/` Terraform here — only the `infra/` and
+> `bootstrap/` roots and the `infra/scripts/` helpers. You run Terraform directly. See
+> [No make pattern](#no-make-pattern-vs-modulesazure).
+
+---
+
+## What this module does / doesn't do
+
+| | |
+|---|---|
+| ✅ **Does** | Provisions the hardened Azure infra (AKS private cluster with CNI Overlay+Cilium and UDR egress, PostgreSQL Flexible Server + Redis via **Private Endpoint**, Blob, Key Vault, a jumpbox VM, Log Analytics) **into your existing RG + VNet** (`infra/`), and bootstraps the cluster in a **separate apply from the jumpbox** (namespace, RBAC, network policies, the Postgres/Redis connection K8s secrets, KEDA, internal NGINX ingress) (`bootstrap/`). The app-config secret (`langsmith-config-secret`) and the TLS secret (`langsmith-tls`) are created by scripts in [Phase 3.5](#phase-35--create-the-app-config-secret). |
+| ❌ **Does not** | Create the resource group or VNet (you bring them). Create the firewall/route table (you bring them). Install the **LangSmith application** itself — that is a separate Helm step ([Phase 4](#phase-4--install-the-langsmith-application-helm)). Provide a `Makefile` or app-deploy automation. |
+
+After both `infra/` and `bootstrap/` apply you have a running, hardened cluster with ingress and
+supporting services — but **not** LangSmith. LangSmith is installed afterward via its Helm chart.
+
+---
+
+## Is this the hub-and-spoke / firewall path? — Yes
+
+This module **is the spoke**. It is built for an enterprise landing zone and assumes the
+surrounding network already exists. Concretely, three hard assumptions are baked in (they are
+not toggles):
+
+- **Egress is `userDefinedRouting`.** There is no public load-balancer egress. The AKS subnet
+  **must** have a route table with `0.0.0.0/0` → your **firewall / NVA** private IP, and that
+  firewall **must allow the required AKS egress** before you apply. If egress doesn't work, the
+  AKS nodes cannot reach the control plane or pull images and **cluster creation fails**. A
+  firewall/NVA is therefore effectively **required** (Azure Firewall in a hub is the canonical
+  setup; any NVA with the right rules works). See
+  [Control egress traffic for AKS](https://learn.microsoft.com/azure/aks/limit-egress-traffic).
+- **The API server is private.** No public endpoint. The `bootstrap/` apply (Helm/kubectl)
+  **must run from inside the VNet** (on the jumpbox) where the private API IP is reachable and
+  the private DNS zone resolves. The `infra/` apply has **no** Kubernetes/Helm providers and is
+  **not** blocked by the private API — run it from anywhere.
+- **Everything is BYO + private.** Existing RG (region inherited from it), existing VNet +
+  subnets, backing services reachable only via Private Endpoint.
+
+You do **not** strictly need a textbook hub-and-spoke, but you **do** need: a VNet whose AKS
+subnet routes egress through a firewall/NVA, private DNS resolution for the API server, and a
+jumpbox (or peered runner) inside that VNet for the `bootstrap/` apply. That is the
+hub-and-spoke pattern in practice.
+
+---
+
+## Customer prerequisites (provision BEFORE `terraform apply`)
+
+### Tools (on the apply host)
+`az` (Azure CLI ≥ 2.50), `terraform` ≥ 1.5 (the repo is validated on 1.x; the offline test
+suite needs ≥ 1.7), `kubectl`, and `helm` ≥ 3.12 (for Phase 4).
+
+The `infra/` apply only needs `az` + `terraform`. `kubectl` and `helm` are needed only on the
+jumpbox for the `bootstrap/` apply and the Phase 4 Helm install.
+
+### Azure RBAC for the Terraform principal
+- **Contributor** + **User Access Administrator** on the subscription/RG (or **Owner**).
+  Contributor alone is insufficient — the module creates role assignments (Key Vault, Blob,
+  the control-plane identity's Network Contributor grant).
+- **Network Contributor on the existing VNet** (or a custom role with
+  `Microsoft.Network/virtualNetworks/subnets/join/action`) so AKS / the private endpoints can
+  join your subnets.
+
+### Network (you create these; the module consumes them)
+- [ ] **Resource group** — existing; you have Contributor+. Deployment **region is inherited
+  from it** (there is no `location` variable).
+- [ ] **VNet** — existing, with non-overlapping CIDRs vs `aks_service_cidr` and `aks_pod_cidr`.
+- [ ] **AKS subnet** with **both**:
+  - a **route table** associated, `0.0.0.0/0` → firewall/NVA private IP (UDR), and
+  - the **`Microsoft.Storage` + `Microsoft.KeyVault` service endpoints** enabled (Blob and Key
+    Vault default-deny firewalls allowlist the AKS subnet via these — without them, pods can't
+    reach Blob/Key Vault).
+- [ ] **Postgres subnet** — a regular subnet with a spare IP for the **Private Endpoint**.
+  **Not** delegated (delegation is VNet injection, which this module does not use). Required
+  when `postgres_source = "external"` (the default).
+- [ ] **Redis subnet** — a regular subnet for the Redis **Private Endpoint**. Required when
+  `redis_source = "external"` (the default).
+- [ ] **Jumpbox subnet** — for the apply-host VM the module provisions. **Use a normal subnet
+  name** (e.g. `jumpbox`); do **not** use `AzureBastionSubnet` (Azure reserves that name for
+  the Azure Bastion PaaS service and rejects a plain VM there).
+- [ ] **Firewall / NVA** reachable from the AKS subnet route table, configured to **allow the
+  required AKS egress** (control-plane FQDNs/ports).
+
+### Private DNS
+- [ ] An **apply host that can resolve the AKS API server's private DNS zone**
+  (`privatelink.<region>.azmk8s.io`). This is only required for the **`bootstrap/` apply**
+  (which must run from the jumpbox). The `infra/` apply has no Kubernetes provider and is not
+  affected. With the default `aks_private_dns_zone_id = ""` (System zone), AKS auto-links the
+  zone to your VNet, so a host in that VNet resolves it. For `"None"` or a custom zone, you
+  own resolution (see README "API-server private DNS"). If your VNet uses **custom DNS
+  servers**, add a conditional forwarder for `privatelink.*` → `168.63.129.16`.
+- [ ] **Centrally-managed private DNS caveat:** this module **creates** the
+  `privatelink.postgres.database.azure.com` and `privatelink.redis.azure.net` zones and links
+  them to your VNet. If a platform team already manages those zones and links them to the VNet,
+  that conflicts (a VNet can't link two same-named zones). There is no BYO-zone toggle for
+  Postgres/Redis yet.
+
+### State backend
+`infra/` and `bootstrap/` ship **no** active backend (local state by default). For any real
+or team deployment, configure an Azure Storage remote backend for each root: copy
+[`infra/backend.tf.example`](infra/backend.tf.example) to `infra/backend.tf` and fill in your
+storage account/container. `bootstrap/` has no example backend file — if you want its state
+remote too, add a `bootstrap/backend.tf` by hand (the same block, with a different state key).
+
+The two roots do **not** need a *shared* backend: `bootstrap/` does not read `infra/`'s state —
+it discovers everything via Azure data sources + Key Vault and only needs its three variables
+(`subscription_id`, `resource_group_name`, `identifier`).
+
+---
+
+## The example tfvars
+
+[`infra/terraform.tfvars.example`](infra/terraform.tfvars.example) is the single worked
+configuration for the `infra/` root. Copy it and fill in your IDs:
+
+```bash
+cd modules/azure-private/infra
+cp terraform.tfvars.example terraform.tfvars
+# edit terraform.tfvars — subscription_id, resource_group_name, vnet_id, the four subnet IDs,
+# CIDRs, the DNS/identity knobs, and bastion_admin_ssh_public_key
+```
+
+The `bootstrap/` root needs only three variables (`subscription_id`, `resource_group_name`,
+`identifier`) — all others default correctly when the same `identifier` was used for `infra/`.
+
+Only `subscription_id` has no default, but the BYO IDs and secrets are **functionally
+required** — empty values fail at apply. The few real knobs (everything else is hardcoded):
+
+| Variable | Notes |
+|---|---|
+| `subscription_id`, `resource_group_name` | Target subscription + existing RG |
+| `vnet_id`, `aks_subnet_id`, `postgres_subnet_id`, `redis_subnet_id`, `bastion_subnet_id` | Your existing network |
+| `aks_service_cidr`, `aks_dns_service_ip`, `aks_pod_cidr` | Non-overlapping with the VNet/peers |
+| `aks_private_dns_zone_id`, `aks_private_cluster_public_fqdn_enabled` | API-server DNS mode (README) |
+| `aks_create_cluster_identity` / `aks_cluster_identity_id` | Control-plane identity (default: module-created user-assigned) |
+| `postgres_source` / `redis_source` | `external` (managed, Private Endpoint) or `in-cluster` (dev) |
+| Secrets | `postgres_admin_password`, `langsmith_license_key`, `langsmith_api_key_salt`, `langsmith_jwt_secret`, `langsmith_admin_password` — supply via `TF_VAR_*` env vars or the `scripts/setup-env.sh` flow; never commit them (`*.tfvars` is gitignored) |
+
+---
+
+## Deployment steps
+
+### Phase 0 — Authenticate & pre-flight
+```bash
+az login
+az account set --subscription "<SUB_ID>"
+cd modules/azure-private/infra
+bash scripts/preflight.sh     # checks login, resource providers, RBAC, terraform.tfvars
+```
+
+### Phase 1 — Azure infrastructure (run from anywhere)
+
+The `infra/` root has **no** Kubernetes or Helm providers. It creates only Azure resources
+(AKS cluster, Postgres, Redis, Blob, Key Vault, bastion, diagnostics) and is **never blocked
+by the private API server**. Run it from your laptop, a CI runner, or any host with az + terraform.
+
+```bash
+cd modules/azure-private/infra
+# Secrets: either export TF_VAR_* for each secret, or use the bootstrap helper which
+# prompts on first run and reads them back from Key Vault on subsequent runs:
+bash scripts/setup-env.sh     # writes secrets.auto.tfvars (gitignored)
+
+terraform init                # add backend.tf first for remote state (recommended)
+terraform plan                # review: NO resource group / NO module.vnet created; AKS shows
+                              # overlay/cilium, outbound_type=userDefinedRouting, private cluster
+terraform apply
+```
+
+**Result (~15–20 min):** AKS cluster up; Postgres/Redis private endpoints; Blob + Key Vault
+(with postgres/redis connection URLs stored as secrets); bastion jumpbox VM. The cluster has
+no workloads — KEDA, NGINX, and K8s secrets are installed in Phase 3.
+
+### Phase 2 — Cluster access + verify
+```bash
+# Run from any host that can reach your Azure subscription (doesn't need VNet connectivity).
+az aks get-credentials --resource-group "<RG>" \
+  --name "$(terraform -chdir=modules/azure-private/infra output -raw aks_cluster_name)" \
+  --overwrite-existing
+# Verify from inside the VNet (jumpbox or peered runner):
+kubectl get nodes                         # Ready
+terraform -chdir=modules/azure-private/infra output aks_private_fqdn   # the private API endpoint
+```
+
+> **kubectl access:** the API server is private — `kubectl` commands must run from the jumpbox
+> (or a peered runner that resolves the private DNS zone). Getting credentials (`az aks
+> get-credentials`) can run from anywhere; the actual API calls need VNet connectivity.
+
+### Phase 3 — In-cluster bootstrap (from the jumpbox)
+
+The `bootstrap/` root installs KEDA, the internal NGINX ingress controller,
+the `langsmith` namespace, and the **Postgres/Redis connection** K8s secrets (read from Key
+Vault). It **must** run from inside the VNet where the private API server is reachable. The
+app-config secret (license key, salts, encryption keys) is **not** created here — that is
+[Phase 3.5](#phase-35--create-the-app-config-secret).
+
+```bash
+# SSH to the jumpbox first:
+# ssh azureuser@<jumpbox-public-ip>
+
+# On the jumpbox — clone the repo, then:
+cd modules/azure-private/bootstrap
+
+# Supply the three required variables (or set TF_VAR_*):
+terraform init
+terraform plan -var="subscription_id=<SUB>" \
+               -var="resource_group_name=<RG>" \
+               -var="identifier=<IDENTIFIER>"
+terraform apply -var="subscription_id=<SUB>" \
+                -var="resource_group_name=<RG>" \
+                -var="identifier=<IDENTIFIER>"
+```
+
+**Result:** namespace `langsmith` with the Postgres/Redis connection K8s secrets;
+KEDA, and an **internal** NGINX ingress (private IP only). LangSmith itself is **not** installed yet.
+
+Verify:
+```bash
+kubectl -n langsmith get secret            # langsmith-postgres-secret / langsmith-redis-secret present
+kubectl get pods -A | grep -E 'keda|ingress-nginx'   # Running
+```
+
+### Phase 3.5 — Create the app-config secret
+
+The LangSmith chart reads the license key, API-key salt, JWT secret, initial admin password,
+and any feature encryption keys from a single Kubernetes secret referenced by
+`config.existingSecretName`. That secret (`langsmith-config-secret`) is **not** created by the
+`bootstrap/` apply — create it from Key Vault with the vendored helper, which uses the exact
+key names the chart expects:
+
+```bash
+# From the jumpbox, with kubectl pointed at the cluster:
+bash modules/azure-private/infra/scripts/create-k8s-secrets.sh
+kubectl -n langsmith get secret langsmith-config-secret   # confirm it exists
+```
+
+This reads `langsmith-license-key`, `langsmith-api-key-salt`, `langsmith-jwt-secret`,
+`langsmith-admin-password`, and the four feature encryption keys from Key Vault and writes them
+into `langsmith-config-secret`. Skipping this step makes the Helm install (which sets
+`config.existingSecretName: langsmith-config-secret`) fail with a missing-secret error.
+
+**TLS secret (`langsmith-tls`).** The internal NGINX ingress terminates TLS using a Kubernetes
+`tls` secret named `langsmith-tls`. This module has **no cert-manager**; create the secret with
+the vendored helper, which by default generates a **self-signed** certificate:
+
+```bash
+bash modules/azure-private/infra/scripts/create-tls-secret.sh --hostname <your-ingress-hostname>
+kubectl -n langsmith get secret langsmith-tls   # confirm it exists
+```
+
+> **⚠️ Self-signed = testing/demo only.** The generated certificate is **not trusted** by
+> browsers or clients. For production, replace `langsmith-tls` with a real certificate from your
+> own CA — for example one exported from Azure Key Vault:
+> `create-tls-secret.sh --cert tls.crt --key tls.key`, or manage the secret yourself. Note the
+> open-source `ingress-nginx` this module installs is scheduled for retirement (upstream
+> maintenance ends **March 2026**); for a longer-term, Key-Vault-native TLS path consider the AKS
+> **Application Routing add-on** or **Application Gateway for Containers**.
+
+Reference the secret in your Helm values: `ingress.tls[].secretName: langsmith-tls`.
+
+### Phase 4 — Install the LangSmith application (Helm)
+
+**This module does not bundle the LangSmith chart or an app-deploy script** (those live in
+`modules/azure/helm` / `modules/azure/app`). Install LangSmith with its Helm chart, supplying
+values derived from the `infra/` Terraform outputs and the secrets `bootstrap/` already
+created in the `langsmith` namespace.
+
+The LangSmith chart is published at `https://langchain-ai.github.io/helm` (chart
+`langchain/langsmith`, pinned to the `~0.15.1` line). Two approaches:
+
+> **⚠️ Chart-version alignment.** A couple of things in this module are coupled to the exact
+> LangSmith chart version you install here. **Before Phase 4, run the
+> [Chart-version compatibility](#chart-version-compatibility) checklist** to confirm the module's
+> hardcoded service-account names and secret keys match the chart version you pin.
+
+- **Reuse the `modules/azure` Helm tooling against this cluster (recommended).** That module's
+  `helm/scripts/init-values.sh` reads Terraform outputs and generates an Azure-specific
+  **overrides** values file, then `helm/scripts/deploy.sh` runs the install
+  (`helm repo add langchain https://langchain-ai.github.io/helm` → `helm upgrade --install
+  langsmith langchain/langsmith --version ~0.15.1`). All the outputs that `init-values.sh`
+  consumes **exist in the `infra/` root** — `storage_account_name`, `storage_container_name`,
+  `storage_account_k8s_managed_identity_client_id`, `langsmith_namespace`,
+  `langsmith_admin_email` — so you can point that tooling at `modules/azure-private/infra` (set
+  its `INFRA_DIR` / run it with this module's `terraform.tfvars`) and deploy. Note the base
+  `helm/values/examples/langsmith-values.yaml` is **AWS-oriented**; the Azure specifics come
+  from the generated overrides, so don't apply that base file unedited.
+- **Or install the chart directly:**
+  ```bash
+  helm repo add langchain https://langchain-ai.github.io/helm
+  helm repo update langchain
+  helm upgrade --install langsmith langchain/langsmith --version "~0.15.1" \
+    -n langsmith -f your-azure-values.yaml
+  ```
+  Author `your-azure-values.yaml` to wire:
+  - **Hostname:** `config.hostname: <your-host>` — the DNS name clients use to reach LangSmith.
+    It must resolve to the **private** ingress IP via your internal DNS (see
+    [Phase 5](#phase-5--verify--access)). Required when ingress is enabled.
+  - **Ingress:** `ingress.enabled: true`, `ingress.ingressClassName: nginx` (the `bootstrap/`
+    root installs the internal NGINX controller), and `ingress.tls[].secretName: langsmith-tls`.
+  - **Azure Blob:** `config.blobStorage.enabled: true`, `config.blobStorage.engine: "Azure"`,
+    `azureStorageAccountName` / `azureStorageContainerName` (from `terraform -chdir=infra
+    output`), with **Workload Identity** — leave the account key empty and, for each
+    blob-accessing component (`backend`, `platformBackend`, `queue`, `ingestQueue`,
+    `hostBackend`, `listener`, and the fleet servers if enabled), set the pod label
+    `azure.workload.identity/use: "true"` **and** the ServiceAccount annotation
+    `azure.workload.identity/client-id: <storage_account_k8s_managed_identity_client_id>`.
+  - **Postgres:** `postgres.external.enabled: true`,
+    `postgres.external.existingSecretName: langsmith-postgres-secret`,
+    `connectionUrlSecretKey: connection_url`.
+  - **Redis:** `redis.external.enabled: true`,
+    `redis.external.existingSecretName: langsmith-redis-secret`,
+    `connectionUrlSecretKey: connection_url`, and — for Azure Managed Redis —
+    `redis.external.clusterSafeMode: true` (see the `redis_cluster_safe_mode` output).
+  - **App config:** `config.existingSecretName: langsmith-config-secret` (created in
+    [Phase 3.5](#phase-35--create-the-app-config-secret)).
+
+  Confirm the exact value keys against the chart version you install (see the alignment note
+  above). Note the recommended `init-values.sh` path emits all of the above automatically.
+
+> **Gap to be aware of:** turnkey app-deploy automation is intentionally not part of this infra
+> module yet. See [Known gaps](#known-gaps--follow-ups). For a fully automated path today, the
+> general-purpose `modules/azure` (public/managed) module has the full `make deploy` /
+> `make apply-app` flow.
+
+### Phase 5 — Verify & access
+
+Check overall health and find the private ingress IP (run from the jumpbox, kubectl pointed at
+the cluster):
+
+```bash
+bash modules/azure-private/infra/scripts/status.sh      # end-to-end health + next steps
+
+# The internal NGINX load balancer's PRIVATE IP (reachable only from within the VNet):
+kubectl -n ingress-nginx get svc ingress-nginx-controller \
+  -o jsonpath='{.status.loadBalancer.ingress[0].ip}'; echo
+```
+
+**Point your hostname at that private IP using internal DNS.** There is no public DNS record for
+a private cluster — map the name you set as `config.hostname` to the private ingress IP via your
+Azure Private DNS zone, a conditional forwarder, or (for a quick test) a `/etc/hosts` entry on
+the jumpbox. Then reach LangSmith from an in-VNet host:
+
+```bash
+# Confirm the ingress serves (self-signed cert → -k). Any 2xx/3xx means frontend is up:
+curl -ksS -o /dev/null -w '%{http_code}\n' https://<your-config-hostname>/
+# or open https://<your-config-hostname>/ in a browser with VNet access.
+```
+
+The certificate warning (`-k` / "not trusted") is expected with the self-signed cert from
+[Phase 3.5](#phase-35--create-the-app-config-secret) — replace `langsmith-tls` with a cert from
+your own CA to remove it.
+
+**First login (basic auth):** sign in with the initial org admin email (the
+`langsmith_admin_email` output / what you set in `setup-env.sh`) and the admin password stored in
+Key Vault as `langsmith-admin-password`.
+
+### Teardown
+```bash
+# Destroy bootstrap/ first (from the jumpbox), then infra/:
+# On the jumpbox:
+terraform -chdir=modules/azure-private/bootstrap destroy
+# Then from anywhere:
+terraform -chdir=modules/azure-private/infra destroy
+# Purge soft-deleted Key Vaults if keyvault_purge_protection = false:
+az keyvault list-deleted --query "[?contains(name,'langsmith-kv')].name" -o tsv | xargs -I{} az keyvault purge -n {}
+```
+
+`infra destroy` removes everything the `infra/` root created **inside** your RG; it does not
+delete your RG, VNet, subnets, route table, or firewall.
+
+---
+
+## Chart-version compatibility
+
+**The Azure infrastructure is version-agnostic.** Phases 0–3 (`infra/` + `bootstrap/`) provision
+the cluster, networking, Postgres/Redis/Blob/Key Vault, internal NGINX, KEDA, and the
+connection/config/TLS secrets. None of that depends on the LangSmith chart version — provision it
+first, then choose a chart version at Phase 4.
+
+**Two things ARE coupled to the chart version you install in Phase 4** — and a mismatch fails
+**silently at runtime**, not at `terraform apply`:
+
+| Coupled thing | Where it lives | If it doesn't match the chart |
+|---|---|---|
+| Workload-identity **service-account names** (`service_accounts_for_workload_identity`) | `infra/modules/k8s-cluster/main.tf` | The pod's SA has no federated credential → OIDC token exchange fails → **Blob + Key Vault access fails** for that component |
+| App-config **secret keys** in `langsmith-config-secret` | `infra/scripts/create-k8s-secrets.sh` (consumed via the chart's `config.existingSecretName`) | The pod can't find `langsmith_license_key` / `api_key_salt` / `jwt_secret` → the app won't start |
+
+The module's `service_accounts_for_workload_identity` list is currently aligned to the LangSmith
+chart's **0.16.x** line — e.g. the Fleet SAs are `fleet-tool-server` / `fleet-trigger-server`
+(renamed from `agent-builder-*` in older charts). The docs pin `~0.15.1` for the recommended
+`modules/azure` tooling path, so **decide which chart version you actually deploy and validate
+before Phase 4.**
+
+### Validation checklist (run before Phase 4)
+
+Render the chart version you intend to install and compare it against the module. (`helm template`
+may need a few `--set`/`-f` values for the chart to render; add them as needed, or just read the
+chart source.)
+
+```bash
+CHART_VERSION="<the version you will install, e.g. 0.16.0-rc.6 or 0.15.1>"
+
+# 1. Service-account names the chart renders (blob/KV-accessing components):
+helm template langsmith langchain/langsmith --version "$CHART_VERSION" \
+  --set config.langsmithLicenseKey=x --set config.apiKeySalt=x \
+  --set config.basicAuth.jwtSecret=x 2>/dev/null \
+  | awk '/kind: ServiceAccount/{f=1} f&&/name:/{print $2; f=0}' | sort -u
+#   → compare to service_accounts_for_workload_identity in
+#     infra/modules/k8s-cluster/main.tf (federated subject = system:serviceaccount:<ns>:<name>)
+
+# 2. Secret keys the chart reads from the config secret:
+helm template langsmith langchain/langsmith --version "$CHART_VERSION" \
+  --set config.langsmithLicenseKey=x --set config.apiKeySalt=x \
+  --set config.basicAuth.jwtSecret=x 2>/dev/null \
+  | grep -oE 'key: (langsmith_license_key|api_key_salt|jwt_secret|[a-z_]+encryption_key)' | sort -u
+#   → compare to the --from-literal keys in infra/scripts/create-k8s-secrets.sh
+```
+
+Or read the chart source directly: component `name:` fields in `values.yaml`, and the keys in
+`templates/secrets.yaml` / `templates/_helpers.tpl`.
+
+**If something differs from what the module encodes:**
+- **SA names** → edit `service_accounts_for_workload_identity` in
+  `infra/modules/k8s-cluster/main.tf` and re-apply `infra/`. Cheap and non-destructive — it only
+  adds/renames `azurerm_federated_identity_credential` resources; the cluster and data are untouched.
+- **Secret keys** → edit the `--from-literal` key names in `infra/scripts/create-k8s-secrets.sh`
+  and re-run it.
+
+Then install with your validated version:
+`helm upgrade --install langsmith langchain/langsmith --version "$CHART_VERSION" ...`.
+
+---
+
+## No `make` pattern (vs `modules/azure`)
+
+`modules/azure` ships a `Makefile` plus `helm/` and `app/` directories that wrap a 5-pass
+workflow (`make apply` → `make kubeconfig` → `make k8s-secrets` → `make deploy`). **This module
+deliberately does not.** It has two Terraform roots (`infra/` + `bootstrap/`) and the
+`infra/scripts/` helpers. Map the familiar `make` targets to direct commands here:
+
+| `modules/azure` (`make …`) | `modules/azure-private` |
+|---|---|
+| `make preflight` | `bash infra/scripts/preflight.sh` |
+| `make setup-env` | `bash infra/scripts/setup-env.sh` |
+| `make init` / `plan` / `apply` | `terraform -chdir=infra init` / `plan` / `apply` (or `bash infra/scripts/tf-run.sh …`) |
+| `make kubeconfig` | `az aks get-credentials …` (from the in-VNet host) |
+| in-cluster bootstrap (namespace, RBAC, Postgres/Redis secrets, KEDA, NGINX) | `terraform -chdir=bootstrap apply` (from the jumpbox) |
+| `make k8s-secrets` (app-config secret) | `bash infra/scripts/create-k8s-secrets.sh` (from the jumpbox, [Phase 3.5](#phase-35--create-the-app-config-secret)) |
+| TLS secret (self-signed / BYO) | `bash infra/scripts/create-tls-secret.sh` (from the jumpbox, [Phase 3.5](#phase-35--create-the-app-config-secret)) |
+| `make status` | `bash infra/scripts/status.sh` |
+| `make deploy` (LangSmith Helm) | **not bundled** — see [Phase 4](#phase-4--install-the-langsmith-application-helm) |
+| `make destroy` / `make clean` | `terraform -chdir=bootstrap destroy` → `terraform -chdir=infra destroy` / `bash infra/scripts/clean.sh` |
+
+The `infra/scripts/` helpers (`preflight.sh`, `setup-env.sh`, `create-k8s-secrets.sh`,
+`create-tls-secret.sh`, `status.sh`, `tf-run.sh`, `manage-keyvault.sh`, `clean.sh`) were
+vendored with the infra and work standalone — they do not require `make`.
+
+---
+
+## What runs in the cluster (bootstrap/ root)
+
+The `bootstrap/` root installs the following in-cluster components. Everything is discovered
+from Azure (data sources + Key Vault) — `bootstrap/` does not import from the `infra/` state:
+
+| Component | Installed by |
+|---|---|
+| KEDA | `bootstrap/` (`helm_release`) |
+| NGINX ingress controller (internal LB, private IP) | `bootstrap/` (`helm_release`) |
+| `langsmith` namespace | `bootstrap/` (`kubernetes_namespace`) |
+| Postgres/Redis connection K8s secrets (`langsmith-postgres-secret`, `langsmith-redis-secret`) | `bootstrap/` (reads from Key Vault) |
+| App-config K8s secret (`langsmith-config-secret`) | `create-k8s-secrets.sh` ([Phase 3.5](#phase-35--create-the-app-config-secret), reads from Key Vault) |
+| TLS K8s secret (`langsmith-tls`) | `create-tls-secret.sh` ([Phase 3.5](#phase-35--create-the-app-config-secret), self-signed by default) |
+
+There is **no cert-manager** — TLS is a script-created secret (self-signed for testing, BYO for
+production). See [Phase 3.5](#phase-35--create-the-app-config-secret).
+
+---
+
+## Key gotchas
+
+- **Egress must work before/at apply.** UDR + no public egress means a misconfigured firewall
+  route ⇒ node provisioning failure, not a clean error. Validate the route + firewall rules first.
+- **`infra/` is always safe to run from anywhere.** It has no Kubernetes or Helm providers.
+  The private API server is not a blocker for `infra/` applies.
+- **`bootstrap/` must run from the jumpbox.** The Kubernetes and Helm providers need to reach
+  the private API server. SSH to the jumpbox, get credentials, then apply.
+- **ClickHouse runs in-cluster.** The chart bundles ClickHouse (a StatefulSet on a PVC using
+  the AKS default StorageClass) — this module does **not** provision a managed ClickHouse. Size
+  the node pool and the `bootstrap` `ResourceQuota` (default 40 CPU / 80 GiB requests) so the
+  bundled ClickHouse **plus** all LangSmith components fit, or pods are rejected with
+  quota-exceeded. Bump the quota / node `max_count` for anything beyond a base install.
+- **Postgres/Redis subnets are Private-Endpoint subnets, not delegated.**
+- **VNet injection vs Private Endpoint is immutable** on Flexible Server; this module is PE by
+  design.
+- **Switching `aks_private_cluster_enabled`/overlay/UDR after creation is destructive** — these
+  are hardcoded here precisely because they're create-time decisions.
+
+---
+
+## Known gaps / follow-ups
+
+These are tracked items, not blockers, surfaced during the build review:
+
+1. **No bundled LangSmith app deploy.** Phase 4 is manual today. A follow-up could vendor a
+   trimmed `helm/` (values + deploy script) or an `app/` Terraform path tailored to internal
+   NGINX, so this module offers a turnkey deploy like `modules/azure`.
+2. **Bastion SSH allowlist defaults open.** `bastion_allowed_ssh_cidrs` defaults to
+   `0.0.0.0/0`. For a hardened landing zone, set it to your operator/runner CIDR (the jumpbox
+   has a public IP). Consider this required hardening.
+3. **Dead ingress code.** `k8s-cluster` still carries unreachable istio/istio-addon/
+   envoy-gateway branches (the module is pinned to internal NGINX). Harmless; a cleanup candidate.
+4. **TLS is self-signed by default.** `create-tls-secret.sh` mints a self-signed cert for the
+   `langsmith-tls` secret — testing only. Production must supply a real cert (`--cert/--key`, e.g.
+   from Key Vault) or adopt a Key-Vault-native managed ingress. The bundled OSS `ingress-nginx`
+   is itself scheduled for upstream retirement (**March 2026**) — a future migration to the AKS
+   Application Routing add-on or Application Gateway for Containers is the longer-term path.

--- a/modules/azure-private/PRIVATE_DNS.md
+++ b/modules/azure-private/PRIVATE_DNS.md
@@ -1,0 +1,183 @@
+# AKS API-server private DNS — how it works and what this Terraform does
+
+When `private_cluster_enabled = true` (hardcoded in this module), the AKS **API server** gets a
+**private IP** with no public endpoint. Reaching it requires DNS that resolves the API server's
+FQDN (which lives under `privatelink.<region>.azmk8s.io`) to that private IP. This doc explains
+who creates that zone, who links it, who manages the record — and exactly which of those steps
+**our Terraform** performs versus which **AKS** (or you) performs.
+
+> This is specifically about the **AKS API-server** zone. The **Postgres/Redis** private DNS
+> zones are different and *are* created by this module — see [Backing-service zones](#dont-confuse-this-with-the-postgresredis-zones) at the bottom.
+
+---
+
+## The one line that selects the behavior
+
+In `modules/k8s-cluster/main.tf` the cluster resource sets:
+
+```hcl
+private_cluster_enabled             = true
+private_cluster_public_fqdn_enabled = var.private_cluster_public_fqdn_enabled
+private_dns_zone_id                 = var.private_dns_zone_id != "" ? var.private_dns_zone_id : "System"
+```
+
+`var.private_dns_zone_id` comes from the root variable **`aks_private_dns_zone_id`**. Its value
+picks one of three modes. **In every mode, AKS — not our Terraform — creates the API-server
+private endpoint and manages the DNS A-record.** What differs is who owns the *zone* and who
+*links* it to your VNet.
+
+| `aks_private_dns_zone_id` | Mode | Who creates the **zone** | Who **links** it to the VNet | What **our Terraform** does |
+|---|---|---|---|---|
+| `""` (default) → `"System"` | **System** | **AKS** (in the node RG `MC_*`) | **AKS** (auto-links to the cluster VNet) | Selects `"System"`; provisions the control-plane identity + grants it Network Contributor on the VNet so AKS *can* create & link the zone. Creates **no zone**. |
+| `"None"` | **None (BYO DNS)** | nobody (no zone) | n/a | Passes `"None"`. You own resolution. Requires `aks_private_cluster_public_fqdn_enabled = true` (Azure rejects `None` + disabled public FQDN). Creates **no zone**. |
+| a zone **resource ID** | **Custom (BYO zone)** | **you**, before apply | **you**, before apply | Passes the ID to AKS so it manages the A-record inside *your* zone. Creates **no zone**, sets **no link**, grants **no role on the zone**. |
+
+---
+
+## Mode 1 — System (the default, zero setup)
+
+This is what you get with `aks_private_dns_zone_id = ""` (the example tfvars default).
+
+**AKS does:** creates a private endpoint for the API server in the node resource group
+(`MC_<rg>_<cluster>_<region>`), creates the zone `privatelink.<region>.azmk8s.io` **in that
+node RG**, adds the API server's A-record, and **auto-links the zone to the cluster's VNet**.
+Any host in that VNet then resolves the API server because Azure-provided DNS (`168.63.129.16`)
+serves the linked zone.
+
+**Our Terraform does** (the part that makes the AKS auto-link succeed):
+
+- Selects System mode (the `!= "" ? : "System"` expression above).
+- Because `aks_create_cluster_identity` defaults to `true`, it creates a **user-assigned
+  control-plane identity** and grants it **`Network Contributor` at the VNet scope**:
+  ```hcl
+  # cluster_vnet_id = the VNet that owns the AKS subnet (strip "/subnets/<name>" off subnet_id)
+  cluster_vnet_id = join("/subnets/", slice(split("/subnets/", var.subnet_id), 0, 1))
+
+  resource "azurerm_role_assignment" "cluster_identity_vnet" {
+    scope                = local.cluster_vnet_id
+    role_definition_name = "Network Contributor"
+    principal_id         = azurerm_user_assigned_identity.cluster[0].principal_id
+  }
+  ```
+  **Why VNet scope, not just the subnet:** the identity needs to do two things — *join the
+  subnet* (`.../subnets/join/action`) **and** *link the System private DNS zone to the VNet*.
+  The zone-link is a VNet-level operation, so a subnet-scoped grant is insufficient in
+  custom-DNS hub-spoke topologies. Granting at the VNet covers both.
+- Adds a 60-second `time_sleep` after the role assignment (RBAC propagation isn't instant) and
+  makes the cluster `depends_on` it, so the grant exists before AKS tries to join the subnet and
+  link the zone.
+
+**Our Terraform does NOT** create the zone, the link, or the A-record — those are all AKS's job
+in System mode.
+
+> **System mode + a system-assigned identity:** if you set `aks_create_cluster_identity = false`
+> *and* provide no `aks_cluster_identity_id`, the cluster falls back to a **system-assigned**
+> identity and no VNet grant is created by this module — AKS then needs your Terraform principal
+> to have rights to self-assign the subnet/zone permissions during creation. The module defaults
+> to a module-created user-assigned identity precisely to avoid that timing problem.
+
+## Mode 2 — None (you own DNS)
+
+`aks_private_dns_zone_id = "None"`. AKS creates the private endpoint but **no zone and no
+record**. You are responsible for resolving the API FQDN — typically a central DNS forwarder in
+a hub. Azure requires `aks_private_cluster_public_fqdn_enabled = true` here. Our Terraform only
+passes `"None"`; it creates nothing DNS-related.
+
+## Mode 3 — Custom zone (centralized hub DNS)
+
+`aks_private_dns_zone_id = "/subscriptions/.../privateDnsZones/privatelink.<region>.azmk8s.io"`.
+This is the hub-spoke pattern where a platform team owns the zone centrally.
+
+**You must, before apply:**
+- Pre-create a zone named **exactly** `privatelink.<region>.azmk8s.io` (or
+  `<subzone>.privatelink.<region>.azmk8s.io`) and **link it to your VNet** (commonly the hub).
+- Use a **BYO control-plane identity**: set `aks_cluster_identity_id` (and leave
+  `aks_create_cluster_identity = false` — they're mutually exclusive, enforced by a validation).
+- **Pre-grant that identity** `Private DNS Zone Contributor` on the zone **and** `Network
+  Contributor` on the VNet/subnet.
+
+**Our Terraform does:** pass the zone ID to AKS (so AKS manages the A-record in your zone) and
+use your BYO identity. It does **not** create the zone, link it, or grant `Private DNS Zone
+Contributor` — the zone is yours and may live in another RG/subscription, so those grants are
+your responsibility. (A system-assigned identity is **not supported** with a custom zone.)
+
+---
+
+## Resolving the zone from the apply host (every mode)
+
+`terraform apply` runs the in-cluster bootstrap (Helm/kubernetes providers) against the private
+API server *during apply*, so the apply host must **resolve and reach** the chosen zone:
+
+- **System:** a host in the **linked VNet** (e.g. the jumpbox this module provisions, or a
+  peered runner) resolves it automatically via `168.63.129.16`.
+- **Custom DNS servers on the VNet:** Azure-provided DNS isn't in the path, so add a
+  **conditional forwarder** for `privatelink.<region>.azmk8s.io` → `168.63.129.16` (the same
+  applies to the Postgres/Redis privatelink zones).
+- **None / Custom:** you must provide resolution (your forwarder / your zone link).
+
+The applied private endpoint FQDN is exposed as the **`aks_private_fqdn`** output.
+
+---
+
+## Does the control-plane identity have the right permissions?
+
+Short answer: **for the default System mode, yes** — and **for a custom zone, the module
+deliberately does not grant enough, because that grant is yours to make.** Per Microsoft's
+[private-cluster docs](https://learn.microsoft.com/azure/aks/private-clusters):
+
+**System mode (module-created identity) — sufficient.**
+- The only role the cluster identity needs against *your* network is **Network Contributor on
+  the VNet**, which this module grants. Microsoft states that with the default System zone, "AKS
+  tries to link the zone directly to the spoke VNet… this action can fail if the cluster's
+  managed identity lacks **Network Contributor** on the spoke VNet." Our VNet-scoped grant is
+  exactly that permission (and it also covers subnet-join).
+- The zone itself is created in the **node resource group (`MC_*`)**, where AKS auto-grants the
+  control-plane identity **Contributor** as part of provisioning — so zone creation + the
+  A-record are covered without anything from us.
+- You do **not** need `Private DNS Zone Contributor` for System mode.
+
+**Custom zone mode — Network Contributor alone is NOT enough.**
+- Microsoft requires the user-assigned identity to hold **both `Private DNS Zone Contributor`
+  (on the custom zone) and `Network Contributor` (on the VNet).** Missing the zone role produces
+  `CustomPrivateDNSZoneMissingPermissionError`.
+- This module does **not** create that zone role assignment — the zone is yours (often in a hub
+  / another subscription). You must pre-grant both roles to the identity you pass via
+  `aks_cluster_identity_id`. (System-assigned identities are not supported with a custom zone.)
+
+**RBAC propagation caveat.** The module adds a 60-second `time_sleep` after its Network
+Contributor grant, which is enough in practice. Azure notes propagation can occasionally take
+**up to 60 minutes**; for a custom BYO identity, make the grants well before `apply`.
+
+---
+
+## Summary — what our Terraform creates for the AKS API zone
+
+| Thing | System (default) | None | Custom |
+|---|---|---|---|
+| Private endpoint for API server | AKS | AKS | AKS |
+| The `privatelink.<region>.azmk8s.io` **zone** | AKS | — | **you** |
+| **VNet link** to that zone | AKS (auto) | — | **you** |
+| API server **A-record** | AKS | — | AKS |
+| Control-plane **identity** | **our TF** (user-assigned) | our TF | **you** (BYO) |
+| **Network Contributor** on the VNet | **our TF** | our TF | **you** |
+| **Private DNS Zone Contributor** on the zone | n/a | n/a | **you** |
+
+In short: for the default System mode, **our Terraform's job is the identity + the VNet
+Network-Contributor grant** (so AKS can create and link the zone); **AKS creates and manages the
+zone itself**. We never create the AKS API-server zone in any mode.
+
+---
+
+## Don't confuse this with the Postgres/Redis zones
+
+Unlike the API-server zone, this module **does** create the backing-service private DNS zones and
+link them to your VNet (in the `postgres`/`redis` sub-modules):
+
+- `azurerm_private_dns_zone "privatelink.postgres.database.azure.com"` + a
+  `azurerm_private_dns_zone_virtual_network_link` to your VNet, with the Postgres **Private
+  Endpoint** registering its A-record via a `private_dns_zone_group`.
+- `azurerm_private_dns_zone "privatelink.redis.azure.net"` + link, same pattern for Redis.
+
+**Caveat:** because the module always creates these two zones, if a platform team already manages
+them centrally and links them to your VNet, you get a conflict (a VNet can't link two zones of
+the same name). There is no BYO-zone toggle for Postgres/Redis yet — see the README caveat.

--- a/modules/azure-private/README.md
+++ b/modules/azure-private/README.md
@@ -1,0 +1,285 @@
+# azure-private — Private / Hub-Spoke AKS Landing Zone for LangSmith
+
+> **Deploying?** See **[DEPLOYMENT.md](DEPLOYMENT.md)** for the customer prerequisites
+> (hub-and-spoke / firewall / apply-host requirements), the example tfvars, and the
+> step-by-step runbook (Terraform infra → Helm app). This README is the reference for the
+> input variables and the DNS / identity modes.
+>
+> **Just want to try it end to end?** [DEPLOYMENT.md](DEPLOYMENT.md)'s **Path A** stands up a
+> throwaway hub-spoke landing zone + firewall (via [`test/hub-spoke/`](test/hub-spoke/)) and takes
+> you from nothing to a running LangSmith.
+>
+> **Prefer a picture?** [architecture.html](architecture.html) is a one-page visual of what the
+> module builds, what you bring as a prerequisite, and the deployment order — open it in a browser.
+
+## What this is
+
+`modules/azure-private` is an **opinionated, self-contained, forkable** private landing
+zone for LangSmith on AKS. Every security control is **always on** — there are no opt-in
+toggles. The module is a sibling to `modules/azure` (the simple managed/public quickstart)
+and was vendored from it; the two modules now intentionally diverge.
+
+The module is split into **two Terraform roots** that are applied in sequence:
+
+- **`infra/`** — azurerm-only. Creates the AKS cluster, Postgres, Redis, Blob, Key Vault,
+  bastion, and diagnostics. Has **no** Kubernetes or Helm providers. Run from anywhere —
+  it is never blocked by the private API server.
+- **`bootstrap/`** — in-cluster. Installs KEDA, the internal NGINX ingress,
+  the `langsmith` namespace, and K8s secrets (read from Key Vault). Discovers everything it
+  needs (cluster endpoint, kubeconfig, identities, connection strings) via Azure data sources
+  and Key Vault — no dependency on `infra/` Terraform state. Must run **from the jumpbox**
+  (inside the VNet) as a **separate apply run after** `infra/` completes.
+
+The always-on posture:
+
+- **BYO resource group + BYO VNet** (you pre-create both; the module consumes them).
+- **Private API server** — AKS control plane has no public IP.
+- **Azure CNI Overlay + Cilium** — pods draw IPs from `aks_pod_cidr`, not the subnet; eBPF
+  dataplane.
+- **UDR egress** — the AKS subnet's route table routes `0.0.0.0/0` to your firewall/NVA.
+- **User-assigned control-plane identity** (module-created by default).
+- **Internal NGINX ingress** — private IP only; no WAF, no public Azure DNS zone, no AGIC.
+  Installed by `bootstrap/`.
+- **Private Endpoints for Postgres and Redis** — the module creates the
+  `privatelink.postgres.database.azure.com` and `privatelink.redis.azure.net` zones and
+  links them to your VNet.
+
+---
+
+## Prerequisites
+
+Everything in this section must exist **before** `terraform apply`.
+
+### Resource group
+
+An existing Azure resource group. The deployment region is **inherited from the RG** — you
+do not set a `location` variable. You need at least Contributor on the RG.
+
+### VNet and subnets
+
+An existing VNet with the following subnets:
+
+| Subnet | Requirements |
+|--------|-------------|
+| **AKS subnet** | Route table with `0.0.0.0/0` → firewall/NVA private IP (UDR). `Microsoft.Storage` and `Microsoft.KeyVault` service endpoints enabled (the Blob and Key Vault firewalls allowlist this subnet via these endpoints). |
+| **Postgres PE subnet** | A regular subnet with at least one spare IP for the private endpoint. **Not delegated** — Postgres uses a Private Endpoint, not VNet injection. |
+| **Redis PE subnet** | A regular subnet for the Redis private endpoint. |
+| **Jumpbox subnet** | A normal subnet (e.g. `jumpbox`). The module always provisions a jumpbox VM here as the in-VNet apply host. |
+
+### Firewall egress rules
+
+The AKS subnet's route table sends all egress through your firewall. You must permit the
+required AKS control-plane FQDNs and ports:
+[https://learn.microsoft.com/azure/aks/limit-egress-traffic](https://learn.microsoft.com/azure/aks/limit-egress-traffic)
+
+### In-VNet apply host
+
+`terraform apply` must run from a host that **resolves the private DNS zone** for the AKS
+API server. Options:
+
+- The bastion jumpbox VM this module provisions (SSH in via the jumpbox's public IP, then
+  run `terraform` there).
+- A peered self-hosted CI/CD runner with a line of sight to the private DNS zone.
+
+### RBAC
+
+The Terraform principal needs:
+
+- **Contributor** + **User Access Administrator** (or **Owner**) on the subscription/RG.
+- **Network Contributor on the VNet** — so AKS can join the subnet and the module can grant
+  the control-plane identity its Network Contributor role.
+
+---
+
+## Inputs
+
+### Resource IDs
+
+| Variable | Description |
+|----------|-------------|
+| `subscription_id` | Target subscription. |
+| `resource_group_name` | Name of the existing RG (region is inherited). |
+| `vnet_id` | Resource ID of the existing VNet. |
+| `aks_subnet_id` | Resource ID of the AKS subnet. |
+| `postgres_subnet_id` | Resource ID of the Postgres PE subnet (regular, not delegated). |
+| `redis_subnet_id` | Resource ID of the Redis PE subnet. |
+| `bastion_subnet_id` | Resource ID of the jumpbox subnet (a normal subnet, e.g. `.../subnets/jumpbox`). |
+
+### Deployment metadata
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `identifier` | `""` | Short suffix appended to every resource name (e.g. `"-prod"`). |
+| `environment` | `"dev"` | `dev`, `staging`, or `prod` — applied as a tag. |
+| `owner` | `""` | Owner email/team tag. |
+| `cost_center` | `""` | Cost center tag. |
+
+### CIDRs
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `aks_pod_cidr` | `10.244.0.0/16` | Pod CIDR for Azure CNI Overlay. Must not overlap the VNet, `aks_service_cidr`, or peered/on-prem ranges. |
+| `aks_service_cidr` | `10.0.64.0/20` | Kubernetes service CIDR. |
+| `aks_dns_service_ip` | `10.0.64.10` | Kubernetes DNS service IP (must be within `aks_service_cidr`). |
+
+### API-server private DNS
+
+See [API-server private DNS](#api-server-private-dns) below.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `aks_private_dns_zone_id` | `""` | Private DNS zone mode — see the section below. |
+| `aks_private_cluster_public_fqdn_enabled` | `false` | Expose a public FQDN for the private API server. Required when `aks_private_dns_zone_id = "None"`. |
+
+### Control-plane identity
+
+See [Control-plane identity](#control-plane-identity) below.
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `aks_create_cluster_identity` | `true` | Create a module-managed user-assigned identity and grant it Network Contributor on the VNet. |
+| `aks_cluster_identity_id` | `""` | BYO user-assigned identity resource ID. Mutually exclusive with `aks_create_cluster_identity`. |
+
+### Key Vault
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `keyvault_name` | `""` | Key Vault name (globally unique, 3–24 chars). Defaults to `langsmith-kv<identifier>`. |
+| `keyvault_purge_protection` | `true` | Set `false` for dev environments. |
+| `keyvault_default_action` | `"Allow"` | Set `"Deny"` + `keyvault_allowed_ips` for production. |
+| `keyvault_allowed_ips` | `[]` | Additional IPs/CIDRs for the Key Vault firewall (AKS subnet is added automatically). |
+
+### Backing services
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `postgres_source` | `"external"` | `"external"` provisions Azure Database for PostgreSQL Flexible Server (recommended). `"in-cluster"` for dev/demo only. |
+| `redis_source` | `"external"` | `"external"` provisions Azure Cache for Redis. `"in-cluster"` for dev/demo only. |
+| `amr_sku` | `"Balanced_B0"` | Azure Managed Redis SKU. Increase if the region reports `AllocationFailed`. |
+| `postgres_admin_username` | `"langsmith"` | Postgres admin username. |
+| `postgres_admin_password` | — | Postgres admin password. Supply via `TF_VAR_postgres_admin_password`. |
+
+### App inputs / secrets
+
+| Variable | Description |
+|----------|-------------|
+| `langsmith_domain` | Hostname for the LangSmith ingress (e.g. `langsmith.internal.example.com`). |
+| `langsmith_license_key` | LangSmith enterprise license key. Supply via `TF_VAR_langsmith_license_key`. |
+| `langsmith_api_key_salt` | API key hash salt. Generate once: `openssl rand -base64 32`. Supply via env var. |
+| `langsmith_jwt_secret` | JWT session secret. Generate once: `openssl rand -base64 32`. Supply via env var. |
+
+### Node sizing
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `default_node_pool_vm_size` | `Standard_D8s_v3` | Default pool VM size (8 vCPU / 32 GiB). |
+| `default_node_pool_min_count` | `1` | Min nodes. Set `3` for production. |
+| `default_node_pool_max_count` | `10` | Max nodes for autoscaler. |
+| `default_node_pool_max_pods` | `60` | Max pods per node (immutable). |
+| `additional_node_pools` | `{large: Standard_D16s_v3}` | Extra node pools. The `large` pool is required for ClickHouse and LangGraph Platform. |
+| `availability_zones` | `["1"]` | Set `["1","2","3"]` for zone-redundant HA. |
+
+---
+
+## API-server private DNS
+
+> **Deep dive:** [PRIVATE_DNS.md](PRIVATE_DNS.md) explains exactly what *this Terraform* does
+> versus what *AKS* does for each mode (zone creation, VNet linking, the control-plane identity
+> + Network Contributor grant), and how it differs from the Postgres/Redis zones.
+
+`aks_private_dns_zone_id` controls how the AKS private API server's DNS is resolved. Three
+modes:
+
+| Value | Behaviour |
+|-------|-----------|
+| `""` *(default)* | **System** — AKS creates and manages the private DNS zone automatically and links it to your VNet. The simplest option; works for most deployments. |
+| `"None"` | **BYO DNS** — AKS creates no private DNS zone; resolution is your responsibility. Requires `aks_private_cluster_public_fqdn_enabled = true` so the API FQDN resolves publicly (e.g. via your own DNS server). AKS does not support `"None"` with a disabled public FQDN. |
+| `<zone resource ID>` | **Custom zone** — supply the resource ID of your own `privatelink.<region>.azmk8s.io` zone. The zone must be linked to the VNet. You must also bring a BYO user-assigned identity (`aks_create_cluster_identity = false`, `aks_cluster_identity_id = "..."`) pre-granted **Private DNS Zone Contributor** on the zone and **Network Contributor** on the VNet. |
+
+### Hub-spoke / custom DNS caveat
+
+If your VNet uses custom DNS servers (common in hub-spoke), add conditional forwarders to
+`168.63.129.16` for:
+
+- `privatelink.<region>.azmk8s.io` (AKS API server zone, if using System or custom mode)
+- `privatelink.postgres.database.azure.com`
+- `privatelink.redis.azure.net`
+
+Without these forwarders the in-VNet apply host and pods cannot resolve the private
+endpoint FQDNs.
+
+---
+
+## Control-plane identity
+
+The AKS control plane needs a managed identity with **Network Contributor on the VNet** to
+join subnets and (in System DNS mode) link the private DNS zone.
+
+| Mode | How to configure |
+|------|-----------------|
+| **Module-created (default)** | Leave `aks_create_cluster_identity = true` (default). The module creates a user-assigned identity and grants it Network Contributor on the VNet. |
+| **BYO identity** | Set `aks_create_cluster_identity = false` and set `aks_cluster_identity_id` to your identity's resource ID. Pre-grant it Network Contributor on the VNet (and Private DNS Zone Contributor on the zone if using a custom DNS zone). |
+
+These two options are **mutually exclusive** — setting both is rejected by a Terraform
+`precondition`.
+
+---
+
+## Backing services — Private Endpoints
+
+Postgres and Redis reach the cluster via **Private Endpoints**, not VNet injection or
+public endpoints.
+
+The module automatically creates:
+
+| Service | Private DNS zone | VNet link |
+|---------|-----------------|-----------|
+| Azure Database for PostgreSQL Flexible Server | `privatelink.postgres.database.azure.com` | Linked to your VNet |
+| Azure Cache for Redis (AMR) | `privatelink.redis.azure.net` | Linked to your VNet |
+
+You do **not** pre-create these zones. The Postgres subnet must be a **regular subnet** —
+it is NOT delegated to `Microsoft.DBforPostgreSQL/flexibleServers` (delegation was the old
+VNet-injection model; the module now uses Private Endpoints exclusively).
+
+**Caveat — centrally-managed zones:** if your platform team already manages
+`privatelink.postgres.database.azure.com` or `privatelink.redis.azure.net` centrally and
+links them to your VNet, applying this module will conflict (a VNet cannot link two zones
+with the same name). Coordinate with your platform team before applying.
+
+---
+
+## Validate offline
+
+Both roots ship with Terraform test cases. Run them without provisioning real Azure
+resources:
+
+```bash
+terraform -chdir=modules/azure-private/infra test
+terraform -chdir=modules/azure-private/bootstrap test
+```
+
+Requires Terraform >= 1.7.
+
+---
+
+## Quick start
+
+```bash
+# Phase 1 — Azure infra (run from anywhere)
+cp modules/azure-private/infra/terraform.tfvars.example modules/azure-private/infra/terraform.tfvars
+# Edit terraform.tfvars — fill in subscription_id, resource IDs, secrets
+terraform -chdir=modules/azure-private/infra init
+terraform -chdir=modules/azure-private/infra plan
+terraform -chdir=modules/azure-private/infra apply
+
+# Phase 2 — In-cluster bootstrap (run from the jumpbox inside the VNet)
+# ssh azureuser@<jumpbox-public-ip>
+terraform -chdir=modules/azure-private/bootstrap init
+terraform -chdir=modules/azure-private/bootstrap apply \
+  -var="subscription_id=<SUB>" \
+  -var="resource_group_name=<RG>" \
+  -var="identifier=<IDENTIFIER>"
+```
+
+See [DEPLOYMENT.md](DEPLOYMENT.md) for the full runbook including prerequisites, the LangSmith
+Helm install (Phase 4), and teardown order.

--- a/modules/azure-private/architecture.html
+++ b/modules/azure-private/architecture.html
@@ -1,0 +1,478 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>azure-private — architecture &amp; deployment flow</title>
+<style>
+  :root {
+    --bg: #EEF2F6;
+    --surface: #FFFFFF;
+    --surface-2: #F6F8FA;
+    --ink: #16202B;
+    --muted: #566472;
+    --line: #D3DCE4;
+
+    --preq: #5B6875;        --preq-tint: #EAEEF2;
+    --infra: #0A63C9;       --infra-tint: #E6F0FB;
+    --boot: #0C857A;        --boot-tint: #E0F2EF;
+    --app: #B5451B;         --app-tint: #F7E9E1;
+
+    --internet: #7A8794;
+    --radius: 7px;
+    --mono: ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, "Liberation Mono", monospace;
+    --sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #0D141B; --surface: #151E27; --surface-2: #1A2530;
+      --ink: #E7EDF3; --muted: #97A6B4; --line: #293845;
+      --preq: #8896A4; --preq-tint: #202C38;
+      --infra: #4C9BF5; --infra-tint: #10263F;
+      --boot: #2BC4B4; --boot-tint: #0C2E2C;
+      --app: #F08A5D; --app-tint: #331B12;
+      --internet: #8A97A4;
+    }
+  }
+  :root[data-theme="light"] {
+    --bg: #EEF2F6; --surface: #FFFFFF; --surface-2: #F6F8FA;
+    --ink: #16202B; --muted: #566472; --line: #D3DCE4;
+    --preq: #5B6875; --preq-tint: #EAEEF2;
+    --infra: #0A63C9; --infra-tint: #E6F0FB;
+    --boot: #0C857A; --boot-tint: #E0F2EF;
+    --app: #B5451B; --app-tint: #F7E9E1;
+    --internet: #7A8794;
+  }
+  :root[data-theme="dark"] {
+    --bg: #0D141B; --surface: #151E27; --surface-2: #1A2530;
+    --ink: #E7EDF3; --muted: #97A6B4; --line: #293845;
+    --preq: #8896A4; --preq-tint: #202C38;
+    --infra: #4C9BF5; --infra-tint: #10263F;
+    --boot: #2BC4B4; --boot-tint: #0C2E2C;
+    --app: #F08A5D; --app-tint: #331B12;
+    --internet: #8A97A4;
+  }
+
+  * { box-sizing: border-box; }
+  html { -webkit-text-size-adjust: 100%; }
+  body {
+    margin: 0; background: var(--bg); color: var(--ink);
+    font-family: var(--sans); line-height: 1.45;
+    -webkit-font-smoothing: antialiased;
+  }
+  .page { max-width: 1240px; margin: 0 auto; padding: 34px 30px 48px; }
+
+  /* ── header ── */
+  header { margin-bottom: 22px; }
+  .kicker {
+    font-size: 11px; letter-spacing: .13em; text-transform: uppercase;
+    color: var(--infra); font-weight: 700; margin: 0 0 6px;
+  }
+  h1 {
+    font-size: 27px; line-height: 1.15; margin: 0 0 8px; letter-spacing: -.015em;
+    font-weight: 700; text-wrap: balance;
+  }
+  h1 code { font-family: var(--mono); font-size: .82em; background: var(--surface-2);
+    padding: 1px 7px; border-radius: 5px; border: 1px solid var(--line); }
+  .lede { margin: 0; color: var(--muted); font-size: 14px; max-width: 78ch; }
+
+  /* ── legend ── */
+  .legend {
+    display: flex; flex-wrap: wrap; gap: 8px 20px; margin: 18px 0 4px;
+    padding: 12px 16px; background: var(--surface); border: 1px solid var(--line);
+    border-radius: var(--radius);
+  }
+  .legend-item { display: flex; align-items: center; gap: 8px; font-size: 12.5px; }
+  .legend-item b { font-weight: 600; }
+  .legend-item span { color: var(--muted); }
+  .sw { width: 15px; height: 15px; border-radius: 4px; flex: 0 0 auto; }
+  .sw.preq { background: var(--preq-tint); border: 1.5px dashed var(--preq); }
+  .sw.infra { background: var(--infra-tint); border: 1.5px solid var(--infra); }
+  .sw.boot { background: var(--boot-tint); border: 1.5px solid var(--boot); }
+  .sw.app { background: var(--app-tint); border: 1.5px solid var(--app); }
+
+  /* ── section scaffolding ── */
+  .section { margin-top: 26px; }
+  .section-label {
+    font-size: 11px; letter-spacing: .12em; text-transform: uppercase;
+    color: var(--muted); font-weight: 700; margin: 0 0 12px;
+    display: flex; align-items: baseline; gap: 10px;
+  }
+  .section-label .num {
+    font-family: var(--mono); color: var(--infra); font-size: 12px;
+  }
+  .scroll { overflow-x: auto; }
+
+  /* ── generic card ── */
+  .card {
+    background: var(--surface); border: 1.5px solid var(--line);
+    border-radius: var(--radius); padding: 11px 13px;
+  }
+  .card-h { display: flex; align-items: center; gap: 8px; margin-bottom: 4px; flex-wrap: wrap; }
+  .card-title { font-weight: 650; font-size: 13.5px; letter-spacing: -.005em; }
+  .card-meta { color: var(--muted); font-size: 11.5px; line-height: 1.4; }
+  .card-meta code, .chip code, .tl-desc code { font-family: var(--mono); font-size: 11px;
+    background: var(--surface-2); padding: 0 4px; border-radius: 4px; }
+
+  .tag {
+    font-family: var(--mono); font-size: 10.5px; font-weight: 600;
+    padding: 1.5px 6px; border-radius: 5px; letter-spacing: .01em; white-space: nowrap;
+  }
+  .tag-preq { background: var(--preq-tint); color: var(--preq); }
+  .tag-infra { background: var(--infra-tint); color: var(--infra); }
+  .tag-boot { background: var(--boot-tint); color: var(--boot); }
+  .tag-app { background: var(--app-tint); color: var(--app); }
+
+  .cat-preq { border-color: var(--preq); border-style: dashed; background: color-mix(in srgb, var(--preq-tint) 55%, var(--surface)); }
+  .cat-infra { border-color: var(--infra); }
+  .cat-boot { border-color: var(--boot); }
+  .cat-app { border-color: var(--app); }
+
+  /* ── topology ── */
+  .rg {
+    border: 1.5px dashed var(--preq); border-radius: 10px; padding: 14px;
+    background: color-mix(in srgb, var(--preq-tint) 40%, var(--surface));
+    min-width: 900px;
+  }
+  .container-label {
+    display: flex; align-items: center; gap: 8px; margin-bottom: 12px;
+    font-size: 12.5px; font-weight: 650;
+  }
+  .container-label .tag { font-size: 10px; }
+  .container-sub { color: var(--muted); font-weight: 400; font-size: 11.5px; }
+
+  .topo { display: flex; align-items: flex-start; gap: 0; }
+  .hub-col { flex: 0 0 210px; display: flex; flex-direction: column; gap: 10px; }
+  .peer { flex: 0 0 74px; display: flex; flex-direction: column;
+    align-items: center; justify-content: flex-start; gap: 6px; padding-top: 120px; }
+  .peer .line { height: 2px; width: 100%; background: var(--preq); }
+  .peer .lbl { font-size: 10px; color: var(--muted); text-align: center; line-height: 1.2;
+    text-transform: uppercase; letter-spacing: .04em; }
+  .spoke-col { flex: 1 1 auto; min-width: 0; }
+
+  .vnet {
+    border: 1.5px dashed var(--preq); border-radius: 9px; padding: 11px;
+    background: var(--surface);
+  }
+  .vnet-h { display: flex; align-items: center; gap: 7px; margin-bottom: 9px; font-size: 12px; font-weight: 650; }
+
+  .internet {
+    display: flex; align-items: center; justify-content: center; gap: 7px;
+    border: 1.5px solid var(--internet); border-radius: 40px; padding: 6px 12px;
+    color: var(--internet); font-weight: 650; font-size: 12.5px; background: var(--surface);
+  }
+  .egress-arrow { text-align: center; color: var(--internet); font-size: 11px; line-height: 1;
+    display: flex; flex-direction: column; align-items: center; gap: 1px; }
+  .egress-arrow .k { font-size: 9.5px; letter-spacing: .04em; text-transform: uppercase; }
+
+  .subnet-lane { display: flex; flex-direction: column; gap: 9px; }
+  .subnet {
+    border: 1.5px dashed var(--preq); border-radius: 8px; padding: 9px 10px;
+    background: color-mix(in srgb, var(--preq-tint) 30%, var(--surface));
+  }
+  .subnet-h { display: flex; align-items: center; gap: 7px; margin-bottom: 7px; }
+  .subnet-h .name { font-weight: 650; font-size: 12px; }
+  .subnet-h .cidr { font-family: var(--mono); font-size: 10.5px; color: var(--muted); }
+
+  .cluster { border: 1.5px solid var(--infra); border-radius: 7px; padding: 9px 10px;
+    background: var(--surface); }
+  .cluster > .card-h { margin-bottom: 6px; }
+  .layerbox { border-radius: 6px; padding: 7px 8px; margin-top: 7px; }
+  .layerbox.boot { border: 1.3px solid var(--boot); background: color-mix(in srgb, var(--boot-tint) 45%, var(--surface)); }
+  .layerbox.app { border: 1.3px solid var(--app); background: color-mix(in srgb, var(--app-tint) 45%, var(--surface)); }
+  .layerbox-h { display: flex; align-items: center; gap: 7px; margin-bottom: 6px; }
+  .layerbox-h .t { font-size: 11.5px; font-weight: 650; }
+
+  .chips { display: flex; flex-wrap: wrap; gap: 5px; }
+  .chip {
+    font-size: 11px; padding: 2.5px 8px; border-radius: 5px; background: var(--surface);
+    border: 1px solid var(--line); white-space: nowrap; color: var(--ink);
+  }
+  .chip.mono { font-family: var(--mono); font-size: 10.5px; }
+
+  .accessnote {
+    margin-top: 7px; font-size: 10.5px; color: var(--muted);
+    display: flex; align-items: center; gap: 6px;
+  }
+  .arrow { color: var(--infra); font-weight: 700; }
+
+  /* ── regional band ── */
+  .grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 11px; }
+  .grid.two { grid-template-columns: repeat(2, 1fr); }
+
+  /* ── deployment timeline ── */
+  .timeline { display: flex; flex-direction: column; gap: 0; }
+  .tl {
+    display: grid; grid-template-columns: 44px 1fr; gap: 14px; position: relative;
+    padding-bottom: 14px;
+  }
+  .tl:not(:last-child) .tl-badge::after {
+    content: ""; position: absolute; left: 21px; top: 34px; bottom: -1px; width: 2px;
+    background: var(--line);
+  }
+  .tl-badge { position: relative; }
+  .tl-badge .n {
+    width: 34px; height: 34px; border-radius: 50%; display: flex; align-items: center;
+    justify-content: center; font-weight: 700; font-size: 13px; color: var(--bg);
+    background: var(--ink); font-family: var(--mono);
+  }
+  .tl-body { background: var(--surface); border: 1px solid var(--line); border-radius: var(--radius);
+    padding: 10px 13px; }
+  .tl-h { display: flex; align-items: center; gap: 9px; flex-wrap: wrap; margin-bottom: 3px; }
+  .tl-title { font-weight: 650; font-size: 13.5px; }
+  .tl-desc { color: var(--muted); font-size: 12px; }
+  .runpill {
+    font-size: 10px; text-transform: uppercase; letter-spacing: .05em; font-weight: 700;
+    padding: 2px 8px; border-radius: 20px; border: 1px solid var(--line); color: var(--muted);
+    white-space: nowrap;
+  }
+  .runpill.vnet-only { color: var(--app); border-color: color-mix(in srgb, var(--app) 45%, var(--line)); }
+  .dot { width: 9px; height: 9px; border-radius: 50%; flex: 0 0 auto; }
+  .dot.infra { background: var(--infra); } .dot.boot { background: var(--boot); }
+  .dot.app { background: var(--app); } .dot.tool { background: var(--muted); }
+
+  /* ── footer ── */
+  .notes { margin-top: 28px; border-top: 1px solid var(--line); padding-top: 16px;
+    display: grid; grid-template-columns: repeat(2, 1fr); gap: 8px 26px; }
+  .note { font-size: 12px; color: var(--muted); display: flex; gap: 8px; }
+  .note b { color: var(--ink); font-weight: 650; }
+  .note::before { content: "▪"; color: var(--infra); }
+
+  @media (max-width: 720px) {
+    .grid, .grid.two, .notes { grid-template-columns: 1fr; }
+    .page { padding: 24px 16px 40px; }
+  }
+</style>
+</head>
+<body>
+<div class="page">
+
+  <header>
+    <p class="kicker">Terraform · modules/azure-private</p>
+    <h1>Private / Hub-Spoke AKS Landing Zone for LangSmith</h1>
+    <p class="lede">What this module builds, what you bring as prerequisites, and the order you
+      deploy it in. Two Terraform roots — <code>infra/</code> (Azure) and <code>bootstrap/</code>
+      (in-cluster) — plus a Helm install, bridged through Key Vault with no shared state.</p>
+  </header>
+
+  <div class="legend" role="list" aria-label="Legend">
+    <div class="legend-item" role="listitem"><span class="sw preq"></span><b>Pre-req</b><span>— you provide</span></div>
+    <div class="legend-item" role="listitem"><span class="sw infra"></span><b><code style="font-family:var(--mono)">infra/</code> root</b><span>— Azure resources</span></div>
+    <div class="legend-item" role="listitem"><span class="sw boot"></span><b><code style="font-family:var(--mono)">bootstrap/</code> root</b><span>— in-cluster</span></div>
+    <div class="legend-item" role="listitem"><span class="sw app"></span><b>Helm</b><span>— LangSmith app (not bundled)</span></div>
+  </div>
+
+  <!-- ── TOPOLOGY ── -->
+  <div class="section">
+    <p class="section-label"><span class="num">01</span> Network topology &amp; what runs where</p>
+    <div class="scroll">
+      <div class="rg">
+        <div class="container-label">
+          <span class="tag tag-preq">pre-req</span>
+          Resource group
+          <span class="container-sub">— existing; deployment region is inherited from it (no <code style="font-family:var(--mono);font-size:11px">location</code> variable)</span>
+        </div>
+
+        <div class="topo">
+          <!-- HUB -->
+          <div class="hub-col">
+            <div class="internet">☁ Internet</div>
+            <div class="egress-arrow"><span class="k">▲ allowed egress</span></div>
+            <div class="vnet">
+              <div class="vnet-h"><span class="tag tag-preq">pre-req</span> Hub VNet</div>
+              <div class="card cat-preq">
+                <div class="card-h"><span class="tag tag-preq">pre-req</span><span class="card-title">Azure Firewall</span></div>
+                <div class="card-meta">Egress allow-list for AKS control-plane FQDNs &amp; ports. Route table on the AKS subnet sends <code>0.0.0.0/0</code> here.</div>
+              </div>
+            </div>
+          </div>
+
+          <!-- PEERING -->
+          <div class="peer">
+            <div class="line"></div>
+            <div class="lbl">VNet<br>peering</div>
+            <div class="line"></div>
+          </div>
+
+          <!-- SPOKE -->
+          <div class="spoke-col">
+            <div class="vnet">
+              <div class="vnet-h"><span class="tag tag-preq">pre-req</span> Spoke VNet <span class="container-sub">— you create the VNet &amp; subnets; the module joins them</span></div>
+              <div class="subnet-lane">
+
+                <!-- AKS subnet -->
+                <div class="subnet">
+                  <div class="subnet-h"><span class="tag tag-preq">pre-req</span><span class="name">AKS subnet</span><span class="cidr">+ route table (UDR → firewall) + service endpoints: Storage, KeyVault</span></div>
+                  <div class="cluster">
+                    <div class="card-h"><span class="tag tag-infra">infra/</span><span class="card-title">Private AKS cluster</span></div>
+                    <div class="card-meta">Azure CNI Overlay + Cilium · <code>outbound_type=userDefinedRouting</code> · private API server · user-assigned control-plane identity · OIDC + Workload Identity · CSI Secrets Store. <span class="arrow">◀</span> egress leaves via UDR to the hub firewall.</div>
+
+                    <div class="layerbox boot">
+                      <div class="layerbox-h"><span class="tag tag-boot">bootstrap/</span><span class="t">In-cluster components</span></div>
+                      <div class="chips">
+                        <span class="chip">KEDA</span>
+                        <span class="chip">Internal NGINX ingress <span style="color:var(--muted)">(private LB IP)</span></span>
+                        <span class="chip mono">langsmith namespace</span>
+                        <span class="chip mono">langsmith-postgres-secret</span>
+                        <span class="chip mono">langsmith-redis-secret</span>
+                        <span class="chip">default-deny NetworkPolicies</span>
+                      </div>
+                      <div class="layerbox-h" style="margin-top:7px"><span class="tag tag-boot">scripts</span><span class="t">Config &amp; TLS secrets</span></div>
+                      <div class="chips">
+                        <span class="chip mono">langsmith-config-secret</span>
+                        <span class="chip mono">langsmith-tls <span style="color:var(--muted);font-family:var(--sans)">(self-signed / BYO)</span></span>
+                      </div>
+                    </div>
+
+                    <div class="layerbox app">
+                      <div class="layerbox-h"><span class="tag tag-app">Helm</span><span class="t">LangSmith application</span> <span style="color:var(--muted);font-size:11px">— installed separately, not bundled</span></div>
+                      <div class="chips">
+                        <span class="chip">backend</span><span class="chip">platform-backend</span>
+                        <span class="chip">queue</span><span class="chip">ingest-queue</span>
+                        <span class="chip">host-backend</span><span class="chip">listener</span>
+                        <span class="chip">fleet servers</span><span class="chip">frontend / playground</span>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+
+                <!-- data PE subnets -->
+                <div class="grid two">
+                  <div class="subnet">
+                    <div class="subnet-h"><span class="tag tag-preq">pre-req</span><span class="name">postgres-pe subnet</span></div>
+                    <div class="card cat-infra">
+                      <div class="card-h"><span class="tag tag-infra">infra/</span><span class="card-title">Postgres Private Endpoint</span></div>
+                      <div class="card-meta"><span class="arrow">▶</span> to PostgreSQL Flexible Server (below)</div>
+                    </div>
+                  </div>
+                  <div class="subnet">
+                    <div class="subnet-h"><span class="tag tag-preq">pre-req</span><span class="name">redis-pe subnet</span></div>
+                    <div class="card cat-infra">
+                      <div class="card-h"><span class="tag tag-infra">infra/</span><span class="card-title">Redis Private Endpoint</span></div>
+                      <div class="card-meta"><span class="arrow">▶</span> to Azure Managed Redis (below)</div>
+                    </div>
+                  </div>
+                </div>
+
+                <!-- jumpbox subnet -->
+                <div class="subnet">
+                  <div class="subnet-h"><span class="tag tag-preq">pre-req</span><span class="name">jumpbox subnet</span></div>
+                  <div class="card cat-infra">
+                    <div class="card-h"><span class="tag tag-infra">infra/</span><span class="card-title">Bastion VM</span> <span style="color:var(--muted);font-size:11px">— day-2 access</span></div>
+                    <div class="card-meta">The in-VNet apply host for the <code>bootstrap/</code> root &amp; Helm install lives here (it can reach the private API server).</div>
+                  </div>
+                </div>
+
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ── REGIONAL SERVICES ── -->
+  <div class="section">
+    <p class="section-label"><span class="num">02</span> Azure managed &amp; regional services <span style="color:var(--infra);font-weight:600;text-transform:none;letter-spacing:0">· built by <code style="font-family:var(--mono);font-size:11px">infra/</code></span></p>
+    <div class="grid">
+      <div class="card cat-infra">
+        <div class="card-h"><span class="tag tag-infra">infra/</span><span class="card-title">PostgreSQL Flexible Server</span></div>
+        <div class="card-meta">Public access disabled · <code>privatelink.postgres</code> DNS zone · connection URL written to Key Vault. <br><span class="arrow">◀</span> reached via Private Endpoint in <b>postgres-pe</b>.</div>
+      </div>
+      <div class="card cat-infra">
+        <div class="card-h"><span class="tag tag-infra">infra/</span><span class="card-title">Azure Managed Redis</span></div>
+        <div class="card-meta">redisEnterprise (Balanced) · TLS · public access disabled · <code>privatelink.redis</code> DNS zone · URL to Key Vault. <br><span class="arrow">◀</span> reached via Private Endpoint in <b>redis-pe</b>.</div>
+      </div>
+      <div class="card cat-infra">
+        <div class="card-h"><span class="tag tag-infra">infra/</span><span class="card-title">Key Vault</span></div>
+        <div class="card-meta">RBAC mode + default-deny · holds connection URLs &amp; app secrets · the "bridge" the other root reads. <br><span class="arrow">◀</span> Service Endpoint from AKS subnet.</div>
+      </div>
+      <div class="card cat-infra">
+        <div class="card-h"><span class="tag tag-infra">infra/</span><span class="card-title">Blob Storage</span></div>
+        <div class="card-meta">Default-deny · Blob Data Contributor to the workload identity · TTL lifecycle. <br><span class="arrow">◀</span> Service Endpoint from AKS subnet.</div>
+      </div>
+      <div class="card cat-infra">
+        <div class="card-h"><span class="tag tag-infra">infra/</span><span class="card-title">Private DNS zones</span></div>
+        <div class="card-meta"><code>privatelink.postgres</code> &amp; <code>privatelink.redis</code>, linked to the spoke VNet. API-server DNS has System / None / custom modes.</div>
+      </div>
+      <div class="card cat-infra">
+        <div class="card-h"><span class="tag tag-infra">infra/</span><span class="card-title">Diagnostics + Workload Identity</span></div>
+        <div class="card-meta">Log Analytics diagnostics · 8 federated identity credentials mapping AKS service accounts to Entra identities for Blob/Key Vault access.</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- ── DEPLOYMENT ── -->
+  <div class="section">
+    <p class="section-label"><span class="num">03</span> Deployment sequence</p>
+    <div class="timeline">
+
+      <div class="tl">
+        <div class="tl-badge"><div class="n">0</div></div>
+        <div class="tl-body">
+          <div class="tl-h"><span class="dot tool"></span><span class="tl-title">Authenticate &amp; pre-flight</span><span class="runpill">runs anywhere</span></div>
+          <div class="tl-desc"><code>az login</code> → <code>scripts/preflight.sh</code> checks login, resource providers, RBAC, and <code>terraform.tfvars</code>.</div>
+        </div>
+      </div>
+
+      <div class="tl">
+        <div class="tl-badge"><div class="n">1</div></div>
+        <div class="tl-body">
+          <div class="tl-h"><span class="dot infra"></span><span class="tl-title">Deploy Azure infrastructure</span><span class="tag tag-infra">infra/</span><span class="runpill">runs anywhere</span></div>
+          <div class="tl-desc"><code>terraform apply</code> → private AKS, Postgres, Redis, Blob, Key Vault, bastion, private DNS. No Kubernetes provider, so the private API server never blocks it. ~15–20 min.</div>
+        </div>
+      </div>
+
+      <div class="tl">
+        <div class="tl-badge"><div class="n">2</div></div>
+        <div class="tl-body">
+          <div class="tl-h"><span class="dot infra"></span><span class="tl-title">Cluster access + verify</span><span class="tag tag-infra">infra/</span><span class="runpill">runs anywhere</span></div>
+          <div class="tl-desc"><code>az aks get-credentials</code> (works anywhere); <code>kubectl</code> API calls need VNet connectivity — run them from the jumpbox.</div>
+        </div>
+      </div>
+
+      <div class="tl">
+        <div class="tl-badge"><div class="n">3</div></div>
+        <div class="tl-body">
+          <div class="tl-h"><span class="dot boot"></span><span class="tl-title">In-cluster bootstrap</span><span class="tag tag-boot">bootstrap/</span><span class="runpill vnet-only">from jumpbox</span></div>
+          <div class="tl-desc"><code>terraform apply</code> (3 vars) → KEDA, internal NGINX, <code>langsmith</code> namespace, Postgres/Redis connection secrets. Discovers everything via Azure data sources + Key Vault.</div>
+        </div>
+      </div>
+
+      <div class="tl">
+        <div class="tl-badge"><div class="n">3.5</div></div>
+        <div class="tl-body">
+          <div class="tl-h"><span class="dot boot"></span><span class="tl-title">Config &amp; TLS secrets</span><span class="tag tag-boot">scripts</span><span class="runpill vnet-only">from jumpbox</span></div>
+          <div class="tl-desc"><code>create-k8s-secrets.sh</code> → <code>langsmith-config-secret</code> (from Key Vault); <code>create-tls-secret.sh</code> → <code>langsmith-tls</code> (self-signed for testing, or BYO cert).</div>
+        </div>
+      </div>
+
+      <div class="tl">
+        <div class="tl-badge"><div class="n">4</div></div>
+        <div class="tl-body">
+          <div class="tl-h"><span class="dot app"></span><span class="tl-title">Install LangSmith (Helm)</span><span class="tag tag-app">Helm</span><span class="runpill vnet-only">from jumpbox</span></div>
+          <div class="tl-desc"><code>helm upgrade --install</code> wiring external Postgres/Redis secrets, Blob via Workload Identity, the config secret, and ingress + TLS. Chart not bundled by this module.</div>
+        </div>
+      </div>
+
+      <div class="tl">
+        <div class="tl-badge"><div class="n">5</div></div>
+        <div class="tl-body">
+          <div class="tl-h"><span class="dot app"></span><span class="tl-title">Verify &amp; access</span><span class="tag tag-app">Helm</span><span class="runpill vnet-only">from jumpbox</span></div>
+          <div class="tl-desc"><code>status.sh</code> for health; map your <code>config.hostname</code> to the <b>private</b> ingress IP via internal DNS, then reach LangSmith from an in-VNet host.</div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+  <div class="notes">
+    <div class="note"><span><b>No shared state.</b> <code>bootstrap/</code> reads nothing from <code>infra/</code>'s state — it rediscovers via Azure data sources + a Key Vault "secret bridge".</span></div>
+    <div class="note"><span><b>Private Endpoints, not VNet injection.</b> Postgres &amp; Redis use PEs so they stay compatible with user-defined-routing egress.</span></div>
+    <div class="note"><span><b>No cert-manager.</b> <code>langsmith-tls</code> is script-created — self-signed for testing, real cert for production.</span></div>
+    <div class="note"><span><b>ingress-nginx sunset.</b> The bundled open-source controller's upstream maintenance ends March 2026 — plan a successor for long-term use.</span></div>
+  </div>
+
+</div>
+</body>
+</html>

--- a/modules/azure-private/bootstrap/.terraform.lock.hcl
+++ b/modules/azure-private/bootstrap/.terraform.lock.hcl
@@ -1,0 +1,82 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/azure/azapi" {
+  version     = "2.10.0"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:R6NYsRfXHXd5eNBFAG5gIyD8Um2nFgXiqB5Uz6vHAsA=",
+    "zh:1e6513c791c6be1389fc4acb8ffdd5127dbf0f479bd0c0074d3a5b69edee2faa",
+    "zh:2ad99c9b656a1d796f4f0ae50d98064af0e42915bbb5a9e5a8db68ca633eceb3",
+    "zh:455fcbfe38cf9181fbd78a6a4a1e43ccafbb606757f4142c99a8ce4d0c80b34c",
+    "zh:46dcafe5495aa50984fd393e72d18d59370fd6bb36b44a0c6c034b82644fc7b7",
+    "zh:5b2f0acff55ee9f8896e11b14d0538fc929d7eee0d68a15644751ca8b6cbc2fc",
+    "zh:61e231f5c6d300404e1010aff9634638c533ba2a7279b85df43cff3aec60f1a9",
+    "zh:68d0aefbd2baf276a034037d6e8b7b9049af42e5745a6db1cbc3311b79de0e6d",
+    "zh:8b12924ee9125266d6aee30a818c1d90403eefad82753b5cd70c8c20ddbd3c98",
+    "zh:92f5643c18c67d3c4bd1b03c02bc7069b24936b2cb5fca58fb998452dfa46e04",
+    "zh:a7aa502ba10433dbe6695a0b903d642153a99540e4eba2befe97e3902fd98093",
+    "zh:c3f8155d5b609fa336eb79c7b67b75076d9c31c94e53d2f3d2b2e66b58e1a73f",
+    "zh:e670ae37ed1813e8e475962a109652a15a054111b2b2428435deab884937ff1e",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "4.79.0"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:hEVrA2r7nS0jSd32CwsWNfifS8tV0xhoGuc1T9qU074=",
+    "zh:0129b3fa33289d54f86f150377b19127f85787116b7cc53564fed77c2e2468be",
+    "zh:131427cf40dd3fa4ec52af938b7ab0fd100bcacd75b7137c8e1ea5bf268c4638",
+    "zh:162ebd8f195ac28324d9e9f2e9b39a05d8a946abff21087a43123c83ca807a5d",
+    "zh:209a23777acdcfc674791a4ad37ba4e2110044857afb9db88aa305222fef706c",
+    "zh:21cf740e1fee936de429fa324b86af69c4fe90bbfdbb1f374e6a55118fdff841",
+    "zh:4ad1cde7ad4ef7187633b7fc7b0ed76ef2526b56fbb29f80a6fc54d07ac1204a",
+    "zh:57b942405b27af17cfad9a48d9e4ec75c0bb452f229dd132d6f1d8518ca4a067",
+    "zh:69a4fda56d6405027f303463f796a0d2d250403f67cecf2a25bcdfaeaf731630",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7c21524a423d95a4c84039e06a610f131c0618ee117da9c35e4b4f41d1210c64",
+    "zh:9045f6bb9f764709a5773d8ec65735f56c9995dc9c9ec3f85f2c6adf58654f3c",
+    "zh:e018581ed136640ba733ab583fd0072536b1bc096d66f2215787823cee6cfcdc",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/helm" {
+  version     = "2.17.0"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:kQMkcPVvHOguOqnxoEU2sm1ND9vCHiT8TvZ2x6v/Rsw=",
+    "zh:06fb4e9932f0afc1904d2279e6e99353c2ddac0d765305ce90519af410706bd4",
+    "zh:104eccfc781fc868da3c7fec4385ad14ed183eb985c96331a1a937ac79c2d1a7",
+    "zh:129345c82359837bb3f0070ce4891ec232697052f7d5ccf61d43d818912cf5f3",
+    "zh:3956187ec239f4045975b35e8c30741f701aa494c386aaa04ebabffe7749f81c",
+    "zh:66a9686d92a6b3ec43de3ca3fde60ef3d89fb76259ed3313ca4eb9bb8c13b7dd",
+    "zh:88644260090aa621e7e8083585c468c8dd5e09a3c01a432fb05da5c4623af940",
+    "zh:a248f650d174a883b32c5b94f9e725f4057e623b00f171936dcdcc840fad0b3e",
+    "zh:aa498c1f1ab93be5c8fbf6d48af51dc6ef0f10b2ea88d67bcb9f02d1d80d3930",
+    "zh:bf01e0f2ec2468c53596e027d376532a2d30feb72b0b5b810334d043109ae32f",
+    "zh:c46fa84cc8388e5ca87eb575a534ebcf68819c5a5724142998b487cb11246654",
+    "zh:d0c0f15ffc115c0965cbfe5c81f18c2e114113e7a1e6829f6bfd879ce5744fbb",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/kubernetes" {
+  version     = "2.38.0"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:soK8Lt0SZ6dB+HsypFRDzuX/npqlMU6M0fvyaR1yW0k=",
+    "zh:0af928d776eb269b192dc0ea0f8a3f0f5ec117224cd644bdacdc682300f84ba0",
+    "zh:1be998e67206f7cfc4ffe77c01a09ac91ce725de0abaec9030b22c0a832af44f",
+    "zh:326803fe5946023687d603f6f1bab24de7af3d426b01d20e51d4e6fbe4e7ec1b",
+    "zh:4a99ec8d91193af961de1abb1f824be73df07489301d62e6141a656b3ebfff12",
+    "zh:5136e51765d6a0b9e4dbcc3b38821e9736bd2136cf15e9aac11668f22db117d2",
+    "zh:63fab47349852d7802fb032e4f2b6a101ee1ce34b62557a9ad0f0f0f5b6ecfdc",
+    "zh:924fb0257e2d03e03e2bfe9c7b99aa73c195b1f19412ca09960001bee3c50d15",
+    "zh:b63a0be5e233f8f6727c56bed3b61eb9456ca7a8bb29539fba0837f1badf1396",
+    "zh:d39861aa21077f1bc899bc53e7233262e530ba8a3a2d737449b100daeb303e4d",
+    "zh:de0805e10ebe4c83ce3b728a67f6b0f9d18be32b25146aa89116634df5145ad4",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:faf23e45f0090eef8ba28a8aac7ec5d4fdf11a36c40a8d286304567d71c1e7db",
+  ]
+}

--- a/modules/azure-private/bootstrap/main.tf
+++ b/modules/azure-private/bootstrap/main.tf
@@ -1,0 +1,82 @@
+locals {
+  cluster_name   = "langsmith-aks${var.identifier}"
+  key_vault_name = var.key_vault_name != "" ? var.key_vault_name : "langsmith-kv${var.identifier}"
+}
+
+# ── AKS cluster credentials ────────────────────────────────────────────────────
+# Reads the cluster endpoint and credentials needed to configure the
+# Kubernetes/Helm providers inside the k8s-bootstrap module.
+# The kube_config certificate fields (client_certificate, client_key,
+# cluster_ca_certificate) are base64-encoded in the azurerm data source.
+# They are passed AS-IS to the k8s-bootstrap module, which applies
+# base64decode() internally in its provider blocks.
+
+data "azurerm_kubernetes_cluster" "main" {
+  name                = local.cluster_name
+  resource_group_name = var.resource_group_name
+}
+
+# ── Key Vault ──────────────────────────────────────────────────────────────────
+
+data "azurerm_key_vault" "main" {
+  name                = local.key_vault_name
+  resource_group_name = var.resource_group_name
+}
+
+# ── Key Vault secrets ─────────────────────────────────────────────────────────
+
+data "azurerm_key_vault_secret" "postgres_url" {
+  count        = var.use_external_postgres ? 1 : 0
+  name         = "postgres-connection-url"
+  key_vault_id = data.azurerm_key_vault.main.id
+}
+
+data "azurerm_key_vault_secret" "redis_url" {
+  count        = var.use_external_redis ? 1 : 0
+  name         = "redis-connection-url"
+  key_vault_id = data.azurerm_key_vault.main.id
+}
+
+data "azurerm_key_vault_secret" "postgres_admin_password" {
+  count        = var.use_external_postgres ? 1 : 0
+  name         = "postgres-admin-password"
+  key_vault_id = data.azurerm_key_vault.main.id
+}
+
+# NOTE: The LangSmith license key and the other app-config secrets are NOT read
+# here. They are pulled from Key Vault into `langsmith-config-secret` by
+# infra/scripts/create-k8s-secrets.sh (DEPLOYMENT.md Phase 3.5), keeping the
+# full app-secret set out of this root's Terraform state.
+
+# ── Kubernetes / Helm bootstrap ────────────────────────────────────────────────
+# Creates the langsmith namespace, network policies, the
+# Postgres/Redis connection K8s secrets, KEDA, and the NGINX ingress controller.
+# The app-config secret (langsmith-config-secret) and the TLS secret
+# (langsmith-tls) are created separately by infra/scripts/create-k8s-secrets.sh
+# and create-tls-secret.sh (DEPLOYMENT.md Phase 3.5).
+# All Kubernetes/Helm providers are configured inside the module from the
+# AKS kube_config data source above.
+
+module "k8s_bootstrap" {
+  source = "./modules/k8s-bootstrap"
+
+  # Cluster connection — the module's provider blocks apply base64decode()
+  # internally, so we pass the raw (still base64-encoded) values from the
+  # data source. host is a plain URL and is not encoded.
+  host                   = data.azurerm_kubernetes_cluster.main.kube_config[0].host
+  client_certificate     = data.azurerm_kubernetes_cluster.main.kube_config[0].client_certificate
+  client_key             = data.azurerm_kubernetes_cluster.main.kube_config[0].client_key
+  cluster_ca_certificate = data.azurerm_kubernetes_cluster.main.kube_config[0].cluster_ca_certificate
+
+  langsmith_namespace = var.langsmith_namespace
+
+  use_external_postgres   = var.use_external_postgres
+  postgres_connection_url = var.use_external_postgres ? data.azurerm_key_vault_secret.postgres_url[0].value : ""
+  postgres_admin_password = var.use_external_postgres ? data.azurerm_key_vault_secret.postgres_admin_password[0].value : ""
+  use_external_redis      = var.use_external_redis
+  redis_connection_url    = var.use_external_redis ? data.azurerm_key_vault_secret.redis_url[0].value : ""
+
+  # Version overrides — null/empty means "use the module default"
+  nginx_ingress_version = var.nginx_ingress_version
+  keda_version          = var.keda_version != null ? var.keda_version : "2.14.0"
+}

--- a/modules/azure-private/bootstrap/modules/k8s-bootstrap/main.tf
+++ b/modules/azure-private/bootstrap/modules/k8s-bootstrap/main.tf
@@ -1,0 +1,315 @@
+# ── Providers ─────────────────────────────────────────────────────────────────
+# Credentials are passed in from the root module via variables (not from a local
+# kubeconfig) so this module works in CI/CD pipelines without file system access.
+
+provider "kubernetes" {
+  host                   = var.host
+  client_certificate     = base64decode(var.client_certificate)
+  client_key             = base64decode(var.client_key)
+  cluster_ca_certificate = base64decode(var.cluster_ca_certificate)
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = var.host
+    client_certificate     = base64decode(var.client_certificate)
+    client_key             = base64decode(var.client_key)
+    cluster_ca_certificate = base64decode(var.cluster_ca_certificate)
+  }
+}
+
+# ── Namespace ─────────────────────────────────────────────────────────────────
+# Dedicated namespace isolates LangSmith workloads from other cluster tenants.
+# The workload.identity label is required by the Azure Workload Identity webhook
+# to inject OIDC tokens into pods so they can authenticate to Azure Blob Storage.
+
+resource "kubernetes_namespace_v1" "langsmith" {
+  metadata {
+    name = var.langsmith_namespace
+    labels = {
+      "app"                         = "langsmith"
+      "azure.workload.identity/use" = "true"
+    }
+  }
+}
+
+# Note: LangSmith pods do NOT use a bootstrap-created service account. The Helm
+# chart creates its own per-component service accounts (langsmith-backend,
+# langsmith-queue, …) and they get the Workload Identity client-id via Helm
+# values; those exact names are the ones federated in infra/modules/k8s-cluster.
+
+# ── Resource Quota ────────────────────────────────────────────────────────────
+# Caps total CPU/memory/pod count for the namespace. Prevents a runaway LangSmith
+# deployment (e.g. KEDA over-scaling) from starving kube-system or other tenants.
+# Defaults: 40 CPU req / 80 CPU lim, 80 GiB req / 160 GiB lim, 200 pods.
+
+resource "kubernetes_resource_quota_v1" "langsmith" {
+  metadata {
+    name      = "langsmith-quota"
+    namespace = kubernetes_namespace_v1.langsmith.metadata[0].name
+  }
+
+  spec {
+    hard = {
+      "requests.cpu"    = "40"
+      "requests.memory" = "80Gi"
+      "limits.cpu"      = "80"
+      "limits.memory"   = "160Gi"
+      pods              = "200"
+    }
+  }
+}
+
+# ── Limit Range ───────────────────────────────────────────────────────────────
+# Required companion to the ResourceQuota above: because the quota's `hard` includes
+# requests/limits, Kubernetes forces EVERY pod to declare them. Some chart components
+# (e.g. the bundled Postgres/Redis StatefulSets for the standalone insights/polly/fleet
+# agent features) ship without resource stanzas, so without defaults they're rejected
+# with "failed quota: must specify limits.cpu/... for: <container>" and never schedule.
+# This LimitRange supplies defaults so those pods inherit sane values and satisfy the quota.
+resource "kubernetes_limit_range_v1" "langsmith" {
+  metadata {
+    name      = "langsmith-defaults"
+    namespace = kubernetes_namespace_v1.langsmith.metadata[0].name
+  }
+
+  spec {
+    limit {
+      type = "Container"
+      default = {
+        cpu    = "1"
+        memory = "1Gi"
+      }
+      default_request = {
+        cpu    = "100m"
+        memory = "256Mi"
+      }
+    }
+  }
+}
+
+# ── Network Policy ────────────────────────────────────────────────────────────
+# Default-deny blocks all ingress to LangSmith pods unless explicitly allowed.
+# This is defense-in-depth: even if a pod is compromised, it cannot receive
+# lateral traffic from other namespaces. Egress is unrestricted (external DBs).
+
+resource "kubernetes_network_policy_v1" "langsmith_default_deny" {
+  metadata {
+    name      = "default-deny-ingress"
+    namespace = kubernetes_namespace_v1.langsmith.metadata[0].name
+  }
+
+  spec {
+    pod_selector {}
+    policy_types = ["Ingress"]
+  }
+}
+
+# This module installs the internal NGINX ingress controller in the
+# `ingress-nginx` namespace. The NetworkPolicy below must allow ingress from
+# that namespace, or the controller's proxy cannot reach LangSmith pods
+# (default-deny drops it → 503 with ~10s connection timeout).
+locals {
+  ingress_namespace = "ingress-nginx"
+}
+
+# Allows ingress from the NGINX ingress controller namespace (external traffic
+# via the internal LB) and from within the langsmith namespace itself
+# (inter-service calls). The intra-namespace rule is required on its own:
+# without it, backend pods cannot call each other (e.g. queue workers calling
+# the internal API).
+resource "kubernetes_network_policy_v1" "langsmith_allow_internal" {
+  metadata {
+    name      = "allow-from-ingress"
+    namespace = kubernetes_namespace_v1.langsmith.metadata[0].name
+  }
+
+  spec {
+    pod_selector {}
+
+    ingress {
+      from {
+        namespace_selector {
+          match_labels = {
+            "kubernetes.io/metadata.name" = local.ingress_namespace
+          }
+        }
+      }
+    }
+
+    ingress {
+      from {
+        namespace_selector {
+          match_labels = {
+            "kubernetes.io/metadata.name" = var.langsmith_namespace
+          }
+        }
+      }
+    }
+
+    policy_types = ["Ingress"]
+  }
+}
+
+# ── Kubernetes Secrets (infrastructure dependencies) ──────────────────────────
+# These are created here because they depend on Terraform outputs (connection URLs).
+# The app-config secret (api_key_salt, jwt_secret, license, admin_password) is
+# created separately by infra/scripts/create-k8s-secrets.sh (DEPLOYMENT.md Phase 3.5).
+
+# PostgreSQL connection URL injected into the namespace so the Helm chart can
+# reference it via existingSecretName. Created here (not by Helm) because the
+# URL is a Terraform output — it's only known after the postgres module runs.
+resource "kubernetes_secret_v1" "postgres" {
+  count = var.use_external_postgres ? 1 : 0
+
+  metadata {
+    name      = "langsmith-postgres-secret"
+    namespace = kubernetes_namespace_v1.langsmith.metadata[0].name
+  }
+
+  data = {
+    connection_url = var.postgres_connection_url
+    # POSTGRES_URI and POSTGRES_PASSWORD are required by the listener's deploy_image
+    # task (host.platforms.k8s_operator.database_k8s.add_postgres_uri_secret) to
+    # provision per-deployment databases for LangSmith Deployments (Pass 3+).
+    POSTGRES_URI      = var.postgres_connection_url
+    POSTGRES_PASSWORD = var.postgres_admin_password
+  }
+
+  type = "Opaque"
+}
+
+# Redis connection URL (rediss://...) injected the same way as the Postgres secret.
+# KEDA ScaledObjects also reference this secret to authenticate queue-depth queries.
+resource "kubernetes_secret_v1" "redis" {
+  count = var.use_external_redis ? 1 : 0
+
+  metadata {
+    name      = "langsmith-redis-secret"
+    namespace = kubernetes_namespace_v1.langsmith.metadata[0].name
+  }
+
+  data = {
+    connection_url = var.redis_connection_url
+  }
+
+  type = "Opaque"
+}
+
+# Application config secret (license key, API key salt, JWT secret, admin
+# password, feature encryption keys) is NOT created here. It is created as
+# `langsmith-config-secret` by `infra/scripts/create-k8s-secrets.sh`, which
+# reads all keys from Key Vault and matches the key names the LangSmith chart
+# expects via `config.existingSecretName`. See DEPLOYMENT.md Phase 3.5.
+
+# ── NGINX Ingress Controller ───────────────────────────────────────────────────
+# Internal Azure Load Balancer: traffic stays within the hub-spoke network.
+# Created here (not in the infra root) so the bootstrap layer owns the full
+# Kubernetes/Helm surface.
+
+resource "helm_release" "nginx_ingress" {
+  name       = "ingress-nginx"
+  namespace  = "ingress-nginx"
+  repository = "https://kubernetes.github.io/ingress-nginx"
+  chart      = "ingress-nginx"
+  # Pin for reproducibility; null (default) resolves the latest chart. Pinning is
+  # recommended, especially as OSS ingress-nginx approaches EOL (March 2026).
+  version = var.nginx_ingress_version != "" ? var.nginx_ingress_version : null
+
+  create_namespace = true
+
+  values = [
+    yamlencode({
+      controller = {
+        replicaCount = 2
+
+        # Dedicated health-check endpoint that always returns 200.
+        # Azure LB HTTP probes hit /nginx-health on the NodePort — this returns 200
+        # so backends are never marked unhealthy. More reliable than TCP probes because
+        # the AKS cloud controller manager respects the request-path annotation on every
+        # reconcile cycle (e.g. after autoscaler node add/remove), whereas the protocol
+        # annotation is only applied at service creation time.
+        config = {
+          server-snippet = <<-EOT
+            location /nginx-health {
+              access_log off;
+              return 200 "healthy\n";
+              add_header Content-Type text/plain;
+            }
+          EOT
+        }
+
+        resources = {
+          requests = {
+            cpu    = "100m"
+            memory = "128Mi"
+          }
+          limits = {
+            cpu    = "500m"
+            memory = "512Mi"
+          }
+        }
+
+        service = {
+          type = "LoadBalancer"
+          annotations = {
+            # Internal Azure LB: AKS provisions a private IP instead of a public one.
+            # Required for private/hub-spoke clusters where ingress must not be internet-facing.
+            "service.beta.kubernetes.io/azure-load-balancer-internal" = "true"
+            # Keep HTTP probes (default) but point them at /nginx-health which always 200s.
+            # This survives every CCM reconcile: protocol stays Http, path stays /nginx-health.
+            "service.beta.kubernetes.io/azure-load-balancer-health-probe-request-path" = "/nginx-health"
+          }
+        }
+      }
+    })
+  ]
+}
+
+# ── KEDA ──────────────────────────────────────────────────────────────────────
+# Kubernetes Event-Driven Autoscaling. Scales LangSmith queue workers
+# based on Redis queue depth.
+
+resource "helm_release" "keda" {
+  name             = "keda"
+  namespace        = "keda"
+  create_namespace = true
+  repository       = "https://kedacore.github.io/charts"
+  chart            = "keda"
+  version          = var.keda_version
+  wait             = true
+  wait_for_jobs    = true
+
+  set {
+    name  = "resources.operator.requests.cpu"
+    value = "100m"
+  }
+  set {
+    name  = "resources.operator.requests.memory"
+    value = "128Mi"
+  }
+  set {
+    name  = "resources.operator.limits.cpu"
+    value = "500m"
+  }
+  set {
+    name  = "resources.operator.limits.memory"
+    value = "512Mi"
+  }
+  set {
+    name  = "resources.metricServer.requests.cpu"
+    value = "100m"
+  }
+  set {
+    name  = "resources.metricServer.requests.memory"
+    value = "128Mi"
+  }
+  set {
+    name  = "resources.metricServer.limits.cpu"
+    value = "500m"
+  }
+  set {
+    name  = "resources.metricServer.limits.memory"
+    value = "512Mi"
+  }
+}

--- a/modules/azure-private/bootstrap/modules/k8s-bootstrap/outputs.tf
+++ b/modules/azure-private/bootstrap/modules/k8s-bootstrap/outputs.tf
@@ -1,0 +1,24 @@
+output "langsmith_namespace" {
+  description = "Kubernetes namespace where LangSmith is deployed"
+  value       = kubernetes_namespace_v1.langsmith.metadata[0].name
+}
+
+output "keda_namespace" {
+  description = "Kubernetes namespace where KEDA is deployed"
+  value       = helm_release.keda.namespace
+}
+
+output "postgres_secret_name" {
+  description = "Name of the Kubernetes secret holding the PostgreSQL connection URL"
+  value       = var.use_external_postgres ? kubernetes_secret_v1.postgres[0].metadata[0].name : null
+}
+
+output "redis_secret_name" {
+  description = "Name of the Kubernetes secret holding the Redis connection URL"
+  value       = var.use_external_redis ? kubernetes_secret_v1.redis[0].metadata[0].name : null
+}
+
+output "nginx_ingress_values" {
+  description = "The rendered Helm values string for the NGINX ingress controller. Used by tests to assert the internal-LB annotation is present."
+  value       = helm_release.nginx_ingress.values[0]
+}

--- a/modules/azure-private/bootstrap/modules/k8s-bootstrap/variables.tf
+++ b/modules/azure-private/bootstrap/modules/k8s-bootstrap/variables.tf
@@ -1,0 +1,92 @@
+# ── Cluster connection ────────────────────────────────────────────────────────
+
+variable "host" {
+  type        = string
+  description = "Kubernetes API server endpoint"
+  sensitive   = true
+}
+
+variable "client_certificate" {
+  type        = string
+  description = "Base64-encoded client certificate from AKS kube_config"
+  sensitive   = true
+}
+
+variable "client_key" {
+  type        = string
+  description = "Base64-encoded client key from AKS kube_config"
+  sensitive   = true
+}
+
+variable "cluster_ca_certificate" {
+  type        = string
+  description = "Base64-encoded cluster CA certificate from AKS kube_config"
+  sensitive   = true
+}
+
+# ── Namespace ─────────────────────────────────────────────────────────────────
+
+variable "langsmith_namespace" {
+  type        = string
+  description = "Kubernetes namespace for LangSmith workloads"
+  default     = "langsmith"
+}
+
+# ── Backing services ──────────────────────────────────────────────────────────
+
+variable "use_external_postgres" {
+  type        = bool
+  description = "Create a Kubernetes secret for the external PostgreSQL connection URL"
+  default     = true
+}
+
+variable "postgres_connection_url" {
+  type        = string
+  description = "PostgreSQL connection URL (postgresql://user:pass@host:5432/db?sslmode=require). Required when use_external_postgres = true"
+  sensitive   = true
+  default     = ""
+}
+
+variable "postgres_admin_password" {
+  type        = string
+  description = "PostgreSQL admin password. Added as POSTGRES_PASSWORD to the postgres secret for listener-managed agent deployments."
+  sensitive   = true
+  default     = ""
+}
+
+variable "use_external_redis" {
+  type        = bool
+  description = "Create a Kubernetes secret for the external Redis connection URL"
+  default     = true
+}
+
+variable "redis_connection_url" {
+  type        = string
+  description = "Redis connection URL (rediss://:key@host:6380). Required when use_external_redis = true"
+  sensitive   = true
+  default     = ""
+}
+
+# ── Application secrets ───────────────────────────────────────────────────────
+# This module intentionally creates ONLY the Postgres/Redis connection secrets.
+# The app-config secret (license key, api_key_salt, jwt_secret, admin_password,
+# and the feature encryption keys) is created as `langsmith-config-secret` by
+# infra/scripts/create-k8s-secrets.sh, which reads every key from Key Vault and
+# uses the exact key names the LangSmith chart consumes via
+# config.existingSecretName. Keeping that set in the script (not Terraform)
+# avoids storing the full app-secret set in Terraform state. See DEPLOYMENT.md
+# Phase 3.5.
+
+# ── Ingress / KEDA versions ───────────────────────────────────────────────────
+
+variable "nginx_ingress_version" {
+  type        = string
+  description = "ingress-nginx Helm chart version. Empty string = resolve latest (pinning is recommended for reproducibility)."
+  default     = ""
+}
+
+variable "keda_version" {
+  type        = string
+  description = "KEDA Helm chart version"
+  default     = "2.14.0"
+}

--- a/modules/azure-private/bootstrap/outputs.tf
+++ b/modules/azure-private/bootstrap/outputs.tf
@@ -1,0 +1,9 @@
+output "ingress_namespace" {
+  description = "Kubernetes namespace where the NGINX ingress controller is deployed"
+  value       = "ingress-nginx"
+}
+
+output "note" {
+  description = "How to retrieve the internal ingress IP after apply"
+  value       = "Run: kubectl -n ingress-nginx get svc ingress-nginx-controller -o jsonpath='{.status.loadBalancer.ingress[0].ip}' — the IP is private and only reachable from within the hub-spoke network (e.g. from the jumpbox)."
+}

--- a/modules/azure-private/bootstrap/terraform.tfvars.example
+++ b/modules/azure-private/bootstrap/terraform.tfvars.example
@@ -1,0 +1,20 @@
+# bootstrap/terraform.tfvars.example
+#
+# Run this root FROM THE JUMPBOX after the infra/ root has been applied.
+# The jumpbox has network-level access to the private AKS API server.
+# The Terraform state for this root is independent of infra/ — there is no
+# shared remote state between the two roots.
+#
+# Steps:
+#   1. Apply modules/azure-private/infra first (provisions AKS, Key Vault, etc.)
+#   2. SSH to the jumpbox and clone this repo.
+#   3. cd modules/azure-private/bootstrap
+#   4. cp terraform.tfvars.example terraform.tfvars  && edit terraform.tfvars
+#   5. terraform init && terraform apply
+
+subscription_id     = "00000000-0000-0000-0000-000000000000"
+resource_group_name = "rg-langsmith-prod"
+
+# Suffix that was passed as `identifier` when applying infra/.
+# Leave empty ("") if infra was applied without an identifier.
+identifier = "-prod"

--- a/modules/azure-private/bootstrap/tests/bootstrap.tftest.hcl
+++ b/modules/azure-private/bootstrap/tests/bootstrap.tftest.hcl
@@ -1,0 +1,100 @@
+# Credential-free plan tests using mocked providers.
+# Run: terraform -chdir=modules/azure-private/bootstrap init -backend=false && \
+#      terraform -chdir=modules/azure-private/bootstrap test
+# Requires Terraform >= 1.7 (mock_provider) on the runner.
+
+mock_provider "azurerm" {}
+mock_provider "azapi" {}
+mock_provider "kubernetes" {}
+mock_provider "helm" {}
+
+# ── Run 1: NGINX ingress carries the internal-LB annotation ──────────────────
+# Plans the bootstrap root with mocked providers and data source overrides.
+# Asserts that the nginx helm_release is planned and that the langsmith
+# namespace resource is also planned. The cert/key/ca override values are
+# harmless base64 placeholders (no real key material is committed). The kubernetes
+# provider logs a benign "client_key is not a valid PEM" warning for the placeholder
+# key; the plan and the assertions below still pass.
+run "nginx_internal_lb_and_namespace" {
+  command = plan
+
+  # Override AKS data source — the mock generates a non-URL host by default.
+  # client_certificate, client_key, cluster_ca_certificate are base64 placeholders
+  # that base64decode() cleanly; the k8s-bootstrap module decodes them internally.
+  override_data {
+    target = data.azurerm_kubernetes_cluster.main
+    values = {
+      id   = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.ContainerService/managedClusters/langsmith-aks-test"
+      name = "langsmith-aks-test"
+      kube_config = [{
+        host                        = "https://langsmith-aks-test.privatelink.eastus.azmk8s.io:443"
+        client_certificate          = "ZHVtbXktY2VydA=="
+        client_key                  = "ZHVtbXkta2V5"
+        cluster_ca_certificate      = "ZHVtbXktY2E="
+        username                    = ""
+        password                    = ""
+        client_key_data             = ""
+        client_certificate_data     = ""
+        cluster_ca_certificate_data = ""
+      }]
+    }
+  }
+
+  # Override Key Vault data source — mock generates an ID that may not be a
+  # valid Azure resource path; the azurerm_key_vault_secret reads use it as
+  # key_vault_id so we provide a well-formed ID.
+  override_data {
+    target = data.azurerm_key_vault.main
+    values = {
+      id   = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.KeyVault/vaults/langsmith-kv-test"
+      name = "langsmith-kv-test"
+    }
+  }
+
+  # Override KV secret reads — mock returns empty string by default which
+  # is fine for plan; override ensures the value field is present.
+  override_data {
+    target = data.azurerm_key_vault_secret.postgres_url[0]
+    values = {
+      id    = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.KeyVault/vaults/langsmith-kv-test/secrets/postgres-connection-url"
+      value = "postgresql://lsadmin:pass@langsmith-pg-test.postgres.database.azure.com:5432/langsmith?sslmode=require"
+    }
+  }
+
+  override_data {
+    target = data.azurerm_key_vault_secret.redis_url[0]
+    values = {
+      id    = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.KeyVault/vaults/langsmith-kv-test/secrets/redis-connection-url"
+      value = "rediss://:key@langsmith-redis-test.redis.cache.windows.net:6380"
+    }
+  }
+
+  override_data {
+    target = data.azurerm_key_vault_secret.postgres_admin_password[0]
+    values = {
+      id    = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.KeyVault/vaults/langsmith-kv-test/secrets/postgres-admin-password"
+      value = "test-admin-password"
+    }
+  }
+
+  variables {
+    subscription_id     = "00000000-0000-0000-0000-000000000000"
+    resource_group_name = "test-rg"
+    identifier          = "-test"
+  }
+
+  # The nginx helm_release must be planned and must carry the internal-LB
+  # annotation. Resources inside the k8s-bootstrap module are referenced via
+  # module.k8s_bootstrap.
+  assert {
+    condition     = strcontains(module.k8s_bootstrap.nginx_ingress_values, "azure-load-balancer-internal")
+    error_message = "NGINX helm_release values must contain the internal-LB annotation (azure-load-balancer-internal)"
+  }
+
+  # The NGINX release should be planned — ingress_controller is hardcoded to "nginx"
+  # in main.tf so count=1. We verify via the ingress_namespace output.
+  assert {
+    condition     = output.ingress_namespace == "ingress-nginx"
+    error_message = "ingress_namespace output must equal 'ingress-nginx' when ingress_controller is nginx"
+  }
+}

--- a/modules/azure-private/bootstrap/variables.tf
+++ b/modules/azure-private/bootstrap/variables.tf
@@ -1,0 +1,64 @@
+# ── Required ───────────────────────────────────────────────────────────────────
+
+variable "subscription_id" {
+  type        = string
+  description = "Azure subscription ID containing the AKS cluster and Key Vault"
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "Name of the resource group that holds the AKS cluster, Key Vault, and managed identities (created by the infra root)"
+}
+
+# ── Naming ─────────────────────────────────────────────────────────────────────
+
+variable "identifier" {
+  type        = string
+  description = "Suffix appended to resource names (e.g. \"-dev\"). Must match the identifier used when applying the infra root."
+  default     = ""
+}
+
+# ── Key Vault ──────────────────────────────────────────────────────────────────
+
+variable "key_vault_name" {
+  type        = string
+  description = "Key Vault name. Defaults to 'langsmith-kv<identifier>' when empty."
+  default     = ""
+}
+
+# ── Namespace ─────────────────────────────────────────────────────────────────
+
+variable "langsmith_namespace" {
+  type        = string
+  description = "Kubernetes namespace for LangSmith workloads"
+  default     = "langsmith"
+}
+
+# ── Backing services ──────────────────────────────────────────────────────────
+
+variable "use_external_postgres" {
+  type        = bool
+  description = "Read postgres-connection-url and postgres-admin-password from Key Vault and pass them to the k8s-bootstrap module"
+  default     = true
+}
+
+variable "use_external_redis" {
+  type        = bool
+  description = "Read redis-connection-url from Key Vault and pass it to the k8s-bootstrap module"
+  default     = true
+}
+
+# ── Ingress / KEDA versions ───────────────────────────────────────────────────
+# Set only to pin a version at the root level; otherwise the module default is used.
+
+variable "nginx_ingress_version" {
+  type        = string
+  description = "ingress-nginx Helm chart version. Empty string (default) resolves the latest chart; pinning is recommended for reproducibility."
+  default     = ""
+}
+
+variable "keda_version" {
+  type        = string
+  description = "KEDA Helm chart version. Defaults to the k8s-bootstrap module default (2.14.0) when null."
+  default     = null
+}

--- a/modules/azure-private/bootstrap/versions.tf
+++ b/modules/azure-private/bootstrap/versions.tf
@@ -1,0 +1,30 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    azapi = {
+      source  = "azure/azapi"
+      version = "~> 2.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = "~> 2.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = "~> 2.0"
+    }
+  }
+}
+
+# AzureRM provider — subscription scoped to var.subscription_id.
+# Kubernetes and Helm providers are configured inside the k8s-bootstrap module
+# (fed from the AKS data source), so they are not declared at the root level.
+provider "azurerm" {
+  features {}
+  subscription_id = var.subscription_id
+}

--- a/modules/azure-private/infra/.terraform.lock.hcl
+++ b/modules/azure-private/infra/.terraform.lock.hcl
@@ -1,0 +1,84 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/azure/azapi" {
+  version     = "2.10.0"
+  constraints = "~> 2.0"
+  hashes = [
+    "h1:R6NYsRfXHXd5eNBFAG5gIyD8Um2nFgXiqB5Uz6vHAsA=",
+    "zh:1e6513c791c6be1389fc4acb8ffdd5127dbf0f479bd0c0074d3a5b69edee2faa",
+    "zh:2ad99c9b656a1d796f4f0ae50d98064af0e42915bbb5a9e5a8db68ca633eceb3",
+    "zh:455fcbfe38cf9181fbd78a6a4a1e43ccafbb606757f4142c99a8ce4d0c80b34c",
+    "zh:46dcafe5495aa50984fd393e72d18d59370fd6bb36b44a0c6c034b82644fc7b7",
+    "zh:5b2f0acff55ee9f8896e11b14d0538fc929d7eee0d68a15644751ca8b6cbc2fc",
+    "zh:61e231f5c6d300404e1010aff9634638c533ba2a7279b85df43cff3aec60f1a9",
+    "zh:68d0aefbd2baf276a034037d6e8b7b9049af42e5745a6db1cbc3311b79de0e6d",
+    "zh:8b12924ee9125266d6aee30a818c1d90403eefad82753b5cd70c8c20ddbd3c98",
+    "zh:92f5643c18c67d3c4bd1b03c02bc7069b24936b2cb5fca58fb998452dfa46e04",
+    "zh:a7aa502ba10433dbe6695a0b903d642153a99540e4eba2befe97e3902fd98093",
+    "zh:c3f8155d5b609fa336eb79c7b67b75076d9c31c94e53d2f3d2b2e66b58e1a73f",
+    "zh:e670ae37ed1813e8e475962a109652a15a054111b2b2428435deab884937ff1e",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "4.79.0"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:hEVrA2r7nS0jSd32CwsWNfifS8tV0xhoGuc1T9qU074=",
+    "zh:0129b3fa33289d54f86f150377b19127f85787116b7cc53564fed77c2e2468be",
+    "zh:131427cf40dd3fa4ec52af938b7ab0fd100bcacd75b7137c8e1ea5bf268c4638",
+    "zh:162ebd8f195ac28324d9e9f2e9b39a05d8a946abff21087a43123c83ca807a5d",
+    "zh:209a23777acdcfc674791a4ad37ba4e2110044857afb9db88aa305222fef706c",
+    "zh:21cf740e1fee936de429fa324b86af69c4fe90bbfdbb1f374e6a55118fdff841",
+    "zh:4ad1cde7ad4ef7187633b7fc7b0ed76ef2526b56fbb29f80a6fc54d07ac1204a",
+    "zh:57b942405b27af17cfad9a48d9e4ec75c0bb452f229dd132d6f1d8518ca4a067",
+    "zh:69a4fda56d6405027f303463f796a0d2d250403f67cecf2a25bcdfaeaf731630",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7c21524a423d95a4c84039e06a610f131c0618ee117da9c35e4b4f41d1210c64",
+    "zh:9045f6bb9f764709a5773d8ec65735f56c9995dc9c9ec3f85f2c6adf58654f3c",
+    "zh:e018581ed136640ba733ab583fd0072536b1bc096d66f2215787823cee6cfcdc",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/null" {
+  version     = "3.3.0"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:a14TKo7Xvg4W8+H1VA6p+oLZTLxVQnYUD8LOaOs14A8=",
+    "zh:021748b5ea3b5f6956f2e75c42c5cdc113b391fb98ac71364a4965d23b37000f",
+    "zh:3b27956f8541d46704fda234e0d535c2ae2a4b33411848b1ee262a1ec03568b0",
+    "zh:3de4ed47d6d0f4d8edba4a5092c7c9799950eda63989d8d0d2586e6afcb0aa20",
+    "zh:57ed8935c7d56dbc91cf2673534582cacfaab7a2f105f51d9f797e99df0c0c47",
+    "zh:58e176ba1d142827089e30e0711e007309a9f2726e8881986da5026e9778fdf4",
+    "zh:5949c4a3d4a93f841f155cdb7e991c087e637145c1630572e21948224f8f4923",
+    "zh:76d60f366b743003c1b085afa769b45b2198ee919927e45807d7d44fb42c067d",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:79cd1bab1261a07f84e917191d7ddc4340ac5f5524283767256f7ffd7f87caf0",
+    "zh:8ec9083038cf710b30e319eaa467c9df7fa52bbd9969b61053a35bc2cdd2e0a6",
+    "zh:a6e502cb579685ab7aeb886c2bb11ddd9cfed74b41008592d57cbc3351a9218b",
+    "zh:acb74d6b4f66ff6acfcda315df802a7432170ef3955c9b432cb4580767004006",
+    "zh:f0ce55d8d9ffdb33dab612b1246f9bab060a9d54fc32ce2b4a038646155660af",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/time" {
+  version     = "0.14.0"
+  constraints = "~> 0.10"
+  hashes = [
+    "h1:/hlxsUpuN/lvPTNL9+NyVGsOyRsK5NsxwFMsj5CdOp4=",
+    "zh:12abfd6b800e4d7fa6db7310dec8ffd440b31993861ef188c7ed5260b3073937",
+    "zh:23005521e800bb19e1597bf755c5f70d675d30b685d4255001ed5fa47d9df3f1",
+    "zh:2fea249b582ae97cd1cc10385187ea50993bb47c28cc5df0305e57ceaabf0a10",
+    "zh:322018d3b987b7aad08697178029a2bb667bed699e88328f0c89c52a2fd41341",
+    "zh:32a08e98fce2d273cb9b2c89d6c54727cc9f0a32e15bfd896be4e02cc6b48f95",
+    "zh:3db89aabd0e619616bd4b0f8b373a7586dfe60feffcea12a84a0bdbc445714b3",
+    "zh:7488f56c81d742dc020f29063626c8f07ca188aa97be61e7307e8d62397020a2",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7cb4067f2e7559b13f7562ef722f948950901eb37834873e98360ab28f66e9d7",
+    "zh:9d552c8345f61e1b7db8e725144981345f18ac1014d58d6f5ddf0928a195fffb",
+    "zh:a8e69fb6b97fc9d86fb19a9f4d42abe33c4a68e700b15387ce2e17d2b9934bed",
+    "zh:aeeb900eb8dd0f790c60ea5c0e0c8d42bd6e4a54f391681d4decca15b544394b",
+    "zh:c239c619101a8c95e1f14061eb973c57a8d15fa0e68878ced5bbd76858ee5b79",
+  ]
+}

--- a/modules/azure-private/infra/backend.tf.example
+++ b/modules/azure-private/infra/backend.tf.example
@@ -1,0 +1,8 @@
+terraform {
+  backend "azurerm" {
+    resource_group_name  = "my-terraform-state-rg"
+    storage_account_name = "myterraformstate"
+    container_name       = "tfstate"
+    key                  = "langsmith/azure/terraform.tfstate"
+  }
+}

--- a/modules/azure-private/infra/main.tf
+++ b/modules/azure-private/infra/main.tf
@@ -1,0 +1,280 @@
+# ══════════════════════════════════════════════════════════════════════════════
+# Module: langsmith (root / orchestration) — hardened always-BYO form
+# Purpose: Wires all sub-modules together in the correct dependency order to
+#          produce a full LangSmith deployment on Azure.
+#
+# Posture: Always BYO VNet/RG, CNI Overlay (Cilium), UDR egress, private API server.
+#
+# Deployment order (Terraform resolves via implicit dependencies):
+#   1. data.azurerm_resource_group.existing — must exist before everything else
+#   2. module.aks              — cluster needed for OIDC issuer URL (blob module)
+#      module.postgres         — parallel with AKS (both need VNet)
+#      module.redis            — parallel with AKS and postgres
+#   3. module.blob             — needs AKS OIDC issuer URL for federated creds
+#   4. module.keyvault         — needs blob managed identity principal ID for RBAC
+#
+# Deployment pattern (two-root split):
+#   Root 1 — this file (infra/): azurerm-only; runs from anywhere (no k8s/helm providers).
+#             terraform -chdir=infra apply
+#   Root 2 — bootstrap/: in-cluster (KEDA, NGINX, namespace, secrets).
+#             Run from the jumpbox AFTER the cluster is up.
+#             terraform -chdir=bootstrap apply
+# ══════════════════════════════════════════════════════════════════════════════
+
+locals {
+  identifier = var.identifier
+
+  # Always BYO resource group — looked up, never created. Region inherited from it.
+  resource_group_name = data.azurerm_resource_group.existing.name
+  resource_group_id   = data.azurerm_resource_group.existing.id
+  location            = data.azurerm_resource_group.existing.location
+
+  # Derived resource names — all prefixed with "langsmith-<identifier>"
+  vnet_name     = "langsmith-vnet${local.identifier}"
+  aks_name      = "langsmith-aks${local.identifier}"
+  postgres_name = "langsmith-postgres${local.identifier}"
+  redis_name    = "langsmith-redis${local.identifier}"
+  blob_name     = "langsmith-blob${local.identifier}" # blob module strips hyphens → "langsmithblobdz"
+
+  # Key Vault name: max 24 chars, globally unique.
+  # Uses the user-supplied keyvault_name or derives from identifier.
+  keyvault_name = var.keyvault_name != "" ? var.keyvault_name : "langsmith-kv${local.identifier}"
+
+  # Always BYO network — IDs supplied by the caller.
+  vnet_id            = var.vnet_id
+  aks_subnet_id      = var.aks_subnet_id
+  postgres_subnet_id = var.postgres_subnet_id
+  redis_subnet_id    = var.redis_subnet_id
+  bastion_subnet_id  = var.bastion_subnet_id
+
+  # ── Common tags ─────────────────────────────────────────────────────────────
+  # Applied to every Azure resource in every sub-module.
+  # Sub-modules merge their own { module = "..." } tag on top.
+  # Customize via the environment/owner/cost_center variables.
+  common_tags = merge(
+    {
+      environment = var.environment
+      project     = "langsmith"
+      managed_by  = "terraform"
+    },
+    var.owner != "" ? { owner = var.owner } : {},
+    var.cost_center != "" ? { cost_center = var.cost_center } : {}
+  )
+}
+
+# Existing resource group — resources deploy here; region taken from it.
+data "azurerm_resource_group" "existing" {
+  name = var.resource_group_name
+}
+
+# ── Kubernetes Cluster ────────────────────────────────────────────────────────
+# AKS cluster with OIDC + Workload Identity enabled (azurerm-only; no k8s/helm providers).
+# NGINX ingress, KEDA, and K8s secrets are installed by bootstrap/.
+# The OIDC issuer URL output is consumed by module.blob for federated credentials.
+
+module "aks" {
+  source              = "./modules/k8s-cluster"
+  cluster_name        = local.aks_name
+  location            = local.location
+  resource_group_name = local.resource_group_name
+  subnet_id           = local.aks_subnet_id
+  service_cidr        = var.aks_service_cidr   # K8s ClusterIP range (must not overlap VNet)
+  dns_service_ip      = var.aks_dns_service_ip # CoreDNS IP (must be within service_cidr)
+
+  # Network posture (overlay/cilium/UDR) is hardcoded inside the k8s-cluster module.
+  pod_cidr = var.aks_pod_cidr
+
+  default_node_pool_vm_size   = var.default_node_pool_vm_size
+  default_node_pool_min_count = var.default_node_pool_min_count
+  default_node_pool_max_count = var.default_node_pool_max_count
+  default_node_pool_max_pods  = var.default_node_pool_max_pods
+
+  # Additional pools (e.g. "large" for ClickHouse / memory-heavy workloads)
+  additional_node_pools = var.additional_node_pools
+
+  langsmith_namespace    = var.langsmith_namespace
+  langsmith_release_name = var.langsmith_release_name
+
+  # Preserve existing identity name when migrating from storage module.
+  # New deployments leave this unset and get "${cluster_name}-app-identity".
+  workload_identity_name = "k8s-app-identity"
+
+  availability_zones = var.availability_zones
+
+  # Private API server — always enabled (hardcoded inside k8s-cluster module).
+  private_cluster_public_fqdn_enabled = var.aks_private_cluster_public_fqdn_enabled
+  private_dns_zone_id                 = var.aks_private_dns_zone_id
+
+  # Control-plane identity: user-assigned by default (matches always-BYO posture).
+  create_cluster_identity = var.aks_create_cluster_identity
+  cluster_identity_id     = var.aks_cluster_identity_id
+
+  tags = local.common_tags
+}
+
+# ── PostgreSQL ────────────────────────────────────────────────────────────────
+# Managed PostgreSQL Flexible Server in a private subnet.
+# Only provisioned when postgres_source = "external".
+# When postgres_source = "in-cluster", the Helm chart manages its own Postgres pod.
+
+module "postgres" {
+  count               = var.postgres_source == "external" ? 1 : 0
+  source              = "./modules/postgres"
+  name                = local.postgres_name
+  location            = local.location
+  resource_group_name = local.resource_group_name
+  vnet_id             = local.vnet_id # needed to link the private DNS zone
+  subnet_id           = local.postgres_subnet_id
+
+  admin_username = var.postgres_admin_username
+  admin_password = var.postgres_admin_password
+  database_name  = var.postgres_database_name
+
+  availability_zone            = var.availability_zones[0]
+  standby_availability_zone    = var.postgres_standby_availability_zone
+  geo_redundant_backup_enabled = var.postgres_geo_redundant_backup
+
+  tags = local.common_tags
+}
+
+# ── Redis ─────────────────────────────────────────────────────────────────────
+# Managed Redis Cache (Premium) in a private subnet.
+# Only provisioned when redis_source = "external".
+# When redis_source = "in-cluster", the Helm chart manages its own Redis pod.
+
+module "redis" {
+  count               = var.redis_source == "external" ? 1 : 0
+  source              = "./modules/redis"
+  name                = local.redis_name
+  location            = local.location
+  resource_group_name = local.resource_group_name
+  resource_group_id   = local.resource_group_id # azapi parent_id for AMR
+  subnet_id           = local.redis_subnet_id   # private endpoint goes here
+  vnet_id             = local.vnet_id           # private DNS zone link
+  amr_sku             = var.amr_sku
+
+  tags = local.common_tags
+}
+
+# ── Blob Storage ──────────────────────────────────────────────────────────────
+# Azure Blob Storage for trace objects.
+# The Workload Identity (Managed Identity + Federated Credentials) is created
+# in the k8s-cluster module and passed in here for the RBAC role assignment.
+
+module "blob" {
+  source               = "./modules/storage"
+  storage_account_name = local.blob_name
+  container_name       = "${local.blob_name}-container"
+  location             = local.location
+  resource_group_name  = local.resource_group_name
+
+  ttl_enabled    = var.blob_ttl_enabled
+  ttl_short_days = var.blob_ttl_short_days
+  ttl_long_days  = var.blob_ttl_long_days
+
+  # Workload Identity from k8s-cluster module — implicit dep on module.aks.
+  workload_identity_principal_id = module.aks.workload_identity_principal_id
+  workload_identity_client_id    = module.aks.workload_identity_client_id
+
+  # Default-deny on the storage data plane. AKS pods reach blobs via the
+  # Microsoft.Storage service endpoint on the AKS subnet — enabling that
+  # service endpoint (and Microsoft.KeyVault) is the operator's responsibility
+  # as documented in the README prerequisites. Operators with extra clients
+  # (CI runners, jumpboxes) add their public IPs via var.storage_allowed_ips.
+  allowed_subnet_ids = [local.aks_subnet_id]
+  allowed_ips        = var.storage_allowed_ips
+
+  tags = local.common_tags
+}
+
+# ── Key Vault ─────────────────────────────────────────────────────────────────
+# Centralized secret storage for all LangSmith sensitive values.
+# Depends on blob module (needs the managed identity principal ID for RBAC).
+# Secrets stored here: postgres password, admin password, license key, JWT
+# secret, API key salt, and all Fernet encryption keys.
+#
+# First-apply: Key Vault is created and all current TF_VAR_* values are stored.
+# Subsequent applies: setup-env.sh reads from Key Vault instead of local files.
+
+module "keyvault" {
+  source              = "./modules/keyvault"
+  name                = local.keyvault_name
+  location            = local.location
+  resource_group_name = local.resource_group_name
+
+  # The managed identity used by LangSmith pods gets read-only access to
+  # all secrets so future CSI-driver integration requires no RBAC changes.
+  managed_identity_principal_id = module.blob.k8s_managed_identity_principal_id
+
+  # Network ACLs — default Allow keeps first-apply secret creation working.
+  # Production deployments override keyvault_default_action = "Deny" and
+  # populate keyvault_allowed_ips. The AKS subnet is always allowlisted so
+  # pods can read secrets via the Microsoft.KeyVault service endpoint.
+  network_default_action = var.keyvault_default_action
+  allowed_ips            = var.keyvault_allowed_ips
+  allowed_subnet_ids     = [local.aks_subnet_id]
+
+  # ── Secrets ─────────────────────────────────────────────────────────────────
+  # Values come from TF_VAR_* on first apply. setup-env.sh reads from Key Vault
+  # on subsequent applies, eliminating local .secret files.
+  postgres_admin_password  = var.postgres_admin_password
+  langsmith_admin_password = var.langsmith_admin_password
+  langsmith_license_key    = var.langsmith_license_key
+  langsmith_api_key_salt   = var.langsmith_api_key_salt
+  langsmith_jwt_secret     = var.langsmith_jwt_secret
+
+  langsmith_deployments_encryption_key   = var.langsmith_deployments_encryption_key
+  langsmith_agent_builder_encryption_key = var.langsmith_agent_builder_encryption_key
+  langsmith_insights_encryption_key      = var.langsmith_insights_encryption_key
+  langsmith_polly_encryption_key         = var.langsmith_polly_encryption_key
+
+  # Connection URLs — written to Key Vault so the bootstrap/ root can read them
+  # without this infra/ root needing kubernetes/helm providers.
+  postgres_connection_url = var.postgres_source == "external" ? module.postgres[0].connection_url : ""
+  redis_connection_url    = var.redis_source == "external" ? module.redis[0].connection_url : ""
+
+  purge_protection_enabled = var.keyvault_purge_protection
+
+  tags = local.common_tags
+
+  depends_on = [module.blob]
+}
+
+# ── Diagnostics ────────────────────────────────────────────────────────────────
+# Azure Monitor Log Analytics + diagnostic settings for AKS, Key Vault, Postgres.
+# Always created in the hardened posture.
+
+module "diagnostics" {
+  source              = "./modules/diagnostics"
+  name                = "langsmith-logs${local.identifier}"
+  resource_group_name = local.resource_group_name
+  location            = local.location
+  retention_days      = var.log_retention_days
+
+  aks_id      = module.aks.cluster_id
+  keyvault_id = module.keyvault.vault_id
+  postgres_id = var.postgres_source == "external" ? module.postgres[0].postgres_id : ""
+
+  # Boolean flags known at plan time — count cannot depend on computed resource IDs.
+  enable_aks_diag      = true
+  enable_keyvault_diag = true
+  enable_postgres_diag = var.postgres_source == "external"
+
+  tags = local.common_tags
+}
+
+# ── Bastion ────────────────────────────────────────────────────────────────────
+# Jump VM for private AKS cluster access. Uses Azure AD SSH login.
+# Always created in the hardened posture (required for private cluster access).
+
+module "bastion" {
+  source               = "./modules/bastion"
+  name                 = "langsmith-bastion${local.identifier}"
+  resource_group_name  = local.resource_group_name
+  location             = local.location
+  subnet_id            = local.bastion_subnet_id
+  vm_size              = var.bastion_vm_size
+  admin_ssh_public_key = var.bastion_admin_ssh_public_key
+  allowed_ssh_cidrs    = var.bastion_allowed_ssh_cidrs
+  tags                 = local.common_tags
+}

--- a/modules/azure-private/infra/modules/bastion/main.tf
+++ b/modules/azure-private/infra/modules/bastion/main.tf
@@ -1,0 +1,144 @@
+# ══════════════════════════════════════════════════════════════════════════════
+# Module: bastion
+# Purpose: Lightweight jump VM for private AKS cluster access.
+#
+# Uses Azure AD (Entra ID) SSH login — no static SSH keys needed.
+# Access model: az ssh vm -n <vm-name> -g <rg> (uses az CLI identity)
+# Pre-installs: kubectl, helm, azure CLI, jq, curl
+#
+# Equivalent to the AWS bastion EC2 module with SSM Session Manager access.
+# ══════════════════════════════════════════════════════════════════════════════
+
+# Public IP for the jump VM — static so the address doesn't change on restart.
+resource "azurerm_public_ip" "bastion" {
+  name                = "${var.name}-pip"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  allocation_method   = "Static"
+  sku                 = "Standard"
+  tags                = merge(var.tags, { module = "bastion" })
+}
+
+# Network interface for the jump VM.
+resource "azurerm_network_interface" "bastion" {
+  name                = "${var.name}-nic"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  tags                = merge(var.tags, { module = "bastion" })
+
+  ip_configuration {
+    name                          = "internal"
+    subnet_id                     = var.subnet_id
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = azurerm_public_ip.bastion.id
+  }
+}
+
+# NSG — restrict inbound SSH to specified CIDRs only.
+resource "azurerm_network_security_group" "bastion" {
+  name                = "${var.name}-nsg"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  tags                = merge(var.tags, { module = "bastion" })
+
+  security_rule {
+    name                       = "allow-ssh"
+    priority                   = 100
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "22"
+    source_address_prefixes    = var.allowed_ssh_cidrs
+    destination_address_prefix = "*"
+  }
+}
+
+resource "azurerm_network_interface_security_group_association" "bastion" {
+  network_interface_id      = azurerm_network_interface.bastion.id
+  network_security_group_id = azurerm_network_security_group.bastion.id
+}
+
+# Jump VM — Ubuntu LTS, Azure AD SSH login, no password auth.
+resource "azurerm_linux_virtual_machine" "bastion" {
+  name                            = var.name
+  resource_group_name             = var.resource_group_name
+  location                        = var.location
+  size                            = var.vm_size
+  admin_username                  = "azureadmin"
+  disable_password_authentication = true
+  tags                            = merge(var.tags, { module = "bastion" })
+
+  network_interface_ids = [azurerm_network_interface.bastion.id]
+
+  # System-assigned identity required for Azure AD SSH login extension.
+  identity {
+    type = "SystemAssigned"
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Premium_LRS"
+    disk_size_gb         = 30
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "0001-com-ubuntu-server-jammy"
+    sku       = "22_04-lts-gen2"
+    version   = "latest"
+  }
+
+  # Admin SSH key for initial emergency access (az ssh vm is the primary path).
+  admin_ssh_key {
+    username   = "azureadmin"
+    public_key = var.admin_ssh_public_key
+  }
+
+  # Cloud-init: install tooling required for LangSmith SA operations.
+  custom_data = base64encode(<<-EOF
+    #!/bin/bash
+    set -e
+    export DEBIAN_FRONTEND=noninteractive
+    apt-get update -qq
+
+    # kubectl
+    curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.32/deb/Release.key \
+      | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+    echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] \
+      https://pkgs.k8s.io/core:/stable:/v1.32/deb/ /" \
+      > /etc/apt/sources.list.d/kubernetes.list
+    apt-get update -qq && apt-get install -y kubectl
+
+    # Helm
+    curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
+    # Azure CLI
+    curl -fsSL https://aka.ms/InstallAzureCLIDeb | bash
+
+    # jq, curl
+    apt-get install -y jq curl
+
+    echo "Bastion tooling installed successfully." >> /var/log/bastion-init.log
+  EOF
+  )
+}
+
+# Azure AD SSH Login extension — enables `az ssh vm` without static keys.
+resource "azurerm_virtual_machine_extension" "aad_ssh" {
+  name                       = "AADSSHLoginForLinux"
+  virtual_machine_id         = azurerm_linux_virtual_machine.bastion.id
+  publisher                  = "Microsoft.Azure.ActiveDirectory"
+  type                       = "AADSSHLoginForLinux"
+  type_handler_version       = "1.0"
+  auto_upgrade_minor_version = true
+  tags                       = merge(var.tags, { module = "bastion" })
+}
+
+# Grant the VM's system identity "Virtual Machine Administrator Login" so
+# the AAD SSH extension can issue login tokens.
+resource "azurerm_role_assignment" "vm_admin_login" {
+  scope                = azurerm_linux_virtual_machine.bastion.id
+  role_definition_name = "Virtual Machine Administrator Login"
+  principal_id         = azurerm_linux_virtual_machine.bastion.identity[0].principal_id
+}

--- a/modules/azure-private/infra/modules/bastion/outputs.tf
+++ b/modules/azure-private/infra/modules/bastion/outputs.tf
@@ -1,0 +1,19 @@
+output "public_ip" {
+  description = "Public IP address of the bastion VM"
+  value       = azurerm_public_ip.bastion.ip_address
+}
+
+output "vm_id" {
+  description = "Resource ID of the bastion VM"
+  value       = azurerm_linux_virtual_machine.bastion.id
+}
+
+output "vm_name" {
+  description = "Name of the bastion VM"
+  value       = azurerm_linux_virtual_machine.bastion.name
+}
+
+output "ssh_command" {
+  description = "az CLI command to SSH into the bastion VM using Azure AD auth"
+  value       = "az ssh vm --name ${azurerm_linux_virtual_machine.bastion.name} --resource-group ${var.resource_group_name}"
+}

--- a/modules/azure-private/infra/modules/bastion/variables.tf
+++ b/modules/azure-private/infra/modules/bastion/variables.tf
@@ -1,0 +1,42 @@
+variable "name" {
+  type        = string
+  description = "Name of the bastion VM"
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "Resource group for the bastion VM"
+}
+
+variable "location" {
+  type        = string
+  description = "Azure region"
+}
+
+variable "subnet_id" {
+  type        = string
+  description = "ID of the bastion subnet"
+}
+
+variable "vm_size" {
+  type        = string
+  description = "Azure VM SKU for the bastion host"
+  default     = "Standard_B2s" # 2 vCPU, 4 GB RAM — adequate for kubectl/helm operations
+}
+
+variable "admin_ssh_public_key" {
+  type        = string
+  description = "SSH public key for emergency admin access (az ssh vm is the primary path)"
+}
+
+variable "allowed_ssh_cidrs" {
+  type        = list(string)
+  description = "CIDR ranges allowed inbound SSH access to the bastion. Restrict to corporate IP ranges."
+  default     = ["0.0.0.0/0"] # override in production — restrict to VPN/corporate CIDR
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Common Azure resource tags"
+  default     = {}
+}

--- a/modules/azure-private/infra/modules/diagnostics/main.tf
+++ b/modules/azure-private/infra/modules/diagnostics/main.tf
@@ -1,0 +1,74 @@
+# ══════════════════════════════════════════════════════════════════════════════
+# Module: diagnostics
+# Purpose: Azure Monitor Log Analytics workspace + diagnostic settings.
+#
+# Captures control-plane audit logs from:
+#   • AKS  — kube-audit, kube-apiserver, kube-scheduler, cluster-autoscaler
+#   • Key Vault — AuditEvent (who read/wrote secrets, and when)
+#   • PostgreSQL — PostgreSQLLogs (slow queries, failed auth)
+#
+# Equivalent to AWS CloudTrail for Azure. Required for SOC2 / enterprise
+# customers who need an immutable audit trail of infrastructure operations.
+# ══════════════════════════════════════════════════════════════════════════════
+
+# Log Analytics Workspace — the central sink for all diagnostic data.
+resource "azurerm_log_analytics_workspace" "main" {
+  name                = var.name
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  sku                 = "PerGB2018"
+  retention_in_days   = var.retention_days
+  tags                = merge(var.tags, { module = "diagnostics" })
+}
+
+# AKS diagnostic settings — captures control-plane logs.
+# kube-audit: every API server request (create, delete, exec, etc.)
+# kube-audit-admin: admin-level operations only (lower volume)
+# cluster-autoscaler: scale-up/scale-down decisions
+resource "azurerm_monitor_diagnostic_setting" "aks" {
+  count                      = var.enable_aks_diag ? 1 : 0
+  name                       = "${var.name}-aks-diag"
+  target_resource_id         = var.aks_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.main.id
+
+  enabled_log { category = "kube-audit" }
+  enabled_log { category = "kube-audit-admin" }
+  enabled_log { category = "kube-apiserver" }
+  enabled_log { category = "kube-scheduler" }
+  enabled_log { category = "cluster-autoscaler" }
+  enabled_log { category = "guard" }
+
+  enabled_metric {
+    category = "AllMetrics"
+  }
+}
+
+# Key Vault diagnostic settings — captures every secret read/write.
+# AuditEvent: who accessed which secret, from which IP, and the result.
+resource "azurerm_monitor_diagnostic_setting" "keyvault" {
+  count                      = var.enable_keyvault_diag ? 1 : 0
+  name                       = "${var.name}-kv-diag"
+  target_resource_id         = var.keyvault_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.main.id
+
+  enabled_log { category = "AuditEvent" }
+  enabled_log { category = "AzurePolicyEvaluationDetails" }
+
+  enabled_metric {
+    category = "AllMetrics"
+  }
+}
+
+# PostgreSQL diagnostic settings — captures slow queries and auth failures.
+resource "azurerm_monitor_diagnostic_setting" "postgres" {
+  count                      = var.enable_postgres_diag ? 1 : 0
+  name                       = "${var.name}-postgres-diag"
+  target_resource_id         = var.postgres_id
+  log_analytics_workspace_id = azurerm_log_analytics_workspace.main.id
+
+  enabled_log { category = "PostgreSQLLogs" }
+
+  enabled_metric {
+    category = "AllMetrics"
+  }
+}

--- a/modules/azure-private/infra/modules/diagnostics/outputs.tf
+++ b/modules/azure-private/infra/modules/diagnostics/outputs.tf
@@ -1,0 +1,15 @@
+output "workspace_id" {
+  description = "Resource ID of the Log Analytics workspace"
+  value       = azurerm_log_analytics_workspace.main.id
+}
+
+output "workspace_name" {
+  description = "Name of the Log Analytics workspace"
+  value       = azurerm_log_analytics_workspace.main.name
+}
+
+output "workspace_primary_key" {
+  description = "Primary shared key for the Log Analytics workspace"
+  value       = azurerm_log_analytics_workspace.main.primary_shared_key
+  sensitive   = true
+}

--- a/modules/azure-private/infra/modules/diagnostics/variables.tf
+++ b/modules/azure-private/infra/modules/diagnostics/variables.tf
@@ -1,0 +1,63 @@
+variable "name" {
+  type        = string
+  description = "Name of the Log Analytics workspace"
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "Resource group for the Log Analytics workspace"
+}
+
+variable "location" {
+  type        = string
+  description = "Azure region"
+}
+
+variable "retention_days" {
+  type        = number
+  description = "Log retention period in days (min 30, max 730)"
+  default     = 90
+}
+
+variable "aks_id" {
+  type        = string
+  description = "Resource ID of the AKS cluster to enable diagnostic settings on."
+  default     = ""
+}
+
+variable "keyvault_id" {
+  type        = string
+  description = "Resource ID of the Key Vault to enable diagnostic settings on."
+  default     = ""
+}
+
+variable "postgres_id" {
+  type        = string
+  description = "Resource ID of the PostgreSQL Flexible Server to enable diagnostic settings on."
+  default     = ""
+}
+
+# Boolean flags for count — must be known at plan time (cannot use computed IDs for count).
+variable "enable_aks_diag" {
+  type        = bool
+  description = "Whether to create the AKS diagnostic setting. Set to true when AKS is being created."
+  default     = true
+}
+
+variable "enable_keyvault_diag" {
+  type        = bool
+  description = "Whether to create the Key Vault diagnostic setting. Set to true when Key Vault is being created."
+  default     = true
+}
+
+variable "enable_postgres_diag" {
+  type        = bool
+  description = "Whether to create the PostgreSQL diagnostic setting. Set to true when postgres_source = external."
+  default     = false
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Common Azure resource tags"
+  default     = {}
+}

--- a/modules/azure-private/infra/modules/k8s-cluster/main.tf
+++ b/modules/azure-private/infra/modules/k8s-cluster/main.tf
@@ -1,0 +1,258 @@
+# ══════════════════════════════════════════════════════════════════════════════
+# Module: aks
+# Purpose: Azure Kubernetes Service cluster for running LangSmith workloads.
+#
+# Key design decisions (as-built — all hardcoded, not togglable):
+#   • Azure CNI Overlay + Cilium eBPF data plane (hardcoded): pods draw IPs
+#     from pod_cidr, not the VNet subnet — BYO subnets can be far smaller.
+#     network_plugin_mode = "overlay", network_policy = "cilium",
+#     network_data_plane = "cilium".
+#   • Private API server (hardcoded): private_cluster_enabled = true — the
+#     control-plane endpoint is a private IP only; apply must run from inside
+#     the VNet or a peered network that resolves the private DNS zone.
+#   • UDR egress (hardcoded): outbound_type = "userDefinedRouting" — all
+#     cluster egress is routed through the caller's route table / firewall.
+#   • Control-plane identity: user-assigned by default (create_cluster_identity
+#     defaults to true). The module creates the identity and grants it Network
+#     Contributor on the VNet before the cluster joins the subnet. Pass a BYO
+#     identity via cluster_identity_id for a custom API-server private DNS zone.
+#   • OIDC issuer + Workload Identity: allows Kubernetes service accounts to
+#     federate with Azure AD and assume Managed Identities — used by LangSmith
+#     pods to authenticate to Azure Blob Storage without static keys.
+#
+# Note: NGINX ingress, KEDA, and the K8s namespace/secrets are
+# NOT installed by this module. They are installed by the separate bootstrap/
+# root (run from the jumpbox after the cluster is up).
+# ══════════════════════════════════════════════════════════════════════════════
+
+locals {
+  # These MUST match the LangSmith chart's rendered ServiceAccount names
+  # (<release>-<component.name>) for the blob-accessing components. The chart
+  # derives them from each component's `name` value (e.g. fleetToolServer.name
+  # = "fleet-tool-server"), so keep this list in sync with the chart version you
+  # deploy — a mismatch means the pod's OIDC token has no federated credential
+  # and blob/Key Vault access silently fails.
+  service_accounts_for_workload_identity = [
+    "${var.langsmith_release_name}-backend",
+    "${var.langsmith_release_name}-platform-backend",
+    "${var.langsmith_release_name}-queue",
+    "${var.langsmith_release_name}-ingest-queue",
+    "${var.langsmith_release_name}-host-backend",
+    "${var.langsmith_release_name}-listener",
+    "${var.langsmith_release_name}-fleet-tool-server",
+    "${var.langsmith_release_name}-fleet-trigger-server",
+  ]
+
+  # Control-plane identity selection. Empty/false => system-assigned (default).
+  # create_cluster_identity => use the module-created user-assigned identity;
+  # otherwise a non-empty cluster_identity_id => use that BYO identity.
+  use_user_assigned_identity = var.create_cluster_identity || var.cluster_identity_id != ""
+  cluster_identity_id        = var.create_cluster_identity ? one(azurerm_user_assigned_identity.cluster[*].id) : var.cluster_identity_id
+
+  # VNet that owns the AKS subnet — derived by stripping the /subnets/<name>
+  # suffix. The module-created control-plane identity is granted Network
+  # Contributor at this VNet scope so it can both join the subnet and link
+  # the System private DNS zone (the zone link needs VNet-level permission
+  # in custom-DNS hub-spoke topologies).
+  cluster_vnet_id = join("/subnets/", slice(split("/subnets/", var.subnet_id), 0, 1))
+}
+
+# ── Control-plane (cluster) managed identity ───────────────────────────────────
+# Default is system-assigned (see the identity block in the cluster resource).
+# Set var.create_cluster_identity to have the module create a user-assigned
+# identity and grant it Network Contributor on the VNet (the parent of
+# var.subnet_id). VNet scope — not just the subnet — so the identity can both
+# join the subnet (Microsoft.Network/virtualNetworks/subnets/join/action) AND
+# link the System private DNS zone for a private cluster, which needs VNet-level
+# permission in custom-DNS hub-spoke topologies. Azure recommends a user-assigned
+# identity for BYO-VNet / UDR so the grant exists before the cluster joins the
+# subnet. For a custom API-server private DNS zone, pass an existing identity via
+# var.cluster_identity_id and pre-grant its roles (incl. Private DNS Zone
+# Contributor on the zone) yourself.
+resource "azurerm_user_assigned_identity" "cluster" {
+  count               = var.create_cluster_identity ? 1 : 0
+  name                = "${var.cluster_name}-cluster-identity"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  tags                = merge(var.tags, { module = "aks" })
+}
+
+resource "azurerm_role_assignment" "cluster_identity_vnet" {
+  count                = var.create_cluster_identity ? 1 : 0
+  scope                = local.cluster_vnet_id
+  role_definition_name = "Network Contributor"
+  principal_id         = azurerm_user_assigned_identity.cluster[0].principal_id
+}
+
+# Give the Network Contributor grant time to propagate before the cluster tries
+# to join the subnet (RBAC propagation is not instant). 60s is usually enough;
+# cluster provisioning adds further buffer.
+resource "time_sleep" "cluster_identity_rbac" {
+  count           = var.create_cluster_identity ? 1 : 0
+  create_duration = "60s"
+  depends_on      = [azurerm_role_assignment.cluster_identity_vnet]
+}
+
+# The AKS cluster — the Kubernetes control plane + node pools.
+# All LangSmith application pods, supporting tools (KEDA),
+# and the ingress controller run here.
+resource "azurerm_kubernetes_cluster" "main" {
+  name                = var.cluster_name
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  dns_prefix          = var.cluster_name
+  kubernetes_version  = var.kubernetes_version
+  tags                = merge(var.tags, { module = "aks" })
+
+  role_based_access_control_enabled = true
+
+  # Private API server: always enabled — the control-plane endpoint is a private
+  # IP reachable only from the VNet (or peered networks). The apply host must be
+  # able to REACH that private IP (DNS resolution alone is not enough) — run
+  # terraform from a bastion / self-hosted runner with VNet connectivity that
+  # can also resolve the private DNS zone.
+  private_cluster_enabled             = true
+  private_cluster_public_fqdn_enabled = var.private_cluster_public_fqdn_enabled
+  private_dns_zone_id                 = var.private_dns_zone_id != "" ? var.private_dns_zone_id : "System"
+
+  # OIDC issuer: exposes a discovery document at a well-known URL so Azure AD
+  # can verify tokens issued by this cluster. Required for Workload Identity.
+  oidc_issuer_enabled = true
+
+  # Workload Identity: enables the mutating webhook that injects the OIDC
+  # token into pods annotated with azure.workload.identity/use: "true".
+  workload_identity_enabled = true
+
+  # Default system node pool — runs kube-system, KEDA, NGINX,
+  # and LangSmith services that don't require extra resources.
+  default_node_pool {
+    name = "default"
+
+    # Standard_DS3_v2: 4 vCPU, 14 GB RAM — DSv2 family has broad quota availability.
+    # LangSmith backend requests 100m CPU / 500Mi; all pods use lightweight mode.
+    vm_size = var.default_node_pool_vm_size
+
+    # Cluster autoscaler scales between min_count and max_count based on pending pods.
+    auto_scaling_enabled = true
+    min_count            = var.default_node_pool_min_count
+    max_count            = var.default_node_pool_max_count
+
+    # Azure CNI default is 30 pods/node — too low for a full LangSmith deployment.
+    # Pass 2 alone deploys 17 pods; system pods (kube-system, KEDA) add ~15 more.
+    # Setting to 60 fits all passes on 1 node, avoiding autoscaler scale-out and vCPU quota pressure.
+    max_pods = var.default_node_pool_max_pods
+
+    # Nodes live in the main subnet; Azure CNI assigns pod IPs from this range.
+    vnet_subnet_id = var.subnet_id
+
+    # Temporary node pool name used during node pool upgrades/rotations.
+    # Required when auto_scaling_enabled = true and the pool is being replaced.
+    temporary_name_for_rotation = "defaulttmp"
+
+    zones = var.availability_zones
+  }
+
+  # Control-plane identity. Default: system-assigned (AKS manages its own
+  # identity for node VMs, ACR pulls, and node resource group operations).
+  # Opt-in user-assigned (var.create_cluster_identity or var.cluster_identity_id)
+  # for BYO-VNet / UDR / a custom API-server private DNS zone.
+  identity {
+    type         = local.use_user_assigned_identity ? "UserAssigned" : "SystemAssigned"
+    identity_ids = local.use_user_assigned_identity ? [local.cluster_identity_id] : null
+  }
+
+  # When the module creates the control-plane identity, wait for its Network
+  # Contributor grant on the subnet to propagate before joining the subnet.
+  # No-op (empty list) when using system-assigned or a BYO identity.
+  depends_on = [time_sleep.cluster_identity_rbac]
+
+  # Azure CNI Overlay + Cilium eBPF data plane + UDR egress — hardcoded.
+  # Overlay: pods get IPs from pod_cidr (not from the VNet subnet), so pod IPs
+  # do NOT consume subnet space — BYO subnets can be far smaller.
+  # Cilium: eBPF-native network policy (stronger than Azure NPM); requires overlay.
+  # UDR: all cluster egress is routed through the caller's route table / firewall.
+  # service_cidr and pod_cidr must NOT overlap the VNet or any peered network.
+  network_profile {
+    network_plugin      = "azure"
+    network_plugin_mode = "overlay"
+    network_policy      = "cilium"
+    network_data_plane  = "cilium"
+    pod_cidr            = var.pod_cidr
+    service_cidr        = var.service_cidr
+    dns_service_ip      = var.dns_service_ip
+    outbound_type       = "userDefinedRouting"
+  }
+
+  # Key Vault CSI Secrets Store driver — enables pods to mount secrets from
+  # Azure Key Vault as files or environment variables via SecretProviderClass.
+  # secret_rotation_enabled: the driver periodically re-reads secrets from KV
+  # and updates mounted volumes so pods see rotated values without a restart.
+  key_vault_secrets_provider {
+    secret_rotation_enabled  = true
+    secret_rotation_interval = "2m"
+  }
+
+  lifecycle {
+    # upgrade_settings change during rolling node upgrades; ignore to prevent
+    # drift between Terraform state and live cluster configuration.
+    # zones: AKS does not support changing zones on an existing node pool —
+    # it is only applied at creation time. Ignoring prevents forced recreation
+    # when availability_zones is set on an existing cluster.
+    ignore_changes = [
+      default_node_pool[0].upgrade_settings,
+      default_node_pool[0].zones,
+    ]
+  }
+}
+
+# Additional node pools for workloads that need different compute profiles.
+# Default: one "large" pool (Standard_DS4_v2, 8 vCPU / 28 GB) for ClickHouse
+# and other memory-intensive services. Scales 0→2 (scales to zero when idle).
+resource "azurerm_kubernetes_cluster_node_pool" "node_pool" {
+  for_each = var.additional_node_pools
+
+  name                  = each.key
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.main.id
+  vm_size               = each.value.vm_size
+  auto_scaling_enabled  = true
+  vnet_subnet_id        = var.subnet_id
+  min_count             = each.value.min_count
+  max_count             = each.value.max_count
+  tags                  = merge(var.tags, { module = "aks", pool = each.key })
+
+  # "User" mode: these pools run application workloads.
+  # "System" mode pools are reserved for system pods (kube-system).
+  mode = "User"
+
+  temporary_name_for_rotation = "${each.key}tmp"
+
+  lifecycle {
+    ignore_changes = [upgrade_settings]
+  }
+}
+
+# ── Workload Identity ─────────────────────────────────────────────────────────
+# User-Assigned Managed Identity for LangSmith pods.
+# Centralised here because the AKS OIDC issuer URL (needed for federated
+# credentials) is produced by this module. Having identity creation and
+# federation in the same place avoids circular dependency.
+resource "azurerm_user_assigned_identity" "k8s_app" {
+  name                = var.workload_identity_name != "" ? var.workload_identity_name : "${var.cluster_name}-app-identity"
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  tags                = merge(var.tags, { module = "aks" })
+}
+
+# Federated Identity Credentials — bind each LangSmith K8s service account to
+# the Managed Identity via OIDC. One credential per service account.
+resource "azurerm_federated_identity_credential" "k8s_app" {
+  for_each = toset(local.service_accounts_for_workload_identity)
+
+  name                      = "langsmith-federated-${each.value}"
+  user_assigned_identity_id = azurerm_user_assigned_identity.k8s_app.id
+
+  audience = ["api://AzureADTokenExchange"]
+  issuer   = azurerm_kubernetes_cluster.main.oidc_issuer_url
+  subject  = "system:serviceaccount:${var.langsmith_namespace}:${each.value}"
+}
+

--- a/modules/azure-private/infra/modules/k8s-cluster/outputs.tf
+++ b/modules/azure-private/infra/modules/k8s-cluster/outputs.tf
@@ -1,0 +1,35 @@
+output "cluster_id" {
+  description = "The ID of the AKS cluster"
+  value       = azurerm_kubernetes_cluster.main.id
+}
+
+output "cluster_name" {
+  description = "The name of the AKS cluster"
+  value       = azurerm_kubernetes_cluster.main.name
+}
+
+output "oidc_issuer_url" {
+  description = "The OIDC issuer URL of the AKS cluster, used for workload identity federation"
+  value       = azurerm_kubernetes_cluster.main.oidc_issuer_url
+}
+
+output "kube_config_raw" {
+  description = "Raw kubeconfig for the AKS cluster"
+  value       = azurerm_kubernetes_cluster.main.kube_config_raw
+  sensitive   = true
+}
+
+output "workload_identity_client_id" {
+  description = "Client ID of the User-Assigned Managed Identity for LangSmith pods (Workload Identity)"
+  value       = azurerm_user_assigned_identity.k8s_app.client_id
+}
+
+output "workload_identity_principal_id" {
+  description = "Principal (Object) ID of the Managed Identity — used by keyvault and storage modules for RBAC role assignments"
+  value       = azurerm_user_assigned_identity.k8s_app.principal_id
+}
+
+output "private_fqdn" {
+  description = "Private FQDN of the AKS API server (empty/null when the cluster is public)"
+  value       = azurerm_kubernetes_cluster.main.private_fqdn
+}

--- a/modules/azure-private/infra/modules/k8s-cluster/variables.tf
+++ b/modules/azure-private/infra/modules/k8s-cluster/variables.tf
@@ -1,0 +1,146 @@
+variable "resource_group_name" {
+  type        = string
+  description = "Resource group name of the cluster"
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "Name of the cluster"
+}
+
+variable "location" {
+  type        = string
+  description = "Location of the cluster"
+}
+
+variable "subnet_id" {
+  description = "The ID of the subnet where the AKS cluster will be deployed"
+  type        = string
+}
+
+variable "kubernetes_version" {
+  type        = string
+  description = "Kubernetes version of the cluster"
+  default     = "1.33" # 1.32 and below are LTS-only in eastus as of April 2026; use 1.33+ for standard tier
+}
+
+variable "default_node_pool_vm_size" {
+  type        = string
+  description = "VM size of the default node pool"
+  default     = "Standard_DS3_v2" # 4 vCPU, 14GB RAM — DSv2 family (60 free vCPUs in eastus)
+}
+
+variable "default_node_pool_min_count" {
+  type        = number
+  description = "Min count of the default node pool. Autoscaler never scales below this. Set to 3 for production — Pass 2 needs ~14.4 vCPU and 3× Standard_D8s_v3 provides 18,870m allocatable."
+  default     = 1
+}
+
+variable "default_node_pool_max_count" {
+  type        = number
+  description = "Max count of the default node pool"
+  default     = 10
+}
+
+variable "default_node_pool_max_pods" {
+  type        = number
+  description = "Max pods per node in the default node pool. AKS default is 30 (Azure CNI). LangSmith Pass 2 deploys ~17 pods; Pass 3 adds ~20 more. Set to 60 to fit a full multi-pass deployment on a single node without triggering autoscaler quota limits."
+  default     = 60
+}
+
+variable "service_cidr" {
+  type        = string
+  description = "Service CIDR of the cluster"
+  default     = "10.0.64.0/20"
+}
+
+variable "dns_service_ip" {
+  type        = string
+  description = "DNS service IP of the cluster"
+  default     = "10.0.64.10"
+}
+
+variable "additional_node_pools" {
+  type = map(object({
+    vm_size   = string
+    min_count = number
+    max_count = number
+  }))
+  description = "Node pools to be created"
+  default = {
+    large = {
+      vm_size   = "Standard_DS4_v2" # 8 vCPU, 28GB RAM — DSv2 family
+      min_count = 0
+      max_count = 2
+    }
+  }
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Common Azure resource tags to apply to all resources in this module"
+  default     = {}
+}
+
+variable "langsmith_namespace" {
+  type        = string
+  description = "Kubernetes namespace where LangSmith is deployed. Used for Workload Identity federation."
+  default     = "langsmith"
+}
+
+variable "langsmith_release_name" {
+  type        = string
+  description = "Helm release name for LangSmith. Used to generate federated identity credential subjects."
+  default     = "langsmith"
+}
+
+variable "workload_identity_name" {
+  type        = string
+  description = "Override the managed identity name. Set to the existing identity name when migrating from the storage module to avoid recreating it."
+  default     = ""
+}
+
+variable "availability_zones" {
+  type        = list(string)
+  description = "Availability zones for the default node pool. Use [\"1\",\"2\",\"3\"] for zone-redundant HA."
+  default     = ["1"]
+}
+
+# ── Network (Azure CNI Overlay + Cilium + UDR — hardcoded in main.tf) ─────────
+# pod_cidr is the only tunable: pods get IPs from this range (not from the VNet
+# subnet). Must not overlap the VNet, service_cidr, or any peered network.
+
+variable "pod_cidr" {
+  type        = string
+  description = "Pod CIDR for Azure CNI Overlay (network_plugin_mode = overlay). Must not overlap the VNet, service_cidr, or peered/on-prem ranges. Ignored in classic mode."
+  default     = "10.244.0.0/16"
+}
+
+# ── Private API server ────────────────────────────────────────────────────────
+# private_cluster_enabled is hardcoded true in main.tf (always private).
+
+variable "private_cluster_public_fqdn_enabled" {
+  type        = bool
+  description = "When private_cluster_enabled, also expose a public FQDN resolving to the private IP. Default false (public FQDN disabled). Ignored when the cluster is public."
+  default     = false
+}
+
+variable "private_dns_zone_id" {
+  type        = string
+  description = "Private DNS zone for the private API server. \"\" => \"System\" (AKS-managed zone). \"None\" => bring-your-own DNS. Or a private DNS zone resource ID (requires Private DNS Zone Contributor for the cluster identity + VNet link). Only used when private_cluster_enabled."
+  default     = ""
+}
+
+# ── Control-plane (cluster) managed identity ───────────────────────────────────
+
+variable "create_cluster_identity" {
+  type        = bool
+  description = "Create a user-assigned managed identity for the AKS control plane and grant it Network Contributor on the VNet (the parent of subnet_id) — VNet scope so it can both join the subnet and link the System private DNS zone for a private cluster. Default true (user-assigned by default). Set false ONLY when bringing your own via cluster_identity_id (mutually exclusive)."
+  default     = true
+}
+
+variable "cluster_identity_id" {
+  type        = string
+  description = "Resource ID of an existing user-assigned managed identity to use as the AKS control-plane identity. You manage its role assignments (Network Contributor on the VNet/subnet, Private DNS Zone Contributor on a custom private DNS zone). Mutually exclusive with create_cluster_identity. Empty => system-assigned."
+  default     = ""
+}

--- a/modules/azure-private/infra/modules/keyvault/main.tf
+++ b/modules/azure-private/infra/modules/keyvault/main.tf
@@ -1,0 +1,273 @@
+# ══════════════════════════════════════════════════════════════════════════════
+# Module: keyvault
+# Purpose: Azure Key Vault for centralized secret management.
+#
+# What this module does:
+#   1. Creates a Key Vault with RBAC authorization mode (not legacy access policies).
+#   2. Grants the Terraform deployer (current az login identity) the
+#      "Key Vault Secrets Officer" role to create and update secrets.
+#   3. Grants the LangSmith pod managed identity "Key Vault Secrets User"
+#      so K8s pods can read secrets at runtime via Workload Identity.
+#   4. Stores all LangSmith secrets: passwords, salts, JWT secret, and
+#      Fernet encryption keys for optional features.
+#
+# Security properties:
+#   • RBAC mode: access controlled by Azure role assignments, not vault-level
+#     access policies — auditable, revocable, least-privilege.
+#   • Soft delete (90 days): secrets survive accidental deletion.
+#   • Purge protection: vault cannot be permanently destroyed until retention
+#     period expires — prevents data loss from mistaken `terraform destroy`.
+#   • All secrets marked sensitive in Terraform outputs.
+#
+# First-apply note:
+#   Azure RBAC role assignments can take 1–3 minutes to propagate. If secret
+#   creation fails with a 403 "ForbiddenByRbac" error on the first apply,
+#   run `terraform apply` again — the second apply will succeed.
+# ══════════════════════════════════════════════════════════════════════════════
+
+# Current Azure identity running Terraform (az login user or service principal).
+# Used to grant the deployer permission to create/update Key Vault secrets.
+data "azurerm_client_config" "current" {}
+
+# ── Key Vault ─────────────────────────────────────────────────────────────────
+
+resource "azurerm_key_vault" "langsmith" {
+  name                = var.name
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  tenant_id           = data.azurerm_client_config.current.tenant_id
+  sku_name            = "standard"
+
+  # RBAC mode: access controlled by Azure role assignments on this vault's
+  # resource ID. Preferred over legacy access policies — more granular and
+  # auditable via Azure Activity Log.
+  rbac_authorization_enabled = true
+
+  # Soft delete: deleted secrets are retained for this many days before
+  # permanent removal. Once set, retention_days cannot be reduced.
+  soft_delete_retention_days = var.soft_delete_retention_days
+
+  # Purge protection: vault cannot be immediately destroyed after deletion.
+  # Set false for dev environments where you need to quickly destroy and recreate.
+  purge_protection_enabled = var.purge_protection_enabled
+
+  # Network ACLs gate the data plane (azurerm_key_vault_secret etc.). Default
+  # is "Allow" because the first apply creates ~10 secrets via the data plane
+  # and would be 403'd under "Deny" without an operator-supplied IP allowlist.
+  # Production deployments override default_action = "Deny" plus allowed_ips /
+  # allowed_subnet_ids. AKS pods reach KV via the Microsoft.KeyVault service
+  # endpoint on the AKS subnet (see networking module).
+  network_acls {
+    default_action             = var.network_default_action
+    bypass                     = "AzureServices"
+    ip_rules                   = var.allowed_ips
+    virtual_network_subnet_ids = var.allowed_subnet_ids
+  }
+
+  tags = merge(var.tags, { module = "keyvault" })
+}
+
+# ── RBAC: Terraform deployer ───────────────────────────────────────────────────
+# "Key Vault Secrets Officer" allows: create, read, update, delete, list secrets.
+# This grants the person running `terraform apply` full secret management rights.
+# For CI/CD pipelines, replace the object_id with a dedicated service principal.
+
+resource "azurerm_role_assignment" "terraform_kv_admin" {
+  scope                = azurerm_key_vault.langsmith.id
+  role_definition_name = "Key Vault Secrets Officer"
+  principal_id         = data.azurerm_client_config.current.object_id
+}
+
+# ── RBAC: Pod managed identity ─────────────────────────────────────────────────
+# "Key Vault Secrets User" allows: read (get) secrets only.
+# LangSmith pods use Workload Identity to assume this managed identity and
+# read secrets at runtime — currently used by setup-env.sh, and ready for
+# the CSI Secrets Store driver in Phase 2.
+
+resource "azurerm_role_assignment" "managed_identity_kv_reader" {
+  scope                = azurerm_key_vault.langsmith.id
+  role_definition_name = "Key Vault Secrets User"
+  principal_id         = var.managed_identity_principal_id
+}
+
+# ── Wait for RBAC propagation ──────────────────────────────────────────────────
+# Azure RBAC role assignments propagate within 1–3 minutes. Without this wait
+# the first `terraform apply` would fail with 403 when creating secrets.
+# Subsequent applies skip this (the role already exists).
+
+resource "time_sleep" "wait_for_rbac" {
+  create_duration = "30s"
+  depends_on      = [azurerm_role_assignment.terraform_kv_admin]
+}
+
+# ── Secrets ───────────────────────────────────────────────────────────────────
+# All sensitive values stored here survive rotation: each secret has full
+# version history, audit log, and can be read by any authorized principal
+# (setup-env.sh, CI/CD pipelines, future CSI driver).
+#
+# Naming convention: kebab-case, matching the TF variable names.
+# setup-env.sh reads these by name: az keyvault secret show --name <name>
+
+resource "azurerm_key_vault_secret" "postgres_admin_password" {
+  name         = "postgres-admin-password"
+  value        = var.postgres_admin_password
+  key_vault_id = azurerm_key_vault.langsmith.id
+  content_type = "text/plain"
+  tags         = merge(var.tags, { component = "postgres", module = "keyvault" })
+
+  depends_on = [time_sleep.wait_for_rbac]
+}
+
+resource "azurerm_key_vault_secret" "langsmith_api_key_salt" {
+  name         = "langsmith-api-key-salt"
+  value        = var.langsmith_api_key_salt
+  key_vault_id = azurerm_key_vault.langsmith.id
+  content_type = "text/plain"
+
+  # CRITICAL: Changing this value invalidates ALL existing LangSmith API keys.
+  # The lifecycle ignore_changes ensures Terraform never updates this after creation
+  # even if the variable value changes. Rotate only deliberately via the CLI:
+  #   az keyvault secret set --vault-name <vault> --name langsmith-api-key-salt --value <new>
+  lifecycle {
+    ignore_changes = [value]
+  }
+
+  tags       = merge(var.tags, { component = "langsmith", stability = "critical", module = "keyvault" })
+  depends_on = [time_sleep.wait_for_rbac]
+}
+
+resource "azurerm_key_vault_secret" "langsmith_jwt_secret" {
+  name         = "langsmith-jwt-secret"
+  value        = var.langsmith_jwt_secret
+  key_vault_id = azurerm_key_vault.langsmith.id
+  content_type = "text/plain"
+
+  # CRITICAL: Changing this invalidates all active LangSmith user sessions.
+  lifecycle {
+    ignore_changes = [value]
+  }
+
+  tags       = merge(var.tags, { component = "langsmith", stability = "critical", module = "keyvault" })
+  depends_on = [time_sleep.wait_for_rbac]
+}
+
+resource "azurerm_key_vault_secret" "langsmith_admin_password" {
+  count        = var.langsmith_admin_password != "" ? 1 : 0
+  name         = "langsmith-admin-password"
+  value        = var.langsmith_admin_password
+  key_vault_id = azurerm_key_vault.langsmith.id
+  content_type = "text/plain"
+  tags         = merge(var.tags, { component = "langsmith", module = "keyvault" })
+
+  depends_on = [time_sleep.wait_for_rbac]
+}
+
+resource "azurerm_key_vault_secret" "langsmith_license_key" {
+  count        = var.langsmith_license_key != "" ? 1 : 0
+  name         = "langsmith-license-key"
+  value        = var.langsmith_license_key
+  key_vault_id = azurerm_key_vault.langsmith.id
+  content_type = "text/plain"
+  tags         = merge(var.tags, { component = "langsmith", module = "keyvault" })
+
+  depends_on = [time_sleep.wait_for_rbac]
+}
+
+resource "azurerm_key_vault_secret" "deployments_encryption_key" {
+  count        = var.langsmith_deployments_encryption_key != "" ? 1 : 0
+  name         = "langsmith-deployments-encryption-key"
+  value        = var.langsmith_deployments_encryption_key
+  key_vault_id = azurerm_key_vault.langsmith.id
+  content_type = "text/plain"
+
+  # CRITICAL: Changing this key corrupts all encrypted LangGraph deployment data.
+  lifecycle {
+    ignore_changes = [value]
+  }
+
+  tags       = merge(var.tags, { component = "deployments", stability = "critical", module = "keyvault" })
+  depends_on = [time_sleep.wait_for_rbac]
+}
+
+resource "azurerm_key_vault_secret" "agent_builder_encryption_key" {
+  count        = var.langsmith_agent_builder_encryption_key != "" ? 1 : 0
+  name         = "langsmith-agent-builder-encryption-key"
+  value        = var.langsmith_agent_builder_encryption_key
+  key_vault_id = azurerm_key_vault.langsmith.id
+  content_type = "text/plain"
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+
+  tags       = merge(var.tags, { component = "agent-builder", stability = "critical", module = "keyvault" })
+  depends_on = [time_sleep.wait_for_rbac]
+}
+
+resource "azurerm_key_vault_secret" "insights_encryption_key" {
+  count        = var.langsmith_insights_encryption_key != "" ? 1 : 0
+  name         = "langsmith-insights-encryption-key"
+  value        = var.langsmith_insights_encryption_key
+  key_vault_id = azurerm_key_vault.langsmith.id
+  content_type = "text/plain"
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+
+  tags       = merge(var.tags, { component = "insights", stability = "critical", module = "keyvault" })
+  depends_on = [time_sleep.wait_for_rbac]
+}
+
+resource "azurerm_key_vault_secret" "polly_encryption_key" {
+  count        = var.langsmith_polly_encryption_key != "" ? 1 : 0
+  name         = "langsmith-polly-encryption-key"
+  value        = var.langsmith_polly_encryption_key
+  key_vault_id = azurerm_key_vault.langsmith.id
+  content_type = "text/plain"
+
+  lifecycle {
+    ignore_changes = [value]
+  }
+
+  tags       = merge(var.tags, { component = "polly", stability = "critical", module = "keyvault" })
+  depends_on = [time_sleep.wait_for_rbac]
+}
+
+# ── Connection URL secrets (read by bootstrap/ root via CSI Secrets Store) ────
+# Stored here so the separate bootstrap/ root can retrieve them from Key Vault
+# without the infra/ root needing kubernetes/helm providers.
+
+resource "azurerm_key_vault_secret" "postgres_connection_url" {
+  count        = var.postgres_connection_url != "" ? 1 : 0
+  name         = "postgres-connection-url"
+  value        = var.postgres_connection_url
+  key_vault_id = azurerm_key_vault.langsmith.id
+  content_type = "text/plain"
+
+  # Connection URLs may be regenerated by the infra root on subsequent applies
+  # (e.g. Postgres password rotation). Ignore after initial creation so the
+  # bootstrap/ root always reads the live value from Key Vault, not TF state.
+  lifecycle {
+    ignore_changes = [value]
+  }
+
+  tags       = merge(var.tags, { component = "postgres", module = "keyvault" })
+  depends_on = [time_sleep.wait_for_rbac]
+}
+
+resource "azurerm_key_vault_secret" "redis_connection_url" {
+  count        = var.redis_connection_url != "" ? 1 : 0
+  name         = "redis-connection-url"
+  value        = var.redis_connection_url
+  key_vault_id = azurerm_key_vault.langsmith.id
+  content_type = "text/plain"
+
+  # See postgres_connection_url lifecycle note above.
+  lifecycle {
+    ignore_changes = [value]
+  }
+
+  tags       = merge(var.tags, { component = "redis", module = "keyvault" })
+  depends_on = [time_sleep.wait_for_rbac]
+}

--- a/modules/azure-private/infra/modules/keyvault/outputs.tf
+++ b/modules/azure-private/infra/modules/keyvault/outputs.tf
@@ -1,0 +1,14 @@
+output "vault_id" {
+  value       = azurerm_key_vault.langsmith.id
+  description = "Resource ID of the Key Vault"
+}
+
+output "vault_name" {
+  value       = azurerm_key_vault.langsmith.name
+  description = "Name of the Key Vault — used by setup-env.sh to read/write secrets"
+}
+
+output "vault_uri" {
+  value       = azurerm_key_vault.langsmith.vault_uri
+  description = "URI of the Key Vault (https://<name>.vault.azure.net/)"
+}

--- a/modules/azure-private/infra/modules/keyvault/variables.tf
+++ b/modules/azure-private/infra/modules/keyvault/variables.tf
@@ -1,0 +1,144 @@
+variable "name" {
+  type        = string
+  description = "Key Vault name. Must be globally unique, 3-24 chars, alphanumeric + hyphens. e.g. 'langsmith-kv-prod'"
+}
+
+variable "location" {
+  type        = string
+  description = "Azure region"
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "Resource group to deploy the Key Vault into"
+}
+
+# ── RBAC ──────────────────────────────────────────────────────────────────────
+
+variable "managed_identity_principal_id" {
+  type        = string
+  description = "Principal ID of the user-assigned managed identity used by LangSmith K8s pods. Gets 'Key Vault Secrets User' role to read secrets at runtime."
+}
+
+# ── Vault configuration ───────────────────────────────────────────────────────
+
+variable "soft_delete_retention_days" {
+  type        = number
+  description = "Days to retain deleted Key Vault and secrets (7–90). Cannot be reduced after creation."
+  default     = 90
+}
+
+variable "purge_protection_enabled" {
+  type        = bool
+  description = "Prevent permanent deletion of the vault during the soft-delete retention period. Recommended true for production; set false for dev environments where you need to destroy and recreate quickly."
+  default     = true
+}
+
+variable "network_default_action" {
+  type        = string
+  description = "Default action for the Key Vault data-plane firewall. \"Allow\" (default) keeps the starter UX working — Terraform's first apply creates ~10 secrets via the data plane and \"Deny\" without operator IP allowlisting blocks that. Production deployments set \"Deny\" and populate allowed_ips / allowed_subnet_ids."
+  default     = "Allow"
+
+  validation {
+    condition     = contains(["Allow", "Deny"], var.network_default_action)
+    error_message = "network_default_action must be 'Allow' or 'Deny'."
+  }
+}
+
+variable "allowed_ips" {
+  type        = list(string)
+  description = "Public IPs / CIDRs allowed through the Key Vault firewall when network_default_action = \"Deny\". Operator workstations, CI runners, or jumpboxes that legitimately need to call the data plane."
+  default     = []
+}
+
+variable "allowed_subnet_ids" {
+  type        = list(string)
+  description = "Subnet IDs allowlisted via the Microsoft.KeyVault service endpoint. Typically the AKS subnet so pods can read secrets while the rest of the internet is denied. The subnet must have service_endpoints = [\"Microsoft.KeyVault\", ...] configured."
+  default     = []
+}
+
+# ── Secrets ───────────────────────────────────────────────────────────────────
+
+variable "postgres_admin_password" {
+  type        = string
+  description = "PostgreSQL administrator password"
+  sensitive   = true
+}
+
+variable "langsmith_admin_password" {
+  type        = string
+  description = "LangSmith UI admin account password"
+  sensitive   = true
+  default     = ""
+}
+
+variable "langsmith_license_key" {
+  type        = string
+  description = "LangSmith enterprise license key"
+  sensitive   = true
+  default     = ""
+}
+
+variable "langsmith_api_key_salt" {
+  type        = string
+  description = "Salt used to hash LangSmith API keys. Keep stable — changing it invalidates all existing API keys."
+  sensitive   = true
+}
+
+variable "langsmith_jwt_secret" {
+  type        = string
+  description = "JWT signing secret for LangSmith sessions. Keep stable."
+  sensitive   = true
+}
+
+variable "langsmith_deployments_encryption_key" {
+  type        = string
+  description = "Fernet encryption key for LangGraph Platform deployments. Empty = not stored."
+  sensitive   = true
+  default     = ""
+}
+
+variable "langsmith_agent_builder_encryption_key" {
+  type        = string
+  description = "Fernet encryption key for Agent Builder. Empty = not stored."
+  sensitive   = true
+  default     = ""
+}
+
+variable "langsmith_insights_encryption_key" {
+  type        = string
+  description = "Fernet encryption key for LangSmith Insights. Empty = not stored."
+  sensitive   = true
+  default     = ""
+}
+
+variable "langsmith_polly_encryption_key" {
+  type        = string
+  description = "Fernet encryption key for Polly agent. Empty = not stored."
+  sensitive   = true
+  default     = ""
+}
+
+# ── Connection URLs (written for bootstrap/ root to read via CSI driver) ──────
+
+variable "postgres_connection_url" {
+  type        = string
+  description = "PostgreSQL connection URL. Written to Key Vault so the bootstrap/ root can read it. Empty = not stored."
+  sensitive   = true
+  default     = ""
+}
+
+variable "redis_connection_url" {
+  type        = string
+  description = "Redis connection URL. Written to Key Vault so the bootstrap/ root can read it. Empty = not stored."
+  sensitive   = true
+  default     = ""
+}
+
+# ── Tags ──────────────────────────────────────────────────────────────────────
+
+variable "tags" {
+  type        = map(string)
+  description = "Common Azure resource tags to apply to all resources in this module"
+  default     = {}
+}

--- a/modules/azure-private/infra/modules/keyvault/versions.tf
+++ b/modules/azure-private/infra/modules/keyvault/versions.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.10"
+    }
+  }
+}

--- a/modules/azure-private/infra/modules/postgres/main.tf
+++ b/modules/azure-private/infra/modules/postgres/main.tf
@@ -1,0 +1,150 @@
+# ══════════════════════════════════════════════════════════════════════════════
+# Module: postgres
+# Purpose: Azure PostgreSQL Flexible Server for LangSmith — private access only.
+#
+# Key design decisions:
+#   • Flexible Server (not Single Server): better performance, more configuration
+#     options, and is the current Azure standard.
+#   • public_network_access_enabled = false: database is ONLY reachable via the
+#     private endpoint — no internet exposure.
+#   • Private Endpoint (not VNet injection): PE is compatible with
+#     userDefinedRouting (UDR / 0.0.0.0/0 → firewall) egress, which VNet
+#     injection (delegated_subnet_id) is not. The PE drops a private NIC in any
+#     regular subnet; no delegation required.
+#   • Private DNS zone: resolves <server>.postgres.database.azure.com to the
+#     PE private IP via the dns_zone_group auto-registration.
+#   • Required extensions pre-enabled: LangSmith's backend needs PGCRYPTO
+#     (hashing), BTREE_GIN/PG_TRGM/BTREE_GIST (text search indexes), CITEXT
+#     (case-insensitive text). These must be allow-listed before first use.
+# ══════════════════════════════════════════════════════════════════════════════
+
+# PostgreSQL Flexible Server — the primary relational database for LangSmith.
+# Stores: runs, traces, feedback, users, orgs, API keys, workspace config.
+#
+# Default SKU: GP_Standard_D2ds_v4 = 2 vCPU, 8 GB RAM (General Purpose).
+# Upgrade to GP_Standard_D4ds_v4 (4 vCPU, 16 GB) for production workloads.
+resource "azurerm_postgresql_flexible_server" "db" {
+  name                = var.name
+  resource_group_name = var.resource_group_name
+  location            = var.location
+  version             = var.postgres_version
+
+  storage_mb   = var.storage_mb   # default 32 GB; auto-grow not enabled — size upfront
+  storage_tier = var.storage_tier # P4 = premium SSD, consistent IOPS
+  sku_name     = var.sku_name
+
+  administrator_login    = var.admin_username
+  administrator_password = var.admin_password
+
+  # Private Endpoint mode (not VNet injection). No delegated_subnet_id and no
+  # private_dns_zone_id here — those select VNet integration, which is mutually
+  # exclusive with a private endpoint and is unsupported with UDR (0.0.0.0/0 ->
+  # firewall) egress. Reachability is provided by the private endpoint below.
+  public_network_access_enabled = false
+
+  zone                         = var.availability_zone
+  geo_redundant_backup_enabled = var.geo_redundant_backup_enabled
+
+  dynamic "high_availability" {
+    for_each = var.standby_availability_zone != "" ? [1] : []
+    content {
+      mode                      = "ZoneRedundant"
+      standby_availability_zone = var.standby_availability_zone
+    }
+  }
+
+  tags = merge(var.tags, { module = "postgres" })
+
+  lifecycle {
+    # Azure may move the server to a different availability zone during
+    # maintenance. Ignore zone drift to prevent unnecessary plan noise.
+    ignore_changes = [zone]
+  }
+}
+
+# LangSmith application database.
+# Azure Flexible Server does not auto-create application databases — only
+# the 'postgres' system database exists by default. LangSmith requires
+# a database named after var.database_name to exist before the backend
+# can connect.
+resource "azurerm_postgresql_flexible_server_database" "langsmith" {
+  name      = var.database_name
+  server_id = azurerm_postgresql_flexible_server.db.id
+  charset   = "UTF8"
+  collation = "en_US.utf8"
+}
+
+# Private DNS zone for PostgreSQL name resolution within the VNet.
+# Resolves: <server-name>.postgres.database.azure.com → private IP.
+# Without this zone, AKS pods cannot resolve the database hostname.
+resource "azurerm_private_dns_zone" "db_dns_zone" {
+  name                = "privatelink.postgres.database.azure.com"
+  resource_group_name = var.resource_group_name
+  tags                = merge(var.tags, { module = "postgres" })
+}
+
+# Link the private DNS zone to the VNet so that all resources in the VNet
+# (including AKS pods) can resolve the PostgreSQL private hostname.
+# registration_enabled = false: we don't want auto-registration of VM names.
+resource "azurerm_private_dns_zone_virtual_network_link" "dns_zone_vnet_link" {
+  name                  = "${var.name}-link"
+  resource_group_name   = var.resource_group_name
+  private_dns_zone_name = azurerm_private_dns_zone.db_dns_zone.name
+  virtual_network_id    = var.vnet_id
+  registration_enabled  = false
+  tags                  = merge(var.tags, { module = "postgres" })
+}
+
+# Private Endpoint into the BYO postgres subnet — gives VNet-only reachability
+# without VNet injection. The endpoint's A record is auto-registered in the
+# privatelink zone via the dns_zone_group, so <name>.postgres.database.azure.com
+# resolves to the PE private IP for any VNet linked to the zone.
+resource "azurerm_private_endpoint" "db" {
+  name                = "${var.name}-pe"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  subnet_id           = var.subnet_id
+
+  private_service_connection {
+    name                           = "${var.name}-psc"
+    private_connection_resource_id = azurerm_postgresql_flexible_server.db.id
+    subresource_names              = ["postgresqlServer"]
+    is_manual_connection           = false
+  }
+
+  private_dns_zone_group {
+    name                 = "postgres"
+    private_dns_zone_ids = [azurerm_private_dns_zone.db_dns_zone.id]
+  }
+
+  tags = merge(var.tags, { module = "postgres" })
+}
+
+# Allow-list PostgreSQL extensions that LangSmith requires.
+# These must be enabled at the server level before any extension can be
+# created inside the database with CREATE EXTENSION.
+#   PGCRYPTO   — password/token hashing (gen_random_bytes, crypt)
+#   BTREE_GIN  — GIN indexes on btree-compatible columns (multi-column search)
+#   PG_TRGM    — trigram-based fuzzy text search (run/trace name search)
+#   BTREE_GIST — GiST indexes for range queries
+#   CITEXT     — case-insensitive text type (email lookups)
+resource "azurerm_postgresql_flexible_server_configuration" "extensions" {
+  name      = "azure.extensions"
+  server_id = azurerm_postgresql_flexible_server.db.id
+  value     = "PGCRYPTO,BTREE_GIN,PG_TRGM,BTREE_GIST,CITEXT"
+}
+
+# Increase max_connections from the default (which scales with RAM).
+# LangSmith runs multiple services (backend, platform-backend, queue) each
+# maintaining a connection pool. Default is often too low under load.
+resource "azurerm_postgresql_flexible_server_configuration" "max_connections" {
+  name      = "max_connections"
+  server_id = azurerm_postgresql_flexible_server.db.id
+  value     = var.max_connections
+
+  # Flexible Server serializes configuration operations — applying this in
+  # parallel with the azure.extensions update races and fails the second one
+  # with "ServerIsBusy" on a first apply. Serialize them so one finishes before
+  # the next starts.
+  depends_on = [azurerm_postgresql_flexible_server_configuration.extensions]
+}

--- a/modules/azure-private/infra/modules/postgres/outputs.tf
+++ b/modules/azure-private/infra/modules/postgres/outputs.tf
@@ -1,0 +1,14 @@
+output "postgres_id" {
+  description = "Resource ID of the PostgreSQL Flexible Server — used by the diagnostics module for diagnostic settings"
+  value       = azurerm_postgresql_flexible_server.db.id
+}
+
+output "connection_url" {
+  description = "The connection URL for the PostgreSQL Flexible Server"
+  sensitive   = true
+  # urlencode() percent-encodes every URL-reserved character in the password (@ / : ! …)
+  # so the userinfo section can't be mis-parsed — same approach the redis module uses.
+  # ?sslmode=require — Flexible Server enforces TLS; the chart's example connection
+  # string includes this, so make it explicit rather than relying on client defaults.
+  value = "postgresql://${azurerm_postgresql_flexible_server.db.administrator_login}:${urlencode(azurerm_postgresql_flexible_server.db.administrator_password)}@${azurerm_postgresql_flexible_server.db.name}.postgres.database.azure.com:5432/${var.database_name}?sslmode=require"
+}

--- a/modules/azure-private/infra/modules/postgres/variables.tf
+++ b/modules/azure-private/infra/modules/postgres/variables.tf
@@ -1,0 +1,94 @@
+variable "name" {
+  description = "The name of the PostgreSQL Flexible Server"
+  type        = string
+}
+
+variable "location" {
+  description = "The location of the PostgreSQL Flexible Server"
+  type        = string
+}
+
+variable "resource_group_name" {
+  description = "The name of the resource group"
+  type        = string
+}
+
+variable "vnet_id" {
+  description = "The ID of the VNet to link to the private DNS zone"
+  type        = string
+}
+
+variable "subnet_id" {
+  description = "Subnet for the PostgreSQL private endpoint. A regular subnet with a spare IP — NOT delegated to Microsoft.DBforPostgreSQL (that is VNet injection, which this module does not use)."
+  type        = string
+}
+
+variable "max_connections" {
+  description = "The maximum number of connections to the database"
+  type        = number
+  default     = "200"
+}
+
+variable "postgres_version" {
+  description = "The version of PostgreSQL to use"
+  type        = string
+  default     = "14"
+}
+
+variable "storage_mb" {
+  description = "The storage size of the database"
+  type        = number
+  default     = 32768
+}
+
+variable "storage_tier" {
+  description = "The storage tier of the database"
+  type        = string
+  default     = "P4"
+}
+
+variable "sku_name" {
+  description = "The SKU name of the database"
+  type        = string
+  default     = "GP_Standard_D2ds_v4"
+}
+
+variable "admin_username" {
+  description = "The username of the PostgreSQL Flexible Server administrator"
+  type        = string
+}
+
+variable "admin_password" {
+  description = "The password of the PostgreSQL Flexible Server administrator"
+  type        = string
+}
+
+variable "database_name" {
+  description = "The name of the LangSmith database to create and connect to"
+  type        = string
+  default     = "langsmith"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Common Azure resource tags to apply to all resources in this module"
+  default     = {}
+}
+
+variable "availability_zone" {
+  type        = string
+  description = "Primary availability zone for the Postgres server (\"1\", \"2\", or \"3\")"
+  default     = "1"
+}
+
+variable "standby_availability_zone" {
+  type        = string
+  description = "Standby availability zone for HA. Leave empty to disable zone-redundant HA."
+  default     = ""
+}
+
+variable "geo_redundant_backup_enabled" {
+  type        = bool
+  description = "Enable geo-redundant backups. Requires paired Azure region support."
+  default     = false
+}

--- a/modules/azure-private/infra/modules/redis/main.tf
+++ b/modules/azure-private/infra/modules/redis/main.tf
@@ -1,0 +1,109 @@
+# ══════════════════════════════════════════════════════════════════════════════
+# Module: redis
+# Purpose: Azure Managed Redis (AMR) for LangSmith — private access only.
+#
+# Replaces classic Azure Cache for Redis (azurerm_redis_cache), which is retiring
+# ("Creation of new Azure Cache for Redis Enterprise resources is no longer
+# supported"). AMR = Microsoft.Cache/redisEnterprise, provisioned via azapi because
+# the Balanced_* SKUs aren't reliably exposed by the azurerm provider yet.
+#
+# Networking parity with the old classic module ("private access only"):
+#   classic used VNet subnet INJECTION; AMR doesn't support that, so the private
+#   equivalent is a Private Endpoint into the same redis subnet + a private DNS zone.
+#
+# Connection: rediss://:<url-encoded key>@<host>:10000 (TLS, OSS clustering policy).
+# LangSmith connects via redis.external.clusterSafeMode (standalone client to the
+# endpoint hostname — the cert matches the hostname; cluster node IPs would not).
+# ══════════════════════════════════════════════════════════════════════════════
+
+# AMR cluster — Balanced SKU, TLS 1.2, no public access (private endpoint only).
+resource "azapi_resource" "amr" {
+  type      = "Microsoft.Cache/redisEnterprise@2025-07-01"
+  name      = var.name
+  location  = var.location
+  parent_id = var.resource_group_id
+
+  body = {
+    sku = { name = var.amr_sku }
+    properties = {
+      minimumTlsVersion = "1.2"
+      # Required at API 2025-07-01. Private-endpoint-only — no public access.
+      publicNetworkAccess = "Disabled"
+      # HA (zone redundancy) is unsupported on the smallest (B0) SKU.
+      highAvailability = var.high_availability ? "Enabled" : "Disabled"
+    }
+  }
+
+  response_export_values = ["properties.hostName"]
+  tags                   = merge(var.tags, { module = "redis" })
+
+  # azapi's bundled schema lags behind AMR (Balanced SKU / highAvailability). The
+  # body matches what `az redisenterprise create` accepts — let ARM validate at apply.
+  schema_validation_enabled = false
+}
+
+# AMR database — OSS clustering policy, TLS (Encrypted) on port 10000, key auth on.
+resource "azapi_resource" "amr_db" {
+  type      = "Microsoft.Cache/redisEnterprise/databases@2025-07-01"
+  name      = "default"
+  parent_id = azapi_resource.amr.id
+
+  body = {
+    properties = {
+      clientProtocol           = "Encrypted"
+      port                     = 10000
+      clusteringPolicy         = var.clustering_policy
+      accessKeysAuthentication = "Enabled"
+    }
+  }
+
+  schema_validation_enabled = false
+}
+
+# Primary access key — used to build the connection URL.
+resource "azapi_resource_action" "amr_keys" {
+  type        = "Microsoft.Cache/redisEnterprise/databases@2025-07-01"
+  resource_id = azapi_resource.amr_db.id
+  action      = "listKeys"
+
+  response_export_values = ["primaryKey"]
+}
+
+# ── Private access (parity with classic's "private only") ─────────────────────
+# AMR can't inject into a subnet, so a Private Endpoint in the same redis subnet +
+# a private DNS zone give equivalent VNet-only reachability. The endpoint hostname
+# (*.redis.azure.net) resolves to the PE's private IP via this zone.
+resource "azurerm_private_dns_zone" "redis" {
+  name                = "privatelink.redis.azure.net"
+  resource_group_name = var.resource_group_name
+  tags                = merge(var.tags, { module = "redis" })
+}
+
+resource "azurerm_private_dns_zone_virtual_network_link" "redis" {
+  name                  = "${var.name}-dnslink"
+  resource_group_name   = var.resource_group_name
+  private_dns_zone_name = azurerm_private_dns_zone.redis.name
+  virtual_network_id    = var.vnet_id
+  tags                  = merge(var.tags, { module = "redis" })
+}
+
+resource "azurerm_private_endpoint" "redis" {
+  name                = "${var.name}-pe"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  subnet_id           = var.subnet_id
+
+  private_service_connection {
+    name                           = "${var.name}-psc"
+    private_connection_resource_id = azapi_resource.amr.id
+    subresource_names              = ["redisEnterprise"]
+    is_manual_connection           = false
+  }
+
+  private_dns_zone_group {
+    name                 = "redis"
+    private_dns_zone_ids = [azurerm_private_dns_zone.redis.id]
+  }
+
+  tags = merge(var.tags, { module = "redis" })
+}

--- a/modules/azure-private/infra/modules/redis/outputs.tf
+++ b/modules/azure-private/infra/modules/redis/outputs.tf
@@ -1,0 +1,14 @@
+output "connection_url" {
+  # AMR endpoint over TLS, OSS cluster, port 10000. Key is URL-encoded because AMR
+  # access keys contain +, /, = which would otherwise break the rediss:// URL.
+  value       = "rediss://:${urlencode(azapi_resource_action.amr_keys.output.primaryKey)}@${azapi_resource.amr.output.properties.hostName}:10000"
+  description = "Redis (AMR) connection string using TLS"
+  sensitive   = true
+}
+
+output "cluster_safe_mode" {
+  # AMR is always an OSS cluster — LangSmith must connect as a standalone client to
+  # the endpoint (redis.external.clusterSafeMode: true), not a cluster client.
+  value       = true
+  description = "Whether LangSmith should set redis.external.clusterSafeMode (true for AMR)"
+}

--- a/modules/azure-private/infra/modules/redis/variables.tf
+++ b/modules/azure-private/infra/modules/redis/variables.tf
@@ -1,0 +1,53 @@
+variable "name" {
+  type        = string
+  description = "Name of the Azure Managed Redis cluster"
+}
+
+variable "location" {
+  type        = string
+  description = "Location of the Redis instance"
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "Resource group name (for the private endpoint + DNS zone)"
+}
+
+variable "resource_group_id" {
+  type        = string
+  description = "Resource group ID — azapi parent_id for the AMR cluster"
+}
+
+variable "subnet_id" {
+  type        = string
+  description = "Subnet ID for the AMR private endpoint (the dedicated redis subnet)"
+}
+
+variable "vnet_id" {
+  type        = string
+  description = "VNet ID — linked to the private DNS zone so the hostname resolves to the PE"
+}
+
+variable "amr_sku" {
+  type        = string
+  description = "Azure Managed Redis SKU. Balanced_B0 is the smallest. See `az redisenterprise create -h` for the list."
+  default     = "Balanced_B0"
+}
+
+variable "clustering_policy" {
+  type        = string
+  description = "AMR clustering policy. OSSCluster is what LangSmith expects."
+  default     = "OSSCluster"
+}
+
+variable "high_availability" {
+  type        = bool
+  description = "Zone-redundant HA. NOT supported on the smallest (B0) SKU — keep false there."
+  default     = false
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Common Azure resource tags to apply to all resources in this module"
+  default     = {}
+}

--- a/modules/azure-private/infra/modules/redis/versions.tf
+++ b/modules/azure-private/infra/modules/redis/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_providers {
+    # AMR cluster/database are provisioned via azapi (Balanced SKUs not in azurerm yet).
+    # Source must be declared here — it's Azure/azapi, not the default hashicorp/azapi.
+    azapi = {
+      source  = "Azure/azapi"
+      version = "~> 2.0"
+    }
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+  }
+}

--- a/modules/azure-private/infra/modules/storage/main.tf
+++ b/modules/azure-private/infra/modules/storage/main.tf
@@ -1,0 +1,114 @@
+# ══════════════════════════════════════════════════════════════════════════════
+# Module: blob
+# Purpose: Azure Blob Storage for LangSmith trace data.
+#
+# LangSmith writes raw trace blobs (inputs/outputs, attachments) to blob storage
+# rather than PostgreSQL to keep the database lean. Two TTL tiers:
+#   ttl_s/ prefix  — short-lived traces, deleted after 14 days  (default)
+#   ttl_l/ prefix  — long-lived  traces, deleted after 400 days (default)
+#
+# Authentication approach — Workload Identity (no static keys):
+#   The User-Assigned Managed Identity and Federated Identity Credentials are
+#   created in the k8s-cluster module (which owns the OIDC issuer). This module
+#   receives the identity IDs via var.workload_identity_principal_id and
+#   var.workload_identity_client_id and grants the identity Storage Blob Data
+#   Contributor on this account.
+# ══════════════════════════════════════════════════════════════════════════════
+
+# Azure Storage Account — the container for LangSmith trace blobs.
+# Storage account names must be globally unique, lowercase alphanumeric, 3-24 chars.
+# replace() strips hyphens from the input name to satisfy Azure naming rules.
+# Standard LRS: locally-redundant storage — adequate for trace data.
+# Upgrade to ZRS or GRS in Stage 3 for higher durability.
+resource "azurerm_storage_account" "storage_account" {
+  name                     = replace(var.storage_account_name, "-", "")
+  resource_group_name      = var.resource_group_name
+  location                 = var.location
+  account_tier             = "Standard"
+  account_replication_type = "LRS" # Stage 3: consider ZRS or RA-GRS
+  tags                     = merge(var.tags, { module = "blob" })
+
+  # Default-deny on the storage data plane (blob anonymous/SharedKey traffic).
+  # Terraform itself uses the management plane (azurerm_storage_account /
+  # azurerm_storage_container with storage_account_id / azurerm_storage_management_policy)
+  # so it is unaffected by this rule. Runtime AKS pods reach the account via
+  # the Microsoft.Storage service endpoint added to the AKS subnet (see the
+  # networking module) — that subnet is allowlisted via virtual_network_subnet_ids.
+  network_rules {
+    default_action             = "Deny"
+    bypass                     = ["AzureServices"]
+    ip_rules                   = var.allowed_ips
+    virtual_network_subnet_ids = var.allowed_subnet_ids
+  }
+}
+
+# Blob container — private container that holds all LangSmith trace objects.
+# Access is private: only the Managed Identity (via Workload Identity) can read/write.
+# Objects are organized by prefix: ttl_s/ (short-lived) and ttl_l/ (long-lived).
+resource "azurerm_storage_container" "container" {
+  name                  = var.container_name
+  storage_account_id    = azurerm_storage_account.storage_account.id
+  container_access_type = "private"
+}
+
+# Grant the Managed Identity permission to read and write blobs.
+# "Storage Blob Data Contributor" allows: read, write, delete blobs.
+# Scoped to the storage account (not the container) for flexibility.
+# The identity is created in the k8s-cluster module and passed in via variable.
+resource "azurerm_role_assignment" "blob_data_contributor" {
+  principal_id         = var.workload_identity_principal_id
+  role_definition_name = "Storage Blob Data Contributor"
+  scope                = azurerm_storage_account.storage_account.id
+}
+
+# Lifecycle management policy — automatic blob deletion based on age and prefix.
+# This keeps storage costs bounded without manual cleanup.
+#
+# Rule "base":    delete ttl_s/* blobs after N days (default: 14)  — traces that
+#                 the user hasn't explicitly kept long-term
+# Rule "extended": delete ttl_l/* blobs after N days (default: 400) — traces
+#                  explicitly marked for long retention (~13 months)
+resource "azurerm_storage_management_policy" "lifecycle_policy" {
+  count              = var.ttl_enabled ? 1 : 0
+  storage_account_id = azurerm_storage_account.storage_account.id
+
+  rule {
+    name    = "base"
+    enabled = true
+    filters {
+      prefix_match = ["${var.container_name}/ttl_s"]
+      blob_types   = ["blockBlob"]
+    }
+    actions {
+      base_blob {
+        delete_after_days_since_creation_greater_than = var.ttl_short_days
+      }
+      snapshot {
+        delete_after_days_since_creation_greater_than = var.ttl_short_days
+      }
+      version {
+        delete_after_days_since_creation = var.ttl_short_days
+      }
+    }
+  }
+
+  rule {
+    name    = "extended"
+    enabled = true
+    filters {
+      prefix_match = ["${var.container_name}/ttl_l"]
+      blob_types   = ["blockBlob"]
+    }
+    actions {
+      base_blob {
+        delete_after_days_since_creation_greater_than = var.ttl_long_days
+      }
+      snapshot {
+        delete_after_days_since_creation_greater_than = var.ttl_long_days
+      }
+      version {
+        delete_after_days_since_creation = var.ttl_long_days
+      }
+    }
+  }
+}

--- a/modules/azure-private/infra/modules/storage/outputs.tf
+++ b/modules/azure-private/infra/modules/storage/outputs.tf
@@ -1,0 +1,16 @@
+output "storage_account_name" {
+  value = azurerm_storage_account.storage_account.name
+}
+
+output "container_name" {
+  value = azurerm_storage_container.container.name
+}
+
+output "k8s_managed_identity_client_id" {
+  value = var.workload_identity_client_id
+}
+
+output "k8s_managed_identity_principal_id" {
+  description = "Object ID of the managed identity — used by the keyvault module to grant Key Vault Secrets User role"
+  value       = var.workload_identity_principal_id
+}

--- a/modules/azure-private/infra/modules/storage/variables.tf
+++ b/modules/azure-private/infra/modules/storage/variables.tf
@@ -1,0 +1,65 @@
+variable "storage_account_name" {
+  type        = string
+  description = "Name of the storage account"
+}
+
+variable "container_name" {
+  type        = string
+  description = "Name of the container"
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "Resource group name of the storage account"
+}
+
+variable "location" {
+  type        = string
+  description = "Location of the storage account"
+}
+
+variable "ttl_enabled" {
+  type        = bool
+  description = "Whether to enable time to live for blobs by adding a lifecycle policy"
+  default     = true
+}
+
+variable "ttl_short_days" {
+  type        = number
+  description = "Time to live for short-lived blobs in days"
+  default     = 14
+}
+
+variable "ttl_long_days" {
+  type        = number
+  description = "Time to live for long-lived blobs in days"
+  default     = 400
+}
+
+variable "workload_identity_principal_id" {
+  type        = string
+  description = "Principal ID of the User-Assigned Managed Identity created by the k8s-cluster module. Granted Storage Blob Data Contributor on this account."
+}
+
+variable "workload_identity_client_id" {
+  type        = string
+  description = "Client ID of the User-Assigned Managed Identity. Passed through as an output for k8s-bootstrap annotation."
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Common Azure resource tags to apply to all resources in this module"
+  default     = {}
+}
+
+variable "allowed_ips" {
+  type        = list(string)
+  description = "Public IPs / CIDRs allowed through the default-deny storage firewall. Add operator workstations, CI runner egress, or other clients that legitimately need to reach the data plane. AKS pod traffic uses a service endpoint allowlist (allowed_subnet_ids), not this list."
+  default     = []
+}
+
+variable "allowed_subnet_ids" {
+  type        = list(string)
+  description = "Subnet IDs allowlisted via the Microsoft.Storage service endpoint. Typically the AKS subnet so pods can reach the blob data plane while the rest of the internet is denied. The subnet must have service_endpoints = [\"Microsoft.Storage\", ...] configured."
+  default     = []
+}

--- a/modules/azure-private/infra/outputs.tf
+++ b/modules/azure-private/infra/outputs.tf
@@ -1,0 +1,133 @@
+output "postgres_connection_url" {
+  description = "PostgreSQL connection URL. Empty when postgres_source = 'in-cluster'."
+  sensitive   = true
+  value       = var.postgres_source == "external" ? module.postgres[0].connection_url : ""
+}
+
+output "redis_connection_url" {
+  description = "Redis connection URL. Empty when redis_source = 'in-cluster'."
+  sensitive   = true
+  value       = var.redis_source == "external" ? module.redis[0].connection_url : ""
+}
+
+output "redis_cluster_safe_mode" {
+  description = "Whether LangSmith should set redis.external.clusterSafeMode (true for AMR). init-values.sh reads this."
+  value       = var.redis_source == "external" ? module.redis[0].cluster_safe_mode : false
+}
+
+output "storage_account_name" {
+  description = "Azure Blob Storage account name used for LangSmith traces and assets"
+  value       = module.blob.storage_account_name
+}
+
+output "storage_container_name" {
+  description = "Blob container name within the storage account"
+  value       = module.blob.container_name
+}
+
+# See: https://docs.langchain.com/langsmith/self-host-blob-storage
+output "storage_account_k8s_managed_identity_client_id" {
+  description = "Client ID of the managed identity used by the LangSmith backend pod to access Blob Storage via Workload Identity"
+  value       = module.blob.k8s_managed_identity_client_id
+}
+
+# ── Resource group ────────────────────────────────────────────────────────────
+
+output "resource_group_name" {
+  description = "Name of the Azure resource group containing all LangSmith resources"
+  value       = local.resource_group_name
+}
+
+# ── AKS cluster ───────────────────────────────────────────────────────────────
+
+output "aks_cluster_name" {
+  description = "Name of the AKS cluster"
+  value       = module.aks.cluster_name
+}
+
+output "aks_cluster_id" {
+  description = "Resource ID of the AKS cluster"
+  value       = module.aks.cluster_id
+}
+
+output "aks_oidc_issuer_url" {
+  description = "OIDC issuer URL of the AKS cluster (used for Workload Identity federation)"
+  value       = module.aks.oidc_issuer_url
+}
+
+output "aks_private_fqdn" {
+  description = "Private FQDN of the AKS API server. Reach it from a host with VNet connectivity that can resolve the private DNS zone."
+  value       = module.aks.private_fqdn
+}
+
+output "kubeconfig" {
+  description = "Raw kubeconfig for connecting to the AKS cluster. Run: terraform output -raw kubeconfig > ~/.kube/config"
+  sensitive   = true
+  value       = module.aks.kube_config_raw
+}
+
+# ── LangSmith ─────────────────────────────────────────────────────────────────
+
+output "langsmith_url" {
+  description = "URL where LangSmith is accessible."
+  value       = var.langsmith_domain != "" ? "https://${var.langsmith_domain}" : "Set langsmith_domain and point your DNS at the internal ingress IP"
+}
+
+output "langsmith_admin_email" {
+  description = "Initial LangSmith org admin email — set via setup-env.sh, used as initialOrgAdminEmail in Helm values."
+  value       = var.langsmith_admin_email
+}
+
+output "langsmith_namespace" {
+  description = "Kubernetes namespace where LangSmith is deployed"
+  value       = var.langsmith_namespace
+}
+
+# ── Bootstrap-facing outputs (consumed by the separate bootstrap/ root) ────────
+
+output "key_vault_name" {
+  description = "Name of the Key Vault — passed to the bootstrap/ root so it can read secrets via the CSI driver"
+  value       = module.keyvault.vault_name
+}
+
+output "workload_identity_client_id" {
+  description = "Client ID of the User-Assigned Managed Identity for LangSmith pods (Workload Identity)"
+  value       = module.aks.workload_identity_client_id
+}
+
+output "get_credentials_command" {
+  description = "Run this command to configure kubectl for this cluster"
+  value       = "az aks get-credentials --resource-group ${local.resource_group_name} --name ${module.aks.cluster_name} --overwrite-existing"
+}
+
+# ── Key Vault ─────────────────────────────────────────────────────────────────
+
+output "keyvault_name" {
+  description = "Name of the Key Vault holding all LangSmith secrets. Pass to setup-env.sh via LANGSMITH_KEYVAULT_NAME."
+  value       = module.keyvault.vault_name
+}
+
+output "keyvault_uri" {
+  description = "URI of the Key Vault (https://<name>.vault.azure.net/)"
+  value       = module.keyvault.vault_uri
+}
+
+# ── Diagnostics ───────────────────────────────────────────────────────────────
+
+output "log_analytics_workspace_id" {
+  description = "Log Analytics workspace resource ID"
+  value       = module.diagnostics.workspace_id
+}
+
+# ── Bastion ───────────────────────────────────────────────────────────────────
+
+output "bastion_public_ip" {
+  description = "Public IP of the bastion jump VM"
+  value       = module.bastion.public_ip
+}
+
+output "bastion_ssh_command" {
+  description = "az CLI command to SSH into the bastion VM"
+  value       = module.bastion.ssh_command
+}
+

--- a/modules/azure-private/infra/scripts/_common.sh
+++ b/modules/azure-private/infra/scripts/_common.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+# MIT License - Copyright (c) 2026 LangChain, Inc.
+# NOTICE: Actively being tested and subject to change. Not officially supported by LangChain.
+# See LICENSE at the root of this repository for full license text.
+
+# _common.sh — Shared helpers for Azure LangSmith scripts.
+#
+# Usage: source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_common.sh"
+#
+# Provides:
+#   _parse_tfvar <key>        — Read a value from terraform.tfvars
+#   _tfvar_is_true <key>      — Return 0 if tfvar == true
+#   Color helpers: _bold, _green, _red, _yellow, _cyan, _dim
+#   Status helpers: pass, warn, fail, skip, info, header, action
+
+# ── Resolve INFRA_DIR ────────────────────────────────────────────────────────
+# Assumes this script lives in infra/scripts/. Consumers that live elsewhere
+# should override INFRA_DIR after sourcing.
+_COMMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INFRA_DIR="${INFRA_DIR:-$_COMMON_DIR/..}"
+
+# ── terraform.tfvars parser ──────────────────────────────────────────────────
+_parse_tfvar() {
+  local key="$1"
+  local tfvars_file="${INFRA_DIR:-$(pwd)}/terraform.tfvars"
+  local raw val
+  raw=$(grep -E "^\s*${key}\s*=" "$tfvars_file" 2>/dev/null | head -1) || return 1
+  [[ -n "$raw" ]] || return 1
+  # Quoted string: key = "value"
+  val=$(echo "$raw" | sed -n 's/.*=[[:space:]]*"\([^"]*\)".*/\1/p' | tr -d '[:space:]')
+  if [[ -z "$val" ]]; then
+    # Unquoted value: key = true / key = 42 / key = {}
+    val=$(echo "$raw" | sed 's/.*=[[:space:]]*//' | tr -d '[:space:]"')
+  fi
+  [[ -n "$val" ]] || return 1
+  echo "$val"
+}
+
+# Parse a boolean tfvar (unquoted true/false). Returns 0 for true, 1 for false.
+_tfvar_is_true() {
+  local val
+  val=$(_parse_tfvar "$1") || return 1
+  [[ "$val" == "true" ]]
+}
+
+# ── Color helpers ────────────────────────────────────────────────────────────
+_bold()  { printf '\033[1m%s\033[0m' "$*"; }
+_green() { printf '\033[32m%s\033[0m' "$*"; }
+_red()   { printf '\033[31m%s\033[0m' "$*"; }
+_yellow(){ printf '\033[33m%s\033[0m' "$*"; }
+_cyan()  { printf '\033[0;36m%s\033[0m' "$*"; }
+_dim()   { printf '\033[0;90m%s\033[0m' "$*"; }
+
+# ── Status line helpers ──────────────────────────────────────────────────────
+_RESET='\033[0m'
+pass()  { printf "  \033[32m✔${_RESET}  %s\n" "$1"; }
+warn()  { printf "  \033[1;33m⚠${_RESET}  %s\n" "$1"; }
+fail()  { printf "  \033[31m✘${_RESET}  %s\n" "$1"; }
+skip()  { printf "  \033[0;90m○${_RESET}  %s\n" "$1"; }
+info()  { printf "  \033[0;36mℹ${_RESET}  %s\n" "$1"; }
+header(){ printf "\n\033[1m── %s ──${_RESET}\n" "$1"; }
+action(){ printf "  \033[1;33m→${_RESET}  %s\n" "$1"; }

--- a/modules/azure-private/infra/scripts/clean.sh
+++ b/modules/azure-private/infra/scripts/clean.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+
+# MIT License - Copyright (c) 2026 LangChain, Inc.
+# NOTICE: Actively being tested and subject to change. Not officially supported by LangChain.
+# See LICENSE at the root of this repository for full license text.
+
+set -euo pipefail
+# clean.sh — Remove local generated/sensitive files after teardown.
+#
+# Usage (from infra/):
+#   bash scripts/clean.sh
+#
+# Removes, for both Terraform roots (infra/ and bootstrap/):
+#   terraform.tfvars            — live deployment config
+#   secrets.auto.tfvars         — generated secrets (Key Vault seed values)
+#   .api_key_salt etc.          — temp secret files from setup-env.sh (infra/ only)
+#   terraform.tfstate(.backup)  — local state (only present without a remote backend)
+#
+# Does NOT remove:
+#   terraform.tfvars.example    — templates, keep them
+#   .terraform/                 — provider cache, not sensitive
+#
+# Run AFTER teardown:
+#   terraform -chdir=bootstrap destroy   # from the jumpbox
+#   terraform -chdir=infra destroy
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INFRA_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+MODULE_DIR="$(cd "$INFRA_DIR/.." && pwd)"
+BOOTSTRAP_DIR="$MODULE_DIR/bootstrap"
+
+source "$SCRIPT_DIR/_common.sh"
+
+echo ""
+echo "══════════════════════════════════════════════════════"
+echo "  LangSmith azure-private — Clean local files"
+echo "══════════════════════════════════════════════════════"
+echo ""
+warn "This removes local secrets, tfvars, and local state for both roots."
+warn "Run AFTER: terraform -chdir=bootstrap destroy && terraform -chdir=infra destroy"
+echo ""
+
+# Guard: if a tfstate still tracks resources, destroy hasn't run — deleting it
+# would orphan the Azure resources. Warn and require an explicit force.
+_guard_state() {
+  local dir="$1" name="$2" n
+  if [[ -f "$dir/terraform.tfstate" ]]; then
+    n=$(grep -c '"type":' "$dir/terraform.tfstate" 2>/dev/null; true)
+    if [[ "${n:-0}" -gt 0 ]]; then
+      fail "$name/terraform.tfstate still tracks ${n} resource(s) — run 'terraform -chdir=$name destroy' first."
+      return 1
+    fi
+  fi
+  return 0
+}
+
+_state_ok=true
+_guard_state "$INFRA_DIR" "infra" || _state_ok=false
+_guard_state "$BOOTSTRAP_DIR" "bootstrap" || _state_ok=false
+if [[ "$_state_ok" != "true" ]]; then
+  echo ""
+  warn "Destroy the tracked resources before cleaning, or force-clean anyway."
+  printf "  Force clean anyway? [y/N] "
+  read -r _force
+  [[ "$_force" =~ ^[Yy]$ ]] || { echo "  Aborted."; exit 0; }
+fi
+
+printf "  Continue? [y/N] "
+read -r _confirm
+[[ "$_confirm" =~ ^[Yy]$ ]] || { echo "  Aborted."; exit 0; }
+echo ""
+
+_removed=0
+_rm() {
+  if [[ -f "$1" ]]; then
+    rm -f "$1"
+    pass "Removed: ${1#"$MODULE_DIR"/}"
+    _removed=$((_removed + 1))
+  fi
+}
+
+_clean_root() {
+  local dir="$1" name="$2"
+  header "$name/"
+  _rm "$dir/terraform.tfvars"
+  _rm "$dir/secrets.auto.tfvars"
+  _rm "$dir/terraform.tfstate"
+  _rm "$dir/terraform.tfstate.backup"
+  for f in "$dir"/terraform.tfstate.*.backup; do
+    [[ -f "$f" ]] && _rm "$f"
+  done
+}
+
+_clean_root "$INFRA_DIR" "infra"
+
+# Temp secret files written by setup-env.sh before Key Vault exists (infra/ only)
+for f in .api_key_salt .jwt_secret .deployments_key .agent_builder_key .insights_key .polly_key; do
+  _rm "$INFRA_DIR/$f"
+done
+
+_clean_root "$BOOTSTRAP_DIR" "bootstrap"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+if [[ $_removed -eq 0 ]]; then
+  skip "Nothing to remove — already clean"
+else
+  pass "$_removed file(s) removed"
+fi
+echo ""
+info "To redeploy from scratch, see DEPLOYMENT.md (Phase 0 → Phase 4)."
+echo ""

--- a/modules/azure-private/infra/scripts/create-k8s-secrets.sh
+++ b/modules/azure-private/infra/scripts/create-k8s-secrets.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+
+# MIT License - Copyright (c) 2026 LangChain, Inc.
+# NOTICE: Actively being tested and subject to change. Not officially supported by LangChain.
+# See LICENSE at the root of this repository for full license text.
+
+set -euo pipefail
+# create-k8s-secrets.sh — Create langsmith-config-secret from Azure Key Vault
+#
+# Usage:
+#   cd terraform/azure/infra
+#   ./scripts/create-k8s-secrets.sh
+#
+# Prerequisites:
+#   - terraform apply complete (Key Vault and secrets exist)
+#   - az aks get-credentials run (kubectl context set)
+#   - langsmith namespace exists (created by k8s-bootstrap module)
+#
+# What this creates:
+#   langsmith-config-secret — license key, API salt, JWT secret, admin password,
+#                             and four Fernet encryption keys. Read by all LangSmith
+#                             pods via config.existingSecretName in Helm values.
+#
+# The other two required secrets are created by Terraform (Pass 1):
+#   langsmith-postgres-secret — connection_url
+#   langsmith-redis-secret    — connection_url
+#
+# Safe to re-run — uses --dry-run=client | kubectl apply so it updates in place.
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; NC='\033[0m'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INFRA_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# ── Resolve Key Vault name from terraform output ───────────────────────────────
+if ! KV_NAME=$(cd "$INFRA_DIR" && terraform output -raw keyvault_name 2>/dev/null); then
+  # fallback: read identifier from terraform.tfvars
+  _identifier=$(grep -E '^\s*identifier\s*=' "$INFRA_DIR/terraform.tfvars" \
+    | sed 's/.*=[[:space:]]*"\([^"]*\)".*/\1/' | tr -d '[:space:]') || _identifier=""
+  KV_NAME="langsmith-kv${_identifier}"
+  echo "  (terraform output unavailable — using derived KV name: $KV_NAME)"
+fi
+
+# ── Resolve namespace ──────────────────────────────────────────────────────────
+NAMESPACE=$(cd "$INFRA_DIR" && terraform output -raw langsmith_namespace 2>/dev/null) || NAMESPACE="langsmith"
+
+echo ""
+echo "LangSmith — create K8s config secret"
+echo "  key_vault : $KV_NAME"
+echo "  namespace : $NAMESPACE"
+echo ""
+
+# ── Pull secrets from Key Vault ────────────────────────────────────────────────
+echo "  Reading secrets from Key Vault..."
+
+# Required secrets — abort (via set -e) if missing; a real deploy must set these.
+_kv() {
+  az keyvault secret show --vault-name "$KV_NAME" --name "$1" --query value -o tsv
+}
+
+# Optional feature secrets — the infra module only creates these in Key Vault when
+# the corresponding feature var is set (deployments/agent-builder/insights/polly).
+# Return empty instead of aborting so a base install (feature keys absent) works.
+# The chart only reads a key when its feature is enabled, so an empty value for a
+# disabled feature is never used.
+_kv_opt() {
+  az keyvault secret show --vault-name "$KV_NAME" --name "$1" --query value -o tsv 2>/dev/null || true
+}
+
+API_KEY_SALT=$(_kv "langsmith-api-key-salt")
+JWT_SECRET=$(_kv "langsmith-jwt-secret")
+LICENSE_KEY=$(_kv "langsmith-license-key")
+ADMIN_PASSWORD=$(_kv "langsmith-admin-password")
+DEPLOY_KEY=$(_kv_opt "langsmith-deployments-encryption-key")
+AGENT_KEY=$(_kv_opt "langsmith-agent-builder-encryption-key")
+INSIGHTS_KEY=$(_kv_opt "langsmith-insights-encryption-key")
+POLLY_KEY=$(_kv_opt "langsmith-polly-encryption-key")
+
+echo "  All secrets retrieved."
+echo ""
+
+# ── Create/update the secret ───────────────────────────────────────────────────
+echo "  Applying langsmith-config-secret to namespace/$NAMESPACE..."
+
+kubectl create secret generic langsmith-config-secret \
+  --namespace "$NAMESPACE" \
+  --from-literal=api_key_salt="$API_KEY_SALT" \
+  --from-literal=jwt_secret="$JWT_SECRET" \
+  --from-literal=langsmith_license_key="$LICENSE_KEY" \
+  --from-literal=initial_org_admin_password="$ADMIN_PASSWORD" \
+  --from-literal=deployments_encryption_key="$DEPLOY_KEY" \
+  --from-literal=agent_builder_encryption_key="$AGENT_KEY" \
+  --from-literal=insights_encryption_key="$INSIGHTS_KEY" \
+  --from-literal=polly_encryption_key="$POLLY_KEY" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+echo ""
+
+# ── Verify keys in the secret ──────────────────────────────────────────────────
+REQUIRED_KEYS=(
+  "api_key_salt"
+  "jwt_secret"
+  "langsmith_license_key"
+  "initial_org_admin_password"
+  "deployments_encryption_key"
+  "agent_builder_encryption_key"
+  "insights_encryption_key"
+  "polly_encryption_key"
+)
+
+echo "  Verifying keys in langsmith-config-secret..."
+echo ""
+
+ACTUAL_KEYS=$(kubectl get secret langsmith-config-secret -n "$NAMESPACE" \
+  -o json | python3 -c "import sys,json; d=json.load(sys.stdin); print('\n'.join(sorted(d['data'].keys())))")
+
+ERRORS=0
+for KEY in "${REQUIRED_KEYS[@]}"; do
+  if echo "$ACTUAL_KEYS" | grep -q "^${KEY}$"; then
+    echo -e "  ${GREEN}[✓]${NC} $KEY"
+  else
+    echo -e "  ${RED}[✗]${NC} $KEY — MISSING"
+    ERRORS=$((ERRORS + 1))
+  fi
+done
+
+echo ""
+if [ "$ERRORS" -eq 0 ]; then
+  echo -e "  ${GREEN}All ${#REQUIRED_KEYS[@]} keys present. Ready for helm install.${NC}"
+else
+  echo -e "  ${RED}${ERRORS} key(s) missing. Re-run this script or check Key Vault secrets.${NC}"
+  exit 1
+fi
+# Note: langsmith-clickhouse secret is NOT needed for in-cluster ClickHouse
+# (clickhouse_source = "in-cluster"). The chart manages the connection internally.
+# For external ClickHouse, create the secret manually and set
+# clickhouse.external.existingSecretName in your Helm values.
+
+echo ""
+echo "Next: author your Helm values and run helm upgrade --install (see DEPLOYMENT.md Phase 4)."

--- a/modules/azure-private/infra/scripts/create-tls-secret.sh
+++ b/modules/azure-private/infra/scripts/create-tls-secret.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+# MIT License - Copyright (c) 2026 LangChain, Inc.
+# NOTICE: Actively being tested and subject to change. Not officially supported by LangChain.
+# See LICENSE at the root of this repository for full license text.
+
+set -euo pipefail
+# create-tls-secret.sh — Create the langsmith-tls Kubernetes secret.
+#
+# WARNING: SELF-SIGNED — FOR TESTING/DEMO ONLY. Clients will not trust this cert.
+#   For production, replace langsmith-tls with a certificate from your own CA
+#   (for example one exported from Azure Key Vault): re-run this script with
+#   --cert/--key, or manage the secret yourself. See DEPLOYMENT.md.
+#
+# Usage:
+#   cd terraform/modules/azure-private/infra
+#   ./scripts/create-tls-secret.sh [--hostname langsmith.example.internal]
+#   ./scripts/create-tls-secret.sh --cert path/to/tls.crt --key path/to/tls.key
+#
+# Prerequisites:
+#   - az aks get-credentials run (kubectl context set to the target cluster)
+#   - langsmith namespace exists (created by the bootstrap/ apply)
+#   - openssl + kubectl on PATH
+#
+# What this creates:
+#   langsmith-tls — a kubernetes.io/tls secret. The LangSmith Helm chart
+#                   references it via ingress.tls[].secretName: langsmith-tls.
+#
+# Safe to re-run — uses --dry-run=client | kubectl apply, so it updates in place.
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; NC='\033[0m'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INFRA_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+SECRET_NAME="langsmith-tls"
+CERT_HOSTNAME="langsmith.local"
+CERT_FILE=""
+KEY_FILE=""
+
+# ── Parse args ─────────────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --hostname) CERT_HOSTNAME="$2"; shift 2 ;;
+    --cert)     CERT_FILE="$2"; shift 2 ;;
+    --key)      KEY_FILE="$2"; shift 2 ;;
+    -h|--help)  grep '^#' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *)          echo "Unknown argument: $1" >&2; exit 1 ;;
+  esac
+done
+
+# ── Resolve namespace ──────────────────────────────────────────────────────────
+NAMESPACE=$(cd "$INFRA_DIR" && terraform output -raw langsmith_namespace 2>/dev/null) || NAMESPACE="langsmith"
+
+echo ""
+echo "LangSmith — create TLS secret ($SECRET_NAME)"
+echo "  namespace : $NAMESPACE"
+
+# ── Obtain certificate + key ───────────────────────────────────────────────────
+# Restrict permissions on any files we create (private key must not be world/group
+# readable) and always clean up the temp dir on exit. Key material is never echoed.
+umask 077
+
+if [[ -z "$CERT_FILE" || -z "$KEY_FILE" ]]; then
+  TMP_DIR=$(mktemp -d)
+  trap 'rm -rf "$TMP_DIR"' EXIT
+  CERT_FILE="$TMP_DIR/tls.crt"
+  KEY_FILE="$TMP_DIR/tls.key"
+
+  echo "  cert      : self-signed (CN/SAN=$CERT_HOSTNAME, RSA 2048, 365d)"
+  echo -e "  ${RED}WARNING${NC}: self-signed certificate — testing only, not trusted by clients."
+  openssl req -x509 -newkey rsa:2048 -nodes \
+    -keyout "$KEY_FILE" -out "$CERT_FILE" \
+    -days 365 -subj "/CN=$CERT_HOSTNAME" \
+    -addext "subjectAltName=DNS:$CERT_HOSTNAME" >/dev/null 2>&1
+else
+  echo "  cert      : provided ($CERT_FILE)"
+  [[ -f "$CERT_FILE" && -f "$KEY_FILE" ]] || {
+    echo -e "  ${RED}ERROR${NC}: --cert / --key file not found." >&2
+    exit 1
+  }
+fi
+
+# ── Create/update the secret ───────────────────────────────────────────────────
+echo "  Applying $SECRET_NAME to namespace/$NAMESPACE..."
+kubectl create secret tls "$SECRET_NAME" \
+  --namespace "$NAMESPACE" \
+  --cert="$CERT_FILE" \
+  --key="$KEY_FILE" \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+echo ""
+if kubectl get secret "$SECRET_NAME" -n "$NAMESPACE" >/dev/null 2>&1; then
+  echo -e "  ${GREEN}[OK]${NC} $SECRET_NAME present in namespace/$NAMESPACE"
+  echo -e "  ${GREEN}Ready.${NC} Reference it in Helm values: ingress.tls[].secretName: $SECRET_NAME"
+else
+  echo -e "  ${RED}[FAIL]${NC} $SECRET_NAME not found after apply." >&2
+  exit 1
+fi

--- a/modules/azure-private/infra/scripts/manage-keyvault.sh
+++ b/modules/azure-private/infra/scripts/manage-keyvault.sh
@@ -1,0 +1,506 @@
+#!/usr/bin/env bash
+
+# MIT License - Copyright (c) 2026 LangChain, Inc.
+# NOTICE: Actively being tested and subject to change. Not officially supported by LangChain.
+# See LICENSE at the root of this repository for full license text.
+
+# manage-keyvault.sh — Manage LangSmith Key Vault secrets without re-running setup-env.sh
+#
+# Usage (from azure/):
+#   ./infra/scripts/manage-keyvault.sh list
+#   ./infra/scripts/manage-keyvault.sh get <key>
+#   ./infra/scripts/manage-keyvault.sh set <key> <value>
+#   ./infra/scripts/manage-keyvault.sh validate
+#   ./infra/scripts/manage-keyvault.sh diff
+#   ./infra/scripts/manage-keyvault.sh delete <key>
+#
+# Reads identifier and location from terraform.tfvars to derive the Key Vault name.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/_common.sh"
+
+# ── Resolve Key Vault name ───────────────────────────────────────────────────
+# Priority: terraform output → derived from identifier in terraform.tfvars
+if KV_NAME=$(cd "$INFRA_DIR" && terraform output -raw keyvault_name 2>/dev/null) && [[ -n "$KV_NAME" ]]; then
+  : # got it from terraform output
+else
+  _identifier=$(_parse_tfvar "identifier") || _identifier=""
+  KV_NAME="langsmith-kv${_identifier}"
+fi
+
+NAMESPACE="${NAMESPACE:-langsmith}"
+
+# ── Required and optional secret names ──────────────────────────────────────
+REQUIRED_SECRETS=(
+  "langsmith-license-key"
+  "langsmith-admin-password"
+  "langsmith-api-key-salt"
+  "langsmith-jwt-secret"
+)
+
+OPTIONAL_SECRETS=(
+  "langsmith-deployments-encryption-key"
+  "langsmith-agent-builder-encryption-key"
+  "langsmith-insights-encryption-key"
+  "langsmith-polly-encryption-key"
+)
+
+# Stable secrets — changing them breaks active sessions/API keys
+STABLE_SECRETS=(
+  "langsmith-api-key-salt"
+  "langsmith-jwt-secret"
+)
+
+# KV secret name → K8s secret data key (for diff subcommand)
+DIFF_KV_KEYS=(
+  "langsmith-license-key"
+  "langsmith-api-key-salt"
+  "langsmith-jwt-secret"
+  "langsmith-admin-password"
+  "langsmith-deployments-encryption-key"
+  "langsmith-agent-builder-encryption-key"
+  "langsmith-insights-encryption-key"
+  "langsmith-polly-encryption-key"
+)
+DIFF_K8S_KEYS=(
+  "langsmith_license_key"
+  "api_key_salt"
+  "jwt_secret"
+  "initial_org_admin_password"
+  "deployments_encryption_key"
+  "agent_builder_encryption_key"
+  "insights_encryption_key"
+  "polly_encryption_key"
+)
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+_is_stable() {
+  local key="$1"
+  for s in "${STABLE_SECRETS[@]}"; do
+    [[ "$s" == "$key" ]] && return 0
+  done
+  return 1
+}
+
+_get_secret() {
+  local _out
+  _out=$(az keyvault secret show \
+    --vault-name "$KV_NAME" \
+    --name "$1" \
+    --query value \
+    --output tsv 2>&1) && { echo "$_out"; return 0; }
+  if echo "$_out" | grep -qi "SecretNotFound\|does not exist\|404"; then
+    return 1
+  fi
+  echo "ERROR: Key Vault query failed for $1: $_out" >&2
+  return 1
+}
+
+_secret_exists() {
+  az keyvault secret show \
+    --vault-name "$KV_NAME" \
+    --name "$1" \
+    --query name \
+    --output tsv &>/dev/null
+}
+
+# ── list ─────────────────────────────────────────────────────────────────────
+cmd_list() {
+  echo "Key Vault secrets in: $KV_NAME"
+  echo ""
+
+  local secrets
+  secrets=$(az keyvault secret list \
+    --vault-name "$KV_NAME" \
+    --query '[].{Name:name, Updated:attributes.updated}' \
+    --output json 2>/dev/null) || secrets="[]"
+
+  if [[ "$secrets" == "[]" || -z "$secrets" ]]; then
+    echo "  (no secrets found)"
+    return
+  fi
+
+  printf "  %-48s  %s\n" "SECRET" "LAST UPDATED"
+  printf "  %-48s  %s\n" "------" "------------"
+
+  echo "$secrets" | python3 -c "
+import json, sys
+secrets = json.load(sys.stdin)
+for s in sorted(secrets, key=lambda x: x['Name']):
+    name = s['Name']
+    updated = (s.get('Updated') or 'unknown')[:19]
+    print(f'  {name:<48}  {updated}')
+" 2>/dev/null || {
+    echo "$secrets" | grep -o '"Name":"[^"]*"' | sed 's/"Name":"//;s/"//' | while read -r name; do
+      printf "  %s\n" "$name"
+    done
+  }
+  echo ""
+}
+
+# ── get ──────────────────────────────────────────────────────────────────────
+cmd_get() {
+  local key="${1:-}"
+  if [[ -z "$key" ]]; then
+    echo "Usage: manage-keyvault.sh get <key>" >&2
+    echo "Keys: ${REQUIRED_SECRETS[*]} ${OPTIONAL_SECRETS[*]}" >&2
+    exit 1
+  fi
+
+  local val
+  val=$(_get_secret "$key") || {
+    _red "ERROR"; echo ": Secret not found: $key (vault: $KV_NAME)"
+    exit 1
+  }
+  echo "$val"
+}
+
+# ── set ──────────────────────────────────────────────────────────────────────
+cmd_set() {
+  local key="${1:-}"
+  local val="${2:-}"
+  if [[ -z "$key" || -z "$val" ]]; then
+    echo "Usage: manage-keyvault.sh set <key> <value>" >&2
+    echo "Keys: ${REQUIRED_SECRETS[*]} ${OPTIONAL_SECRETS[*]}" >&2
+    exit 1
+  fi
+
+  # Warn on stable secrets
+  if _is_stable "$key"; then
+    echo ""
+    _yellow "WARNING"; echo ": $key is a stable secret."
+    if [[ "$key" == "langsmith-api-key-salt" ]]; then
+      echo "  Changing this invalidates ALL existing API keys."
+    elif [[ "$key" == "langsmith-jwt-secret" ]]; then
+      echo "  Changing this invalidates ALL active user sessions."
+    fi
+    printf "  Are you sure? [y/N] "
+    read -r confirm
+    [[ "$confirm" =~ ^[Yy]$ ]] || { echo "Aborted."; exit 0; }
+  fi
+
+  # Validate admin password format
+  if [[ "$key" == "langsmith-admin-password" ]]; then
+    if ! printf '%s' "$val" | grep -qE '[]!#$%()+,./:?@^_{~}[\-]'; then
+      _red "ERROR"; echo ": Admin password must contain a symbol: !#\$%()+,-./:?@[\\]^_{~}"
+      echo "  The Helm chart will reject a password without one."
+      exit 1
+    fi
+  fi
+
+  az keyvault secret set \
+    --vault-name "$KV_NAME" \
+    --name "$key" \
+    --value "$val" \
+    --output none
+
+  _green "OK"; echo ": Updated $key in $KV_NAME"
+
+  echo ""
+  echo "  To sync to K8s secret:"
+  echo "    bash scripts/create-k8s-secrets.sh"
+}
+
+# ── delete ───────────────────────────────────────────────────────────────────
+cmd_delete() {
+  local key="${1:-}"
+  if [[ -z "$key" ]]; then
+    echo "Usage: manage-keyvault.sh delete <key>" >&2
+    exit 1
+  fi
+
+  if _is_stable "$key"; then
+    echo ""
+    _red "DANGER"; echo ": $key is a stable secret. Deleting it will break the deployment."
+    printf "  Type the full secret name to confirm: "
+    read -r confirm
+    [[ "$confirm" == "$key" ]] || { echo "Aborted."; exit 0; }
+  else
+    printf "Delete $key from $KV_NAME? [y/N] "
+    read -r confirm
+    [[ "$confirm" =~ ^[Yy]$ ]] || { echo "Aborted."; exit 0; }
+  fi
+
+  az keyvault secret delete \
+    --vault-name "$KV_NAME" \
+    --name "$key" \
+    --output none 2>/dev/null && {
+    _green "OK"; echo ": Deleted $key (soft-deleted — recoverable for 90 days)"
+  } || {
+    _red "ERROR"; echo ": Secret not found or could not be deleted."
+    exit 1
+  }
+}
+
+# ── validate ─────────────────────────────────────────────────────────────────
+cmd_validate() {
+  echo "Validating Key Vault secrets in: $KV_NAME"
+  echo ""
+
+  # Verify vault is accessible
+  if ! az keyvault show --name "$KV_NAME" --query name --output tsv &>/dev/null; then
+    _red "ERROR"; echo ": Key Vault '$KV_NAME' not found or not accessible."
+    echo "  Run: terraform -chdir=infra apply  to provision infrastructure"
+    exit 1
+  fi
+
+  local missing=0
+  local warnings=0
+
+  printf "  %-48s  %s\n" "SECRET" "STATUS"
+  printf "  %-48s  %s\n" "------" "------"
+
+  for key in "${REQUIRED_SECRETS[@]}"; do
+    if _secret_exists "$key"; then
+      local val
+      val=$(_get_secret "$key")
+      if [[ -z "$val" ]]; then
+        printf "  %-48s  %s\n" "$key" "$(_yellow "EMPTY")"
+        warnings=$((warnings + 1))
+      else
+        if [[ "$key" == "langsmith-admin-password" ]]; then
+          if ! printf '%s' "$val" | grep -qE '[]!#$%()+,./:?@^_{~}[\-]'; then
+            printf "  %-48s  %s\n" "$key" "$(_red "INVALID — missing required symbol")"
+            warnings=$((warnings + 1))
+            continue
+          fi
+        fi
+        printf "  %-48s  %s\n" "$key" "$(_green "OK")"
+      fi
+    else
+      printf "  %-48s  %s\n" "$key" "$(_red "MISSING")"
+      missing=$((missing + 1))
+    fi
+  done
+
+  echo ""
+  echo "  Optional:"
+  for key in "${OPTIONAL_SECRETS[@]}"; do
+    if _secret_exists "$key"; then
+      printf "  %-48s  %s\n" "$key" "$(_green "OK")"
+    else
+      printf "  %-48s  %s\n" "$key" "—"
+    fi
+  done
+
+  echo ""
+  if [[ $missing -gt 0 ]]; then
+    _red "FAIL"; echo ": $missing required secret(s) missing."
+    echo "  Run: source infra/scripts/setup-env.sh"
+    exit 1
+  elif [[ $warnings -gt 0 ]]; then
+    _yellow "WARN"; echo ": $warnings secret(s) need attention."
+    exit 0
+  else
+    _green "PASS"; echo ": All required secrets present in Key Vault."
+  fi
+}
+
+# ── diff ─────────────────────────────────────────────────────────────────────
+cmd_diff() {
+  if ! command -v kubectl &>/dev/null; then
+    echo "ERROR: kubectl not found. diff requires cluster access." >&2
+    exit 1
+  fi
+
+  echo "Comparing Key Vault → K8s secret (langsmith-config-secret in $NAMESPACE)..."
+  echo ""
+
+  if ! kubectl get secret langsmith-config-secret -n "$NAMESPACE" &>/dev/null; then
+    _red "ERROR"; echo ": langsmith-config-secret not found in namespace $NAMESPACE."
+    echo "  Run: bash scripts/create-k8s-secrets.sh"
+    exit 1
+  fi
+
+  printf "  %-44s  %-10s  %-10s  %s\n" "KEY" "KV" "K8S" "MATCH"
+  printf "  %-44s  %-10s  %-10s  %s\n" "---" "--" "---" "-----"
+
+  local mismatches=0
+
+  for i in "${!DIFF_KV_KEYS[@]}"; do
+    local kv_key="${DIFF_KV_KEYS[$i]}"
+    local k8s_key="${DIFF_K8S_KEYS[$i]}"
+
+    local kv_val
+    kv_val=$(_get_secret "$kv_key" 2>/dev/null) || kv_val=""
+
+    local k8s_val
+    k8s_val=$(kubectl get secret langsmith-config-secret -n "$NAMESPACE" \
+      -o jsonpath="{.data.${k8s_key}}" 2>/dev/null | base64 -d 2>/dev/null) || k8s_val=""
+
+    local kv_status="—"
+    local k8s_status="—"
+    local match_status=""
+
+    [[ -n "$kv_val" ]] && kv_status="present"
+    [[ -n "$k8s_val" ]] && k8s_status="present"
+
+    if [[ -z "$kv_val" && -z "$k8s_val" ]]; then
+      match_status="—"
+    elif [[ "$kv_val" == "$k8s_val" ]]; then
+      match_status=$(_green "✓")
+    else
+      match_status=$(_red "✗ MISMATCH")
+      mismatches=$((mismatches + 1))
+    fi
+
+    printf "  %-44s  %-10s  %-10s  %s\n" "$kv_key" "$kv_status" "$k8s_status" "$match_status"
+  done
+
+  echo ""
+  if [[ $mismatches -gt 0 ]]; then
+    _yellow "WARN"; echo ": $mismatches key(s) out of sync. Re-sync:"
+    echo "  bash scripts/create-k8s-secrets.sh"
+  else
+    _green "OK"; echo ": Key Vault and K8s secret are in sync."
+  fi
+}
+
+# ── Interactive menu ──────────────────────────────────────────────────────────
+ALL_SECRETS=("${REQUIRED_SECRETS[@]}" "${OPTIONAL_SECRETS[@]}")
+
+_pick_key() {
+  local prompt="${1:-Pick a secret}"
+  echo ""
+  echo "  $prompt:"
+  echo ""
+  echo "  Required:"
+  local i=1
+  for key in "${REQUIRED_SECRETS[@]}"; do
+    local label="$key"
+    _is_stable "$key" && label="$key $(_yellow "[stable — do not change]")"
+    printf "    %2d) %s\n" "$i" "$label"
+    ((i++))
+  done
+  echo ""
+  echo "  Optional:"
+  for key in "${OPTIONAL_SECRETS[@]}"; do
+    printf "    %2d) %s\n" "$i" "$key"
+    ((i++))
+  done
+  echo ""
+  printf "  Enter number: "
+  read -r choice
+
+  if ! [[ "$choice" =~ ^[0-9]+$ ]] || (( choice < 1 || choice > ${#ALL_SECRETS[@]} )); then
+    _red "ERROR"; echo ": Invalid selection."
+    exit 1
+  fi
+  PICKED_KEY="${ALL_SECRETS[$((choice - 1))]}"
+}
+
+_interactive_get() {
+  _pick_key "Which secret to read"
+  echo ""
+  echo "  $PICKED_KEY (vault: $KV_NAME):"
+  echo ""
+  cmd_get "$PICKED_KEY"
+}
+
+_interactive_set() {
+  _pick_key "Which secret to update"
+  echo ""
+
+  if _secret_exists "$PICKED_KEY"; then
+    local current
+    current=$(_get_secret "$PICKED_KEY")
+    local masked="${current:0:4}$(printf '%*s' $(( ${#current} - 4 )) '' | tr ' ' '*')"
+    [[ ${#current} -le 4 ]] && masked="****"
+    echo "  Current value: $masked"
+  else
+    echo "  Current value: $(_yellow "(not set)")"
+  fi
+
+  echo ""
+  if [[ "$PICKED_KEY" == "langsmith-admin-password" ]]; then
+    echo "  Must contain a symbol: !#\$%()+,-./:?@[\\]^_{~}"
+  fi
+  printf "  New value: "
+  read -rs new_val
+  echo ""
+
+  if [[ -z "$new_val" ]]; then
+    echo "Aborted — no value entered."
+    exit 0
+  fi
+
+  cmd_set "$PICKED_KEY" "$new_val"
+}
+
+_interactive_delete() {
+  _pick_key "Which secret to delete"
+  echo ""
+  cmd_delete "$PICKED_KEY"
+}
+
+cmd_interactive() {
+  echo ""
+  echo "  LangSmith Key Vault Manager"
+  echo "  Vault: $(_bold "$KV_NAME")"
+  echo ""
+  echo "    1) list       — Show all secrets"
+  echo "    2) get        — Read a secret"
+  echo "    3) set        — Update a secret"
+  echo "    4) validate   — Check all required secrets"
+  echo "    5) diff       — Compare Key Vault vs K8s secret"
+  echo "    6) delete     — Remove a secret"
+  echo ""
+  printf "  What do you want to do? [1-6]: "
+  read -r action
+
+  case "$action" in
+    1|list)     echo ""; cmd_list ;;
+    2|get)      _interactive_get ;;
+    3|set)      _interactive_set ;;
+    4|validate) echo ""; cmd_validate ;;
+    5|diff)     echo ""; cmd_diff ;;
+    6|delete)   _interactive_delete ;;
+    *)
+      _red "ERROR"; echo ": Invalid selection."
+      exit 1
+      ;;
+  esac
+}
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+usage() {
+  cat <<EOF
+manage-keyvault.sh — Manage LangSmith Key Vault secrets
+
+Usage:
+  manage-keyvault.sh                      Interactive mode (menus)
+  manage-keyvault.sh <command> [args]     Non-interactive (scripting)
+
+  Vault: $KV_NAME
+
+Commands:
+  list                 List all secrets with last-updated timestamps
+  get <key>            Read and print a single secret value
+  set <key> <value>    Update a secret (validates format constraints)
+  delete <key>         Soft-delete a secret (with confirmation)
+  validate             Check all required secrets exist and are valid
+  diff                 Compare Key Vault vs K8s secret (requires kubectl)
+
+Examples:
+  ./infra/scripts/manage-keyvault.sh                                      # interactive
+  ./infra/scripts/manage-keyvault.sh validate                             # scripting
+  ./infra/scripts/manage-keyvault.sh set langsmith-admin-password 'P@ss!'
+  ./infra/scripts/manage-keyvault.sh diff
+EOF
+}
+
+case "${1:-}" in
+  list)     cmd_list ;;
+  get)      cmd_get "${2:-}" ;;
+  set)      cmd_set "${2:-}" "${3:-}" ;;
+  delete)   cmd_delete "${2:-}" ;;
+  validate) cmd_validate ;;
+  diff)     cmd_diff ;;
+  -h|--help|help) usage ;;
+  "")       cmd_interactive ;;
+  *)
+    usage >&2
+    exit 1
+    ;;
+esac

--- a/modules/azure-private/infra/scripts/preflight.sh
+++ b/modules/azure-private/infra/scripts/preflight.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+
+# MIT License - Copyright (c) 2026 LangChain, Inc.
+# NOTICE: Actively being tested and subject to change. Not officially supported by LangChain.
+# See LICENSE at the root of this repository for full license text.
+
+# ──────────────────────────────────────────────────────────────────────────────
+# preflight.sh — Pre-flight checks for LangSmith Azure deployment.
+#
+# Validates:
+#   1. az CLI is installed and logged in
+#   2. Correct subscription is selected
+#   3. Required resource providers are registered
+#   4. Deployer has required RBAC roles (Contributor + User Access Admin)
+#   5. terraform.tfvars exists with required fields populated
+#
+# Run before: terraform init / terraform apply
+# Usage: bash infra/scripts/preflight.sh
+# Equivalent to: terraform/aws/infra/scripts/preflight.sh (IAM validation)
+# ──────────────────────────────────────────────────────────────────────────────
+set -euo pipefail
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+PASS="${GREEN}[✓]${NC}"; FAIL="${RED}[✗]${NC}"; WARN="${YELLOW}[!]${NC}"
+
+INFRA_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ERRORS=0
+
+fail() { echo -e "${FAIL} $1"; ERRORS=$((ERRORS + 1)); }
+pass() { echo -e "${PASS} $1"; }
+warn() { echo -e "${WARN} $1"; }
+
+echo ""
+echo "══════════════════════════════════════════════════════"
+echo "  LangSmith Azure — Pre-flight Checks"
+echo "══════════════════════════════════════════════════════"
+echo ""
+
+# ── 1. az CLI ─────────────────────────────────────────────────────────────────
+echo "── Azure CLI ─────────────────────────────────────────"
+if ! command -v az &>/dev/null; then
+  fail "az CLI not found. Install: https://docs.microsoft.com/cli/azure/install-azure-cli"
+else
+  AZ_VERSION=$(az version --query '"azure-cli"' -o tsv 2>/dev/null || echo "unknown")
+  pass "az CLI installed (v${AZ_VERSION})"
+fi
+
+# ── 2. Login check ────────────────────────────────────────────────────────────
+echo ""
+echo "── Authentication ────────────────────────────────────"
+ACCOUNT=$(az account show 2>/dev/null || true)
+if [ -z "$ACCOUNT" ]; then
+  fail "Not logged in to Azure. Run: az login"
+else
+  SUB_NAME=$(echo "$ACCOUNT" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('name','unknown'))")
+  SUB_ID=$(echo "$ACCOUNT"   | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('id','unknown'))")
+  USER=$(echo "$ACCOUNT"     | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('user',{}).get('name','unknown'))")
+  pass "Logged in as: ${USER}"
+  pass "Subscription: ${SUB_NAME} (${SUB_ID})"
+  warn "Verify this is the correct subscription. Change with: az account set --subscription <id>"
+fi
+
+# ── 3. Resource provider registrations ───────────────────────────────────────
+echo ""
+echo "── Resource Providers ────────────────────────────────"
+REQUIRED_PROVIDERS=(
+  "Microsoft.ContainerService"
+  "Microsoft.DBforPostgreSQL"
+  "Microsoft.Cache"
+  "Microsoft.KeyVault"
+  "Microsoft.Storage"
+  "Microsoft.Network"
+  "Microsoft.Compute"
+  "Microsoft.Authorization"
+  "Microsoft.ManagedIdentity"
+  "Microsoft.OperationalInsights"
+  "Microsoft.Insights"
+)
+
+for PROVIDER in "${REQUIRED_PROVIDERS[@]}"; do
+  STATE=$(az provider show --namespace "$PROVIDER" --query "registrationState" -o tsv 2>/dev/null || echo "NotFound")
+  if [ "$STATE" = "Registered" ]; then
+    pass "${PROVIDER}"
+  else
+    fail "${PROVIDER} is ${STATE}. Register with: az provider register --namespace ${PROVIDER}"
+  fi
+done
+
+# ── 4. RBAC roles ─────────────────────────────────────────────────────────────
+echo ""
+echo "── RBAC Roles ────────────────────────────────────────"
+CURRENT_USER_ID=$(az ad signed-in-user show --query id -o tsv 2>/dev/null || echo "")
+SUB_ID_CHECK=$(az account show --query id -o tsv 2>/dev/null || echo "")
+
+if [ -z "$CURRENT_USER_ID" ]; then
+  warn "Could not determine current user object ID — skipping RBAC check (service principal?)"
+else
+  # Check Contributor
+  CONTRIBUTOR=$(az role assignment list \
+    --assignee "$CURRENT_USER_ID" \
+    --role "Contributor" \
+    --scope "/subscriptions/${SUB_ID_CHECK}" \
+    --query "length(@)" -o tsv 2>/dev/null || echo "0")
+
+  if [ "$CONTRIBUTOR" -gt "0" ]; then
+    pass "Contributor role on subscription"
+  else
+    warn "Contributor role not found at subscription scope — may have it at resource group scope (acceptable)"
+  fi
+
+  # Check User Access Administrator or Owner (required for role assignments in modules).
+  # Owner implicitly includes all User Access Administrator permissions.
+  UAA=$(az role assignment list \
+    --assignee "$CURRENT_USER_ID" \
+    --role "User Access Administrator" \
+    --scope "/subscriptions/${SUB_ID_CHECK}" \
+    --query "length(@)" -o tsv 2>/dev/null || echo "0")
+
+  OWNER=$(az role assignment list \
+    --assignee "$CURRENT_USER_ID" \
+    --role "Owner" \
+    --scope "/subscriptions/${SUB_ID_CHECK}" \
+    --query "length(@)" -o tsv 2>/dev/null || echo "0")
+
+  if [ "$UAA" -gt "0" ]; then
+    pass "User Access Administrator role on subscription"
+  elif [ "$OWNER" -gt "0" ]; then
+    pass "Owner role on subscription (includes User Access Administrator permissions)"
+  else
+    fail "Neither Owner nor User Access Administrator role found. Required for RBAC role assignments in keyvault, storage, and WAF modules."
+  fi
+fi
+
+# ── 5. terraform.tfvars ───────────────────────────────────────────────────────
+echo ""
+echo "── Terraform Config ──────────────────────────────────"
+TFVARS="${INFRA_DIR}/terraform.tfvars"
+if [ ! -f "$TFVARS" ]; then
+  fail "terraform.tfvars not found. Copy the example: cp infra/terraform.tfvars.example infra/terraform.tfvars"
+else
+  pass "terraform.tfvars exists"
+
+  # Check required fields in terraform.tfvars
+  REQUIRED_TFVARS_FIELDS=("location" "subscription_id")
+  for FIELD in "${REQUIRED_TFVARS_FIELDS[@]}"; do
+    VALUE=$(grep "^${FIELD}" "$TFVARS" 2>/dev/null | head -1 | cut -d'"' -f2 || echo "")
+    if [ -z "$VALUE" ] || [[ "$VALUE" == *"<"* ]]; then
+      fail "terraform.tfvars: ${FIELD} is empty or still a placeholder"
+    else
+      pass "terraform.tfvars: ${FIELD} is set"
+    fi
+  done
+
+  # Check secrets.auto.tfvars exists and has license key
+  # Secrets live in secrets.auto.tfvars (written by setup-env.sh), not terraform.tfvars.
+  SECRETS_FILE="${INFRA_DIR}/secrets.auto.tfvars"
+  if [ ! -f "$SECRETS_FILE" ]; then
+    fail "secrets.auto.tfvars not found. Run: ./setup-env.sh"
+  else
+    pass "secrets.auto.tfvars exists"
+    LICENSE=$(grep "^langsmith_license_key" "$SECRETS_FILE" 2>/dev/null | head -1 | cut -d'"' -f2 || echo "")
+    if [ -z "$LICENSE" ] || [[ "$LICENSE" == *"<"* ]]; then
+      fail "secrets.auto.tfvars: langsmith_license_key is empty — re-run ./setup-env.sh"
+    else
+      pass "secrets.auto.tfvars: langsmith_license_key is set"
+    fi
+  fi
+fi
+
+# ── 6. Other tooling ──────────────────────────────────────────────────────────
+echo ""
+echo "── Tooling ───────────────────────────────────────────"
+for TOOL in terraform kubectl helm; do
+  if command -v "$TOOL" &>/dev/null; then
+    VERSION=$("$TOOL" version --short 2>/dev/null | head -1 || "$TOOL" version 2>/dev/null | head -1 || echo "installed")
+    pass "${TOOL}: ${VERSION}"
+  else
+    warn "${TOOL} not found — needed for later passes"
+  fi
+done
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+echo "══════════════════════════════════════════════════════"
+if [ "$ERRORS" -eq 0 ]; then
+  echo -e "${GREEN}  All checks passed. Ready for terraform apply.${NC}"
+else
+  echo -e "${RED}  ${ERRORS} check(s) failed. Fix the issues above before continuing.${NC}"
+  exit 1
+fi
+echo "══════════════════════════════════════════════════════"
+echo ""

--- a/modules/azure-private/infra/scripts/setup-env.sh
+++ b/modules/azure-private/infra/scripts/setup-env.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+
+# MIT License - Copyright (c) 2026 LangChain, Inc.
+# NOTICE: Actively being tested and subject to change. Not officially supported by LangChain.
+# See LICENSE at the root of this repository for full license text.
+
+set -euo pipefail
+# setup-env.sh — Bootstrap LangSmith secrets for Terraform (Pass 1)
+#
+# Usage:
+#   ./setup-env.sh
+#
+# Writes all sensitive variables to secrets.auto.tfvars (gitignored).
+# Terraform picks this file up automatically — no shell session coupling needed.
+#
+# On first run:  prompts for passwords, generates stable secrets → local files + secrets.auto.tfvars.
+#                Terraform apply then creates Key Vault and stores all secrets in it.
+# On subsequent runs:  reads silently from Key Vault → secrets.auto.tfvars. No prompts.
+#
+# setup-env.sh is READ-ONLY against Key Vault — it never writes to KV directly.
+# Terraform is the sole writer. This prevents state conflicts on terraform apply.
+
+SECRETS_FILE="secrets.auto.tfvars"
+
+# ── Read identifier from terraform.tfvars ─────────────────────────────────────
+_identifier=""
+if [[ -f "terraform.tfvars" ]]; then
+  _identifier=$(grep -E '^\s*identifier\s*=' terraform.tfvars \
+    | sed 's/.*=[[:space:]]*"\([^"]*\)".*/\1/' \
+    | tr -d '[:space:]') || _identifier=""
+fi
+_kv_name="langsmith-kv${_identifier}"
+
+# ── Prompt helper (skips if env var already set) ──────────────────────────────
+# If stdin is not a tty and the env var is not set, exit with a clear error
+# rather than silently storing empty/garbage values in secrets.auto.tfvars.
+_prompt() {
+  local env_var="$1"
+  local prompt_text="$2"
+  local val="${!env_var:-}"
+  if [[ -z "$val" ]]; then
+    if [[ ! -t 0 ]]; then
+      echo "ERROR: setup-env.sh requires interactive input (stdin is not a tty)." >&2
+      echo "       Set env vars to skip prompts:" >&2
+      echo "         export LANGSMITH_PG_PASSWORD=..." >&2
+      echo "         export LANGSMITH_LICENSE_KEY=..." >&2
+      echo "         export LANGSMITH_ADMIN_PASSWORD=..." >&2
+      echo "         export LANGSMITH_ADMIN_EMAIL=..." >&2
+      echo "       Then re-run: bash scripts/setup-env.sh" >&2
+      exit 1
+    fi
+    printf "%s: " "$prompt_text"
+    read -rs val
+    echo
+  fi
+  echo "$val"
+}
+
+# ── Stable secret: read from Key Vault or local fallback, generate if missing ──
+# Priority: Key Vault (written by Terraform) → local fallback file → generate fresh
+# Never writes to Key Vault directly — Terraform owns all KV writes.
+_kv_secret() {
+  local kv_secret_name="$1"
+  local fallback_file="$2"
+  local generator="$3"
+  local val=""
+
+  # 1. Read from Key Vault (available after terraform apply)
+  if az keyvault show --name "$_kv_name" --output none 2>/dev/null; then
+    val=$(az keyvault secret show \
+      --vault-name "$_kv_name" \
+      --name "$kv_secret_name" \
+      --query value -o tsv 2>/dev/null) || val=""
+  fi
+
+  # 2. Fall back to local file (before first apply, or on a machine without KV access)
+  if [[ -z "$val" && -f "$fallback_file" ]]; then
+    val=$(cat "$fallback_file")
+  fi
+
+  # 3. Generate fresh — write to local file only; Terraform stores in Key Vault on apply
+  if [[ -z "$val" ]]; then
+    val=$(eval "$generator")
+    echo "$val" > "$fallback_file"
+    echo "  Generated $kv_secret_name → $fallback_file (Terraform stores in Key Vault on apply)" >&2
+  fi
+
+  echo "$val"
+}
+
+_fernet_generator='python3 -c "
+try:
+    from cryptography.fernet import Fernet
+    print(Fernet.generate_key().decode())
+except ImportError:
+    import base64, os
+    print(base64.urlsafe_b64encode(os.urandom(32)).decode())
+"'
+
+# ── Collect secrets ───────────────────────────────────────────────────────────
+echo ""
+echo "LangSmith — secret bootstrap"
+echo "  identifier : ${_identifier:-(empty)}"
+echo "  key_vault  : $_kv_name"
+echo ""
+
+pg_password=$(_prompt "LANGSMITH_PG_PASSWORD"     "PostgreSQL admin password  ")
+license_key=$(_prompt "LANGSMITH_LICENSE_KEY"      "LangSmith license key      ")
+admin_password=$(_prompt "LANGSMITH_ADMIN_PASSWORD" "LangSmith admin password   ")
+admin_email=$(_prompt "LANGSMITH_ADMIN_EMAIL"      "Initial org admin email    ")
+
+echo ""
+echo "  Resolving stable secrets..."
+api_key_salt=$(_kv_secret "langsmith-api-key-salt"               ".api_key_salt"    "openssl rand -base64 32")
+jwt_secret=$(_kv_secret   "langsmith-jwt-secret"                 ".jwt_secret"      "openssl rand -base64 32")
+deployments_key=$(_kv_secret "langsmith-deployments-encryption-key" ".deployments_key" "$_fernet_generator")
+agent_builder_key=$(_kv_secret "langsmith-agent-builder-encryption-key" ".agent_builder_key" "$_fernet_generator")
+insights_key=$(_kv_secret "langsmith-insights-encryption-key"    ".insights_key"    "$_fernet_generator")
+polly_key=$(_kv_secret    "langsmith-polly-encryption-key"        ".polly_key"       "$_fernet_generator")
+
+# ── Write secrets.auto.tfvars ─────────────────────────────────────────────────
+cat > "$SECRETS_FILE" << EOF
+# Auto-generated by setup-env.sh — DO NOT COMMIT
+# Re-run ./setup-env.sh to refresh secrets from Key Vault.
+
+postgres_admin_password                = "$pg_password"
+langsmith_license_key                  = "$license_key"
+langsmith_admin_password               = "$admin_password"
+langsmith_admin_email                  = "$admin_email"
+langsmith_api_key_salt                 = "$api_key_salt"
+langsmith_jwt_secret                   = "$jwt_secret"
+langsmith_deployments_encryption_key   = "$deployments_key"
+langsmith_agent_builder_encryption_key = "$agent_builder_key"
+langsmith_insights_encryption_key      = "$insights_key"
+langsmith_polly_encryption_key         = "$polly_key"
+EOF
+
+chmod 600 "$SECRETS_FILE"
+
+# ── Summary ───────────────────────────────────────────────────────────────────
+echo ""
+echo "  Wrote $SECRETS_FILE (chmod 600)"
+echo ""
+echo "Next:"
+echo "  terraform init    # first run only"
+echo "  terraform plan"
+echo "  terraform apply"
+echo ""
+echo "Then (see DEPLOYMENT.md for the full runbook — this module has no Makefile):"
+echo "  bash scripts/preflight.sh              # verify az login, providers, RBAC (before apply)"
+echo "  az aks get-credentials ...             # from an in-VNet host, after apply"
+echo "  terraform -chdir=../bootstrap apply    # in-cluster bootstrap (from the jumpbox)"
+echo "  bash scripts/create-k8s-secrets.sh     # app-config secret from Key Vault"
+echo "  bash scripts/create-tls-secret.sh      # self-signed TLS secret (testing only)"
+echo "  helm upgrade --install langsmith ...   # Phase 4 (see DEPLOYMENT.md)"

--- a/modules/azure-private/infra/scripts/status.sh
+++ b/modules/azure-private/infra/scripts/status.sh
@@ -1,0 +1,327 @@
+#!/usr/bin/env bash
+
+# MIT License - Copyright (c) 2026 LangChain, Inc.
+# NOTICE: Actively being tested and subject to change. Not officially supported by LangChain.
+# See LICENSE at the root of this repository for full license text.
+
+# status.sh — Check the current state of the azure-private LangSmith deployment
+#             and tell you what to run next. Tailored to this module's two-root
+#             (infra/ + bootstrap/) no-make flow — see DEPLOYMENT.md.
+#
+# Usage (from infra/):
+#   bash scripts/status.sh           # full check
+#   bash scripts/status.sh --quick   # skip slow checks (Key Vault, Kubernetes)
+#
+# No set -euo pipefail — this is a diagnostic that must run every check
+# regardless of individual failures. The AKS API server is private, so the
+# Kubernetes checks only work from a host with VNet connectivity (the jumpbox).
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/_common.sh"
+
+QUICK=false
+[[ "${1:-}" == "--quick" ]] && QUICK=true
+
+NEXT_ACTION=""
+set_next() { [[ -z "$NEXT_ACTION" ]] && NEXT_ACTION="$1"; }
+
+_read_tfvar() { _parse_tfvar "$1"; }
+
+# ── 1. Configuration ─────────────────────────────────────────────────────────
+header "1. Configuration (infra/terraform.tfvars)"
+
+if [[ -f "$INFRA_DIR/terraform.tfvars" ]]; then
+  pass "terraform.tfvars exists"
+  _identifier=$(_read_tfvar identifier)
+  _subscription=$(_read_tfvar subscription_id)
+  _pg_source=$(_read_tfvar postgres_source)
+  _redis_source=$(_read_tfvar redis_source)
+  _kv_name="langsmith-kv${_identifier}"
+
+  if [[ -n "$_subscription" ]]; then
+    pass "Required fields: subscription_id set  identifier=${_identifier:-'(empty)'}"
+  else
+    fail "Missing required field: subscription_id"
+    action "Edit infra/terraform.tfvars — fill in subscription_id"
+    set_next "Edit infra/terraform.tfvars — fill in subscription_id"
+  fi
+  info "Services: postgres=${_pg_source:-external}  redis=${_redis_source:-external}"
+else
+  fail "terraform.tfvars not found"
+  action "cp infra/terraform.tfvars.example infra/terraform.tfvars && edit it"
+  set_next "cp infra/terraform.tfvars.example infra/terraform.tfvars && edit it"
+fi
+
+# ── 2. Secrets File ───────────────────────────────────────────────────────────
+header "2. Secrets (infra/secrets.auto.tfvars)"
+
+_secrets_file="$INFRA_DIR/secrets.auto.tfvars"
+if [[ -f "$_secrets_file" ]]; then
+  pass "secrets.auto.tfvars exists"
+  _license=$(grep "langsmith_license_key" "$_secrets_file" 2>/dev/null | cut -d'"' -f2 || echo "")
+  _pg_pw=$(grep "postgres_admin_password" "$_secrets_file" 2>/dev/null | cut -d'"' -f2 || echo "")
+  [[ -n "$_license" ]] && pass "langsmith_license_key is set" || warn "langsmith_license_key is empty"
+  [[ -n "$_pg_pw" ]] && pass "postgres_admin_password is set" || warn "postgres_admin_password is empty"
+else
+  skip "secrets.auto.tfvars not found (fine if you export TF_VAR_* directly)"
+  action "bash scripts/setup-env.sh"
+  set_next "bash scripts/setup-env.sh"
+fi
+
+# ── 3. Azure Credentials ──────────────────────────────────────────────────────
+header "3. Azure Credentials"
+
+if az account show &>/dev/null; then
+  _account=$(az account show --query user.name -o tsv 2>/dev/null) || _account=""
+  _sub_name=$(az account show --query name -o tsv 2>/dev/null) || _sub_name=""
+  _sub_id=$(az account show --query id -o tsv 2>/dev/null) || _sub_id=""
+  pass "az credentials active — user: ${_account:-unknown}"
+  info "Subscription: ${_sub_name} (${_sub_id})"
+  if [[ -n "${_subscription:-}" && "$_sub_id" != "$_subscription" ]]; then
+    warn "Active subscription differs from terraform.tfvars subscription_id"
+    action "az account set --subscription ${_subscription}"
+  fi
+else
+  fail "az CLI not found or not logged in"
+  action "az login"
+  set_next "az login"
+fi
+
+# ── 4. Key Vault Secrets ──────────────────────────────────────────────────────
+header "4. Key Vault Secrets (${_kv_name:-?})"
+
+if [[ "$QUICK" == "true" ]]; then
+  skip "Skipped (--quick mode)"
+elif [[ -z "${_kv_name:-}" || "$_kv_name" == "langsmith-kv" ]]; then
+  skip "Cannot check — identifier not set in terraform.tfvars"
+elif ! az keyvault show --name "$_kv_name" --output none 2>/dev/null; then
+  skip "Key Vault '${_kv_name}' not found (created by terraform apply)"
+  action "terraform -chdir=infra apply"
+  set_next "terraform -chdir=infra apply"
+else
+  _required_kv_secrets=(
+    langsmith-license-key
+    langsmith-api-key-salt
+    langsmith-jwt-secret
+    langsmith-admin-password
+  )
+  _optional_kv_secrets=(
+    langsmith-deployments-encryption-key
+    langsmith-agent-builder-encryption-key
+    langsmith-insights-encryption-key
+    langsmith-polly-encryption-key
+  )
+
+  _kv_ok=true
+  for secret in "${_required_kv_secrets[@]}"; do
+    if az keyvault secret show --vault-name "$_kv_name" --name "$secret" --query value -o tsv &>/dev/null 2>&1; then
+      pass "KV: ${secret}"
+    else
+      fail "KV: ${secret} — missing"
+      _kv_ok=false
+    fi
+  done
+  for secret in "${_optional_kv_secrets[@]}"; do
+    if az keyvault secret show --vault-name "$_kv_name" --name "$secret" --query value -o tsv &>/dev/null 2>&1; then
+      pass "KV: ${secret} (optional)"
+    else
+      skip "KV: ${secret} (optional — needed for advanced features)"
+    fi
+  done
+
+  if [[ "$_kv_ok" == "false" ]]; then
+    action "bash scripts/setup-env.sh  (re-run after terraform apply)"
+    set_next "Resolve missing Key Vault secrets"
+  fi
+fi
+
+# ── 5. Terraform Infrastructure (infra/) ──────────────────────────────────────
+header "5. Terraform Infrastructure (infra/)"
+
+if [[ -d "$INFRA_DIR/.terraform" ]]; then
+  pass "terraform init — done"
+else
+  fail "terraform init — not run"
+  action "terraform -chdir=infra init"
+  set_next "terraform -chdir=infra init"
+fi
+
+_tf_output=""
+if [[ -d "$INFRA_DIR/.terraform" ]]; then
+  _tf_output=$(terraform -chdir="$INFRA_DIR" output -json 2>/dev/null) || _tf_output=""
+fi
+
+if [[ -n "$_tf_output" ]] && echo "$_tf_output" | grep -q '"aks_cluster_name"'; then
+  pass "terraform apply — infrastructure provisioned"
+  _cluster_name=$(echo "$_tf_output"    | jq -r '.aks_cluster_name.value     // empty' 2>/dev/null) || _cluster_name=""
+  _rg_name=$(echo "$_tf_output"         | jq -r '.resource_group_name.value  // empty' 2>/dev/null) || _rg_name=""
+  _kv_tf_name=$(echo "$_tf_output"      | jq -r '.keyvault_name.value        // empty' 2>/dev/null) || _kv_tf_name=""
+  _storage_account=$(echo "$_tf_output" | jq -r '.storage_account_name.value // empty' 2>/dev/null) || _storage_account=""
+  [[ -n "$_cluster_name" ]]    && info "AKS cluster: ${_cluster_name}"       || warn "No aks_cluster_name output"
+  [[ -n "$_rg_name" ]]         && info "Resource group: ${_rg_name}"
+  [[ -n "$_kv_tf_name" ]]      && info "Key Vault: ${_kv_tf_name}"
+  [[ -n "$_storage_account" ]] && info "Storage account: ${_storage_account}"
+else
+  fail "terraform output — empty (no state, or infra not yet applied)"
+  action "terraform -chdir=infra apply"
+  set_next "terraform -chdir=infra apply"
+fi
+
+# ── 6. Kubeconfig + cluster ───────────────────────────────────────────────────
+header "6. Kubeconfig + cluster"
+
+if [[ "$QUICK" == "true" ]]; then
+  skip "Skipped (--quick mode)"
+elif [[ -z "${_cluster_name:-}" ]]; then
+  skip "Cannot check — no aks_cluster_name from terraform output"
+else
+  _get_creds="az aks get-credentials -g ${_rg_name:-<rg>} -n ${_cluster_name} --overwrite-existing"
+  _current_ctx=$(kubectl config current-context 2>/dev/null) || _current_ctx=""
+  if [[ "$_current_ctx" == *"${_cluster_name}"* ]]; then
+    pass "kubectl context points to ${_cluster_name}"
+  elif [[ -n "$_current_ctx" ]]; then
+    warn "kubectl context is '${_current_ctx}' — expected *${_cluster_name}*"
+    action "$_get_creds"
+  else
+    fail "No kubectl context set"
+    action "$_get_creds"
+    set_next "$_get_creds"
+  fi
+
+  if kubectl cluster-info --request-timeout=5s &>/dev/null; then
+    pass "kubectl can reach the cluster"
+    if NODES=$(kubectl get nodes --no-headers 2>/dev/null); then
+      READY=$(echo "$NODES" | grep -c " Ready " || true)
+      TOTAL=$(echo "$NODES" | wc -l | tr -d ' ')
+      if [[ "$READY" == "$TOTAL" ]]; then
+        pass "$READY/$TOTAL nodes Ready"
+      else
+        warn "$READY/$TOTAL nodes Ready"
+        echo "$NODES"
+      fi
+    fi
+    # In-cluster bootstrap components (installed by bootstrap/ apply)
+    for ns in keda ingress-nginx; do
+      if kubectl get pods -n "$ns" --no-headers 2>/dev/null | grep -v "Running\|Completed" | grep -q .; then
+        warn "$ns: some pods not Running"
+      else
+        _running_count=$(kubectl get pods -n "$ns" --no-headers 2>/dev/null | grep -c Running || echo 0)
+        pass "$ns: ${_running_count} pod(s) Running"
+      fi
+    done
+  else
+    skip "kubectl cannot reach the cluster — the API server is private; run from the jumpbox (inside the VNet)"
+  fi
+fi
+
+# ── 7. Kubernetes resources ───────────────────────────────────────────────────
+header "7. Kubernetes resources (namespace + secrets)"
+
+_NAMESPACE="${NAMESPACE:-langsmith}"
+_k8s_reachable=false
+
+if [[ "$QUICK" == "true" ]]; then
+  skip "Skipped (--quick mode)"
+elif ! kubectl cluster-info --request-timeout=5s &>/dev/null; then
+  skip "Cannot check — cluster unreachable (run from the jumpbox)"
+else
+  _k8s_reachable=true
+
+  if kubectl get namespace "$_NAMESPACE" &>/dev/null; then
+    pass "Namespace: ${_NAMESPACE}"
+  else
+    warn "Namespace '${_NAMESPACE}' does not exist (created by bootstrap/ apply)"
+    action "terraform -chdir=bootstrap apply  (from the jumpbox)"
+    set_next "terraform -chdir=bootstrap apply"
+  fi
+
+  # Connection secrets (bootstrap/ apply)
+  for secret in langsmith-postgres-secret langsmith-redis-secret; do
+    if kubectl get secret "$secret" -n "$_NAMESPACE" &>/dev/null; then
+      pass "Secret: ${secret}"
+    else
+      skip "Secret: ${secret} — not created yet (bootstrap/ apply)"
+    fi
+  done
+
+  # App-config secret (scripts/create-k8s-secrets.sh — Phase 3.5)
+  if kubectl get secret langsmith-config-secret -n "$_NAMESPACE" &>/dev/null; then
+    _cfg_keys=$(kubectl get secret langsmith-config-secret -n "$_NAMESPACE" -o json 2>/dev/null \
+      | python3 -c "import sys,json; print(len(json.load(sys.stdin)['data']))" 2>/dev/null) || _cfg_keys=0
+    pass "Secret: langsmith-config-secret (${_cfg_keys} keys)"
+  else
+    skip "Secret: langsmith-config-secret — not created yet"
+    action "bash scripts/create-k8s-secrets.sh  (Phase 3.5)"
+    set_next "bash scripts/create-k8s-secrets.sh"
+  fi
+
+  # TLS secret (scripts/create-tls-secret.sh — Phase 3.5)
+  if kubectl get secret langsmith-tls -n "$_NAMESPACE" &>/dev/null; then
+    pass "Secret: langsmith-tls (ingress TLS)"
+  else
+    skip "Secret: langsmith-tls — not created yet"
+    action "bash scripts/create-tls-secret.sh --hostname <host>  (Phase 3.5)"
+  fi
+fi
+
+# ── 8. Helm release ───────────────────────────────────────────────────────────
+header "8. Helm release (langsmith)"
+
+if [[ "$QUICK" == "true" ]]; then
+  skip "Skipped (--quick mode)"
+elif [[ "$_k8s_reachable" != "true" ]]; then
+  skip "Cannot check — cluster unreachable"
+else
+  _helm_json=$(helm status langsmith -n "$_NAMESPACE" -o json 2>/dev/null) || _helm_json=""
+  if [[ -n "$_helm_json" ]]; then
+    _helm_status=$(echo "$_helm_json" | grep -o '"status":"[^"]*"' | head -1 | sed 's/"status":"//;s/"//') || _helm_status=""
+    case "$_helm_status" in
+      deployed)        pass "Helm release: langsmith — deployed" ;;
+      pending-upgrade) fail "Helm release: langsmith — stuck pending-upgrade"; action "helm rollback langsmith -n ${_NAMESPACE}" ;;
+      pending-install) fail "Helm release: langsmith — stuck pending-install"; action "helm uninstall langsmith -n ${_NAMESPACE}, then reinstall" ;;
+      failed)          warn "Helm release: langsmith — 'failed' (likely a prior --wait timeout); pods may still be running" ;;
+      *)               warn "Helm release: langsmith — status: ${_helm_status:-unknown}" ;;
+    esac
+  else
+    skip "Helm release: langsmith — not installed"
+    action "helm upgrade --install langsmith ...  (Phase 4 — see DEPLOYMENT.md)"
+    set_next "Install LangSmith (DEPLOYMENT.md Phase 4)"
+  fi
+
+  # Pod health
+  if kubectl get namespace "$_NAMESPACE" &>/dev/null; then
+    _total=$(kubectl get pods -n "$_NAMESPACE" --no-headers 2>/dev/null | wc -l | tr -d ' ')
+    _running=$(kubectl get pods -n "$_NAMESPACE" --no-headers 2>/dev/null | awk '{print $3}' | grep -c "Running" || true)
+    _not_running=$(kubectl get pods -n "$_NAMESPACE" --no-headers 2>/dev/null | awk '$3 != "Running" && $3 != "Completed" {print $1 " (" $3 ")"}' || true)
+    if (( _total == 0 )); then
+      skip "No pods in ${_NAMESPACE} namespace"
+    elif [[ -z "$_not_running" ]]; then
+      pass "Pods: ${_running}/${_total} running"
+    else
+      warn "Pods: ${_running}/${_total} running"
+      while IFS= read -r line; do
+        [[ -n "$line" ]] && fail "  $line"
+      done <<< "$_not_running"
+      action "kubectl describe pod <name> -n ${_NAMESPACE}  (check events)"
+    fi
+  fi
+
+  # Internal NGINX ingress load-balancer IP (private)
+  _ingress_ip=$(kubectl get svc ingress-nginx-controller -n ingress-nginx \
+    -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null) || _ingress_ip=""
+  if [[ -n "$_ingress_ip" ]]; then
+    pass "Ingress private IP: ${_ingress_ip}"
+    info "(Point your internal DNS for the LangSmith hostname at ${_ingress_ip})"
+  else
+    skip "Ingress IP not yet assigned (internal LB provisions once nginx is up)"
+  fi
+fi
+
+# ── Next Step ─────────────────────────────────────────────────────────────────
+header "Next Step"
+
+if [[ -n "$NEXT_ACTION" ]]; then
+  printf "\n  $(_yellow "▶")  $(_bold "%s")\n\n" "$NEXT_ACTION"
+else
+  printf "\n  $(_green "✔")  $(_bold "All checks passed — deployment looks healthy")\n\n"
+fi

--- a/modules/azure-private/infra/scripts/tf-run.sh
+++ b/modules/azure-private/infra/scripts/tf-run.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+# MIT License - Copyright (c) 2026 LangChain, Inc.
+# NOTICE: Actively being tested and subject to change. Not officially supported by LangChain.
+# See LICENSE at the root of this repository for full license text.
+
+# tf-run.sh — Run setup-env.sh (if needed) then execute terraform with all provided args.
+#
+# Useful in CI environments where secrets.auto.tfvars must be regenerated
+# before each terraform run.
+#
+# Usage (from azure/):
+#   ./infra/scripts/tf-run.sh plan
+#   ./infra/scripts/tf-run.sh apply -auto-approve
+#   ./infra/scripts/tf-run.sh output -raw aks_cluster_name
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INFRA_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Run setup-env.sh to generate/refresh secrets.auto.tfvars if it doesn't exist yet.
+# setup-env.sh writes secrets.auto.tfvars relative to its working directory, so run
+# it from INFRA_DIR (where terraform -chdir picks the file up) and by its real path.
+if [[ ! -f "$INFRA_DIR/secrets.auto.tfvars" ]]; then
+  echo "  secrets.auto.tfvars not found — running setup-env.sh first..."
+  (cd "$INFRA_DIR" && bash "$SCRIPT_DIR/setup-env.sh")
+  echo ""
+fi
+
+exec terraform -chdir="$INFRA_DIR" "$@"

--- a/modules/azure-private/infra/terraform.tfvars.example
+++ b/modules/azure-private/infra/terraform.tfvars.example
@@ -1,0 +1,51 @@
+# modules/azure-private — worked configuration.
+# The module is always BYO + hardened: existing RG + VNet, private API server,
+# CNI Overlay+Cilium, UDR egress, internal NGINX, Private-Endpoint Postgres/Redis.
+#
+# Pre-create BEFORE apply:
+#   • Resource group (region is inherited from it).
+#   • VNet + subnets:
+#       - AKS subnet: route table 0.0.0.0/0 -> firewall/NVA private IP (UDR),
+#         Microsoft.Storage + Microsoft.KeyVault service endpoints.
+#       - Postgres subnet: regular subnet with a spare IP for the private endpoint
+#         (NOT delegated).
+#       - Redis subnet: regular subnet for the private endpoint.
+#       - Jumpbox subnet: a normal subnet (e.g. "jumpbox") for the bastion jumpbox VM
+#         this module always provisions as the in-VNet apply host.
+#   • Firewall rules permitting required AKS egress
+#     (https://learn.microsoft.com/azure/aks/limit-egress-traffic).
+#   • Run terraform apply from a host inside/peered to the VNet that resolves the
+#     private DNS zone (the provisioned bastion, or a self-hosted runner).
+
+subscription_id     = "00000000-0000-0000-0000-000000000000"
+identifier          = "-prod"
+resource_group_name = "my-existing-rg"
+
+vnet_id            = "/subscriptions/.../virtualNetworks/my-vnet"
+aks_subnet_id      = "/subscriptions/.../virtualNetworks/my-vnet/subnets/aks"
+postgres_subnet_id = "/subscriptions/.../virtualNetworks/my-vnet/subnets/privatelink"
+redis_subnet_id    = "/subscriptions/.../virtualNetworks/my-vnet/subnets/privatelink"
+bastion_subnet_id  = "/subscriptions/.../virtualNetworks/my-vnet/subnets/jumpbox"
+
+aks_pod_cidr       = "10.244.0.0/16"  # must not overlap the VNet / service CIDR / peered ranges
+aks_service_cidr   = "10.0.64.0/20"
+aks_dns_service_ip = "10.0.64.10"
+
+# API-server private DNS: "" => System (AKS-managed). "None" => BYO DNS (needs
+# aks_private_cluster_public_fqdn_enabled = true). Or a custom zone resource ID.
+aks_private_dns_zone_id                 = ""
+aks_private_cluster_public_fqdn_enabled = false
+
+# Control-plane identity: module-created user-assigned + Network Contributor on the
+# VNet (recommended). For a custom API-server private DNS zone, set
+# aks_create_cluster_identity = false and bring a pre-granted identity:
+#   aks_cluster_identity_id = "/subscriptions/.../userAssignedIdentities/my-aks-identity"
+aks_create_cluster_identity = true
+
+bastion_admin_ssh_public_key = "ssh-ed25519 AAAA..."
+
+# Secrets — supply via TF_VAR_* env vars in real use; placeholders here.
+postgres_admin_password = "CHANGE-ME"
+langsmith_license_key   = "CHANGE-ME"
+langsmith_api_key_salt  = "CHANGE-ME"
+langsmith_jwt_secret    = "CHANGE-ME"

--- a/modules/azure-private/infra/tests/private_landing_zone.tftest.hcl
+++ b/modules/azure-private/infra/tests/private_landing_zone.tftest.hcl
@@ -1,0 +1,226 @@
+# Credential-free plan tests using mocked providers.
+# Run: terraform -chdir=modules/azure-private/infra init -backend=false && \
+#      terraform -chdir=modules/azure-private/infra test
+# Requires Terraform >= 1.7 (mock_provider) on the runner.
+
+mock_provider "azurerm" {}
+mock_provider "azapi" {}
+mock_provider "null" {}
+mock_provider "time" {}
+
+# ── Run 1: AKS posture is hardcoded ──────────────────────────────────────────
+# Plans the k8s-cluster sub-module directly — none of the root variables are
+# needed. Asserts that the hardcoded always-on posture (overlay/Cilium/UDR/
+# private + user-assigned identity) survives exactly as configured.
+# NOTE: subscription_id was removed from the k8s-cluster module interface;
+#       do NOT pass it here.
+run "aks_posture_hardcoded" {
+  command = plan
+  module { source = "./modules/k8s-cluster" }
+
+  variables {
+    cluster_name        = "test-aks"
+    location            = "eastus"
+    resource_group_name = "test-rg"
+    subnet_id           = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/v/subnets/s"
+    pod_cidr            = "10.244.0.0/16"
+  }
+
+  assert {
+    condition     = azurerm_kubernetes_cluster.main.network_profile[0].network_plugin_mode == "overlay"
+    error_message = "Overlay must be hardcoded on"
+  }
+  assert {
+    condition     = azurerm_kubernetes_cluster.main.network_profile[0].network_data_plane == "cilium"
+    error_message = "Cilium data plane must be hardcoded on"
+  }
+  assert {
+    condition     = azurerm_kubernetes_cluster.main.network_profile[0].outbound_type == "userDefinedRouting"
+    error_message = "Egress must be userDefinedRouting"
+  }
+  assert {
+    condition     = azurerm_kubernetes_cluster.main.private_cluster_enabled == true
+    error_message = "API server must be private"
+  }
+  assert {
+    condition     = azurerm_kubernetes_cluster.main.identity[0].type == "UserAssigned"
+    error_message = "Control plane must use a user-assigned identity (create_cluster_identity defaults true)"
+  }
+}
+
+# ── Run 2: Root looks up the RG via data source (never creates it) ────────────
+# Plans the root module with a data source override so the plan succeeds
+# credential-free. Asserts that the resource_group_name output equals the
+# value returned by the data source (proving the root reads the RG, not
+# creates it).
+run "root_creates_no_rg_or_vnet" {
+  command = plan
+
+  override_data {
+    target = data.azurerm_resource_group.existing
+    values = {
+      name     = "test-rg"
+      location = "eastus"
+      id       = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg"
+    }
+  }
+
+  variables {
+    subscription_id         = "00000000-0000-0000-0000-000000000000"
+    identifier              = "-test"
+    resource_group_name     = "test-rg"
+    vnet_id                 = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/v"
+    aks_subnet_id           = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/v/subnets/aks"
+    postgres_subnet_id      = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/v/subnets/pg"
+    redis_subnet_id         = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/v/subnets/redis"
+    bastion_subnet_id       = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/v/subnets/bastion"
+    postgres_admin_password = "TfTest-Sandbox-1!"
+    langsmith_api_key_salt  = "dGVzdC1zYWx0LXNhbmRib3g="
+    langsmith_jwt_secret    = "dGVzdC1qd3Qtc2FuZGJveA=="
+    # Dummy RSA public key — valid SSH format, satisfies the azurerm provider's
+    # SSH key decoder. Not a real key; safe for test use only.
+    bastion_admin_ssh_public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB terraform-test"
+  }
+
+  override_resource {
+    target = module.bastion.azurerm_linux_virtual_machine.bastion
+    values = {
+      id = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Compute/virtualMachines/bastion-test"
+    }
+  }
+
+  # The root module looks up the RG via data source — the output reflects the
+  # data source name, proving the RG name flows from the data-source lookup to
+  # the root output. Structural absence of a managed RG comes from the module
+  # having no azurerm_resource_group resource.
+  assert {
+    condition     = output.resource_group_name == "test-rg"
+    error_message = "Root must look up the RG via data source and expose it as an output"
+  }
+}
+
+# ── Run 3: External Postgres uses a Private Endpoint ─────────────────────────
+# Plans the postgres sub-module directly. Asserts both the server-level
+# public access lockdown and the presence of the postgresqlServer PE.
+run "postgres_external_uses_private_endpoint" {
+  command = plan
+  module { source = "./modules/postgres" }
+
+  variables {
+    name                = "langsmith-postgres-test"
+    location            = "eastus"
+    resource_group_name = "test-rg"
+    vnet_id             = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/v"
+    subnet_id           = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/v/subnets/pg"
+    admin_username      = "lsadmin"
+    admin_password      = "TfTest-Sandbox-1!"
+  }
+
+  assert {
+    condition     = azurerm_postgresql_flexible_server.db.public_network_access_enabled == false
+    error_message = "Postgres public network access must be disabled"
+  }
+  assert {
+    condition     = azurerm_private_endpoint.db.private_service_connection[0].subresource_names[0] == "postgresqlServer"
+    error_message = "Postgres must be reached via a postgresqlServer private endpoint"
+  }
+}
+
+# ── Run 4: Negative — identity conflict guard fires ───────────────────────────
+# Setting both aks_create_cluster_identity = true AND aks_cluster_identity_id
+# must trigger the terraform_data.validate_cluster_identity_exclusive precondition.
+run "reject_cluster_identity_conflict" {
+  command         = plan
+  expect_failures = [terraform_data.validate_cluster_identity_exclusive]
+
+  override_data {
+    target = data.azurerm_resource_group.existing
+    values = {
+      name     = "test-rg"
+      location = "eastus"
+      id       = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg"
+    }
+  }
+
+  variables {
+    subscription_id              = "00000000-0000-0000-0000-000000000000"
+    identifier                   = "-test"
+    resource_group_name          = "test-rg"
+    vnet_id                      = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/v"
+    aks_subnet_id                = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/v/subnets/aks"
+    postgres_subnet_id           = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/v/subnets/pg"
+    redis_subnet_id              = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/v/subnets/redis"
+    bastion_subnet_id            = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/v/subnets/bastion"
+    aks_create_cluster_identity  = true
+    aks_cluster_identity_id      = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/uai"
+    postgres_admin_password      = "TfTest-Sandbox-1!"
+    langsmith_api_key_salt       = "dGVzdC1zYWx0LXNhbmRib3g="
+    langsmith_jwt_secret         = "dGVzdC1qd3Qtc2FuZGJveA=="
+    bastion_admin_ssh_public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB terraform-test"
+  }
+}
+
+# The chart renders SA names as <release>-<component> only when the release name
+# contains "langsmith"; a name like "ls" would break Workload Identity silently.
+run "reject_bad_release_name" {
+  command         = plan
+  expect_failures = [var.langsmith_release_name]
+
+  override_data {
+    target = data.azurerm_resource_group.existing
+    values = {
+      name     = "test-rg"
+      location = "eastus"
+      id       = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg"
+    }
+  }
+
+  variables {
+    subscription_id              = "00000000-0000-0000-0000-000000000000"
+    identifier                   = "-test"
+    resource_group_name          = "test-rg"
+    vnet_id                      = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/v"
+    aks_subnet_id                = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/v/subnets/aks"
+    postgres_subnet_id           = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/v/subnets/pg"
+    redis_subnet_id              = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/v/subnets/redis"
+    bastion_subnet_id            = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/v/subnets/bastion"
+    langsmith_release_name       = "ls"
+    postgres_admin_password      = "TfTest-Sandbox-1!"
+    langsmith_api_key_salt       = "dGVzdC1zYWx0LXNhbmRib3g="
+    langsmith_jwt_secret         = "dGVzdC1qd3Qtc2FuZGJveA=="
+    bastion_admin_ssh_public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB terraform-test"
+  }
+}
+
+# A custom (BYO) API-server private DNS zone needs a BYO identity with Private DNS Zone
+# Contributor; the module-created control-plane identity only has Network Contributor.
+run "reject_custom_dns_zone_with_module_identity" {
+  command         = plan
+  expect_failures = [terraform_data.validate_cluster_identity_exclusive]
+
+  override_data {
+    target = data.azurerm_resource_group.existing
+    values = {
+      name     = "test-rg"
+      location = "eastus"
+      id       = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg"
+    }
+  }
+
+  variables {
+    subscription_id              = "00000000-0000-0000-0000-000000000000"
+    identifier                   = "-test"
+    resource_group_name          = "test-rg"
+    vnet_id                      = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/v"
+    aks_subnet_id                = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/v/subnets/aks"
+    postgres_subnet_id           = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/v/subnets/pg"
+    redis_subnet_id              = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/v/subnets/redis"
+    bastion_subnet_id            = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/virtualNetworks/v/subnets/bastion"
+    aks_create_cluster_identity  = true
+    aks_private_dns_zone_id      = "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.Network/privateDnsZones/privatelink.eastus.azmk8s.io"
+    postgres_admin_password      = "TfTest-Sandbox-1!"
+    langsmith_api_key_salt       = "dGVzdC1zYWx0LXNhbmRib3g="
+    langsmith_jwt_secret         = "dGVzdC1qd3Qtc2FuZGJveA=="
+    bastion_admin_ssh_public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB terraform-test"
+  }
+}

--- a/modules/azure-private/infra/validations.tf
+++ b/modules/azure-private/infra/validations.tf
@@ -1,0 +1,32 @@
+# ══════════════════════════════════════════════════════════════════════════════
+# Input-combination guards for modules/azure-private.
+# The hardened posture (always BYO VNet, overlay+Cilium, UDR, private API server)
+# makes the other cross-field guards structurally impossible, so only the
+# control-plane identity choice remains a real either/or.
+# ══════════════════════════════════════════════════════════════════════════════
+
+resource "terraform_data" "validate_cluster_identity_exclusive" {
+  lifecycle {
+    precondition {
+      condition     = !(var.aks_create_cluster_identity && var.aks_cluster_identity_id != "")
+      error_message = "Set only one of aks_create_cluster_identity or aks_cluster_identity_id (mutually exclusive)."
+    }
+
+    # A custom (BYO) API-server private DNS zone requires the control-plane identity to
+    # hold Private DNS Zone Contributor on that zone. The module-created identity is only
+    # granted Network Contributor on the VNet (enough for the default "System" zone), so a
+    # custom zone must use a BYO identity (aks_cluster_identity_id) that you've granted the
+    # role. Without this guard the combo fails mid-apply with CustomPrivateDNSZoneMissingPermissionError.
+    precondition {
+      condition     = !(var.aks_create_cluster_identity && !contains(["", "None"], var.aks_private_dns_zone_id))
+      error_message = "A custom aks_private_dns_zone_id requires a BYO control-plane identity (aks_cluster_identity_id) with Private DNS Zone Contributor on the zone — not aks_create_cluster_identity = true. Use the System zone (\"\") or supply a pre-authorized identity."
+    }
+
+    # AKS rejects a private cluster whose private DNS zone is "None" unless the public FQDN
+    # is enabled (there is otherwise no way to resolve the API server).
+    precondition {
+      condition     = !(var.aks_private_dns_zone_id == "None" && !var.aks_private_cluster_public_fqdn_enabled)
+      error_message = "aks_private_dns_zone_id = \"None\" requires aks_private_cluster_public_fqdn_enabled = true (otherwise the API server is unresolvable)."
+    }
+  }
+}

--- a/modules/azure-private/infra/variables.tf
+++ b/modules/azure-private/infra/variables.tf
@@ -1,0 +1,513 @@
+# ── Deployment identifier ─────────────────────────────────────────────────────
+
+variable "identifier" {
+  type        = string
+  description = "Short suffix appended to every resource name to distinguish environments (e.g. \"-prod\", \"-staging\"). Must start with a hyphen or be empty. Set in terraform.tfvars."
+  default     = ""
+
+  validation {
+    condition     = var.identifier == "" || can(regex("^-[a-z0-9][a-z0-9-]*$", var.identifier))
+    error_message = "identifier must be empty or a hyphen followed by lowercase letters/numbers/hyphens (e.g. \"-prod\", \"-dev-dz\")."
+  }
+}
+
+# ── Resource tagging ──────────────────────────────────────────────────────────
+# Tags are applied to every Azure resource for cost allocation, compliance,
+# and incident response. Required by most enterprise Azure policies.
+
+variable "environment" {
+  type        = string
+  description = "Deployment environment. Used as the 'environment' tag on all resources."
+  default     = "dev"
+
+  validation {
+    condition     = contains(["dev", "staging", "prod"], var.environment)
+    error_message = "environment must be 'dev', 'staging', or 'prod'."
+  }
+}
+
+variable "owner" {
+  type        = string
+  description = "Email or team name of the resource owner. Used as the 'owner' tag on all resources."
+  default     = ""
+}
+
+variable "cost_center" {
+  type        = string
+  description = "Cost center or billing code for charge-back. Used as the 'cost_center' tag on all resources."
+  default     = ""
+}
+
+# ── Subscription ──────────────────────────────────────────────────────────────
+
+variable "subscription_id" {
+  type        = string
+  description = "The subscription id of the LangSmith deployment"
+}
+
+# ── BYO resource group ────────────────────────────────────────────────────────
+
+variable "resource_group_name" {
+  type        = string
+  description = "Name of the existing resource group to deploy into. All resources deploy here and the region is taken from this RG."
+  default     = ""
+}
+
+# ── BYO network ───────────────────────────────────────────────────────────────
+
+variable "vnet_id" {
+  type        = string
+  description = "The id of the existing VNet to use."
+  default     = ""
+}
+
+variable "aks_subnet_id" {
+  type        = string
+  description = "The id of the existing subnet to use for the AKS cluster."
+  default     = ""
+}
+
+variable "postgres_subnet_id" {
+  type        = string
+  description = "The id of the existing subnet to use for the Postgres server."
+  default     = ""
+}
+
+variable "redis_subnet_id" {
+  type        = string
+  description = "The id of the existing subnet to use for the Redis server."
+  default     = ""
+}
+
+variable "bastion_subnet_id" {
+  type        = string
+  description = "Existing bastion subnet ID."
+  default     = ""
+}
+
+# ── Key Vault ─────────────────────────────────────────────────────────────────
+
+variable "keyvault_name" {
+  type        = string
+  description = "Name for the Azure Key Vault. Must be globally unique, 3-24 chars. Defaults to 'langsmith-kv<identifier>' which you may need to customize to avoid naming conflicts."
+  default     = ""
+  # When empty, main.tf computes: "langsmith-kv${local.identifier}"
+}
+
+variable "keyvault_purge_protection" {
+  type        = bool
+  description = "Enable purge protection on Key Vault. Set false for dev environments where you need to destroy and recreate. Always true for production."
+  default     = true
+}
+
+variable "keyvault_default_action" {
+  type        = string
+  description = "Default action for the Key Vault data-plane firewall. \"Allow\" (default) keeps the starter UX working — first apply creates ~10 secrets via the data plane and \"Deny\" without operator IP allowlisting blocks that. Production deployments set \"Deny\" and populate keyvault_allowed_ips."
+  default     = "Allow"
+
+  validation {
+    condition     = contains(["Allow", "Deny"], var.keyvault_default_action)
+    error_message = "keyvault_default_action must be 'Allow' or 'Deny'."
+  }
+}
+
+variable "keyvault_allowed_ips" {
+  type        = list(string)
+  description = "Public IPs / CIDRs allowed through the Key Vault firewall when keyvault_default_action = \"Deny\". The AKS subnet is allowlisted automatically via the Microsoft.KeyVault service endpoint."
+  default     = []
+}
+
+# ── Backing services ──────────────────────────────────────────────────────────
+
+variable "postgres_database_name" {
+  type        = string
+  description = "Name of the PostgreSQL database LangSmith connects to. Must match the database that exists on the server."
+  default     = "langsmith"
+}
+
+variable "postgres_source" {
+  type        = string
+  description = "PostgreSQL deployment type. 'external' provisions Azure Database for PostgreSQL Flexible Server (private VNet). 'in-cluster' uses the chart-managed in-cluster Postgres pod (dev/demo only)."
+  default     = "external"
+
+  validation {
+    condition     = contains(["external", "in-cluster"], var.postgres_source)
+    error_message = "postgres_source must be 'external' or 'in-cluster'."
+  }
+}
+
+variable "redis_source" {
+  type        = string
+  description = "Redis deployment type. 'external' provisions Azure Cache for Redis (private VNet). 'in-cluster' uses the chart-managed in-cluster Redis pod (dev/demo only)."
+  default     = "external"
+
+  validation {
+    condition     = contains(["external", "in-cluster"], var.redis_source)
+    error_message = "redis_source must be 'external' or 'in-cluster'."
+  }
+}
+
+variable "clickhouse_source" {
+  type        = string
+  description = "ClickHouse deployment type. 'in-cluster' deploys ClickHouse as a pod via Helm (dev/POC only). 'external' for LangChain Managed ClickHouse (recommended for production) — see https://docs.langchain.com/langsmith/langsmith-managed-clickhouse"
+  default     = "in-cluster"
+
+  validation {
+    condition     = contains(["in-cluster", "external"], var.clickhouse_source)
+    error_message = "clickhouse_source must be 'in-cluster' or 'external'."
+  }
+}
+
+variable "amr_sku" {
+  type        = string
+  description = "Azure Managed Redis SKU. Balanced_B0 is the smallest. Bump (Balanced_B1/B3/...) if the region reports AllocationFailed. (Replaces the classic redis_capacity.)"
+  default     = "Balanced_B0"
+}
+
+variable "blob_ttl_enabled" {
+  type        = bool
+  description = "Enable TTL for the blob container"
+  default     = true
+}
+
+variable "blob_ttl_short_days" {
+  type        = number
+  description = "The number of days to keep short-lived blobs"
+  default     = 14
+}
+
+variable "blob_ttl_long_days" {
+  type        = number
+  description = "The number of days to keep long-lived blobs"
+  default     = 400
+}
+
+variable "storage_allowed_ips" {
+  type        = list(string)
+  description = "Public IPs / CIDRs allowed through the storage account default-deny firewall. AKS pod traffic is allowlisted automatically via the Microsoft.Storage service endpoint on the AKS subnet — only add operator workstations, CI runners, or other external clients that need to reach the blob data plane."
+  default     = []
+}
+
+# ── AKS node pool sizing guidance ─────────────────────────────────────────────
+# Pass 2 (core LangSmith): ~13 vCPU / 24 GiB scheduled across default pool nodes.
+#   backend×3 (3 vCPU/6Gi) + platformBackend (1 vCPU/2Gi) + queue×3 (3 vCPU/6Gi)
+#   + ingestQueue×3 (3 vCPU/6Gi) + frontend + playground + aceBackend + system pods
+#   → Standard_D8s_v3 × 3 nodes (24 vCPU / 96 GiB) comfortably fits Pass 2.
+#
+# Pass 3–5 (LangGraph Platform, Agent Builder, Insights): add ~3 vCPU / 5 GiB.
+#   Total with autoscale headroom: max_count = 12 (Standard_D8s_v3).
+#
+# ClickHouse: 3.5 vCPU / 15 GiB request — always scheduled to the large pool
+#   (Standard_D16s_v3, 16 vCPU / 64 GiB) via node affinity set in the chart.
+#   Production recommendation from upstream: 8 vCPU / 32 GiB for heavy tracing load.
+#
+# Official LangSmith minimum: 16 vCPU / 64 GiB cluster-wide.
+# See: https://docs.langchain.com/langsmith/kubernetes
+
+variable "default_node_pool_vm_size" {
+  type        = string
+  description = "VM size for the default AKS node pool. Standard_D8s_v3 (8 vCPU / 32 GiB) is the recommended baseline for Pass 2+ (external Postgres + Redis). Use Standard_D4s_v3 (4 vCPU / 16 GiB) only for light/demo deployments (in-cluster DBs). See sizing comment above."
+  default     = "Standard_D8s_v3" # 8 vCPU, 32 GiB
+}
+
+variable "default_node_pool_min_count" {
+  type        = number
+  description = "Min node count for the default pool. Autoscaler never scales below this floor. Set to 3 for production — Pass 2 needs ~14.4 vCPU and 3× Standard_D8s_v3 provides 18,870m allocatable (76% CPU). Set to 1 for minimum/dev deployments."
+  default     = 1
+}
+
+variable "default_node_pool_max_count" {
+  type        = number
+  description = "Max node count for the default pool. Pass 2: 4–6 nodes. Pass 3 (LangGraph Platform): 6. Pass 4 (Agent Builder): 8. Pass 5 (Insights): 10–12. Autoscaler scales within this limit — increasing max_count takes effect immediately with no node restarts."
+  default     = 10
+}
+
+variable "default_node_pool_max_pods" {
+  type        = number
+  description = "Max pods per node in the default pool. AKS Azure CNI default is 30 — too low for LangSmith. Pass 2 alone needs ~32 pods (17 LangSmith + 15 system). Set to 60 to fit full multi-pass deployments on a single node. Immutable — changing requires node pool recreation."
+  default     = 60
+}
+
+variable "aks_service_cidr" {
+  type        = string
+  description = "The service CIDR of the AKS cluster"
+  default     = "10.0.64.0/20"
+}
+
+variable "aks_dns_service_ip" {
+  type        = string
+  description = "The DNS service IP of the AKS cluster"
+  default     = "10.0.64.10"
+}
+
+variable "additional_node_pools" {
+  type = map(object({
+    vm_size   = string
+    min_count = number
+    max_count = number
+  }))
+  description = "Additional node pools. The 'large' pool (Standard_D16s_v3, 16 vCPU / 64 GiB) is required for ClickHouse (requests 3.5 vCPU / 15 GiB) and LangGraph Platform agent pods. min_count = 0 means it scales to zero when idle. Increase max_count to 3+ for Pass 4 (Agent Builder) with multiple simultaneous deployments."
+  default = {
+    large = {
+      vm_size   = "Standard_D16s_v3" # 16 vCPU, 64 GiB — ClickHouse (3.5 vCPU/15Gi request) + dataplane agent pods
+      min_count = 0
+      max_count = 2
+    }
+  }
+}
+
+variable "aks_deletion_protection" {
+  type        = bool
+  description = "Prevent accidental AKS cluster deletion. Set false for dev/test environments where you need to destroy and recreate."
+  default     = true
+}
+
+variable "postgres_deletion_protection" {
+  type        = bool
+  description = "Prevent accidental PostgreSQL server deletion. Set false for dev/test environments."
+  default     = true
+}
+
+variable "langsmith_namespace" {
+  type        = string
+  description = "Namespace of the LangSmith deployment. Used to set up workload identity in a specific namespace for blob storage."
+  default     = "langsmith"
+}
+
+variable "langsmith_domain" {
+  type        = string
+  description = "Hostname for the LangSmith deployment (e.g. langsmith.example.com). Used in Helm values and ingress TLS configuration."
+  default     = ""
+}
+
+variable "langsmith_helm_chart_version" {
+  type        = string
+  description = "Pin a specific LangSmith Helm chart version for reproducible deploys. Empty string = use latest available."
+  default     = ""
+}
+
+# TLS: the ingress consumes a Kubernetes secret named `langsmith-tls`, created by
+# infra/scripts/create-tls-secret.sh (self-signed for testing; replace for prod).
+# There is no cert-manager and no tls_certificate_source variable — see DEPLOYMENT.md.
+
+variable "postgres_admin_username" {
+  type        = string
+  description = "The username of the Postgres administrator"
+  default     = "langsmith"
+}
+
+variable "postgres_admin_password" {
+  type        = string
+  description = "The password of the Postgres administrator. Set via: source setup-env.sh"
+  sensitive   = true
+  default     = ""
+}
+
+# ── LangSmith secrets (stored in Key Vault by the keyvault module) ────────────
+# These are written to Azure Key Vault on first apply. On subsequent runs,
+# setup-env.sh reads them back from Key Vault so they stay stable.
+# scripts/create-k8s-secrets.sh pulls them from Key Vault into the cluster.
+
+variable "langsmith_release_name" {
+  type        = string
+  description = "Helm release name for LangSmith (used for Workload Identity federated credential subjects in the k8s-cluster module)"
+  default     = "langsmith"
+
+  # The chart renders service-account names as <langsmith.fullname>-<component>, and
+  # langsmith.fullname collapses to just the release name only when the release name
+  # CONTAINS the chart name "langsmith". If it doesn't, the rendered SA names won't
+  # match the federated-credential subjects and Workload Identity fails silently.
+  validation {
+    condition     = can(regex("langsmith", var.langsmith_release_name))
+    error_message = "langsmith_release_name must contain the substring \"langsmith\" so the chart's rendered ServiceAccount names match the Workload Identity federation (see DEPLOYMENT.md → Chart-version compatibility)."
+  }
+}
+
+variable "langsmith_license_key" {
+  type        = string
+  description = "LangSmith enterprise license key. Stored in Key Vault; surfaced into the cluster as key langsmith_license_key of the langsmith-config-secret by create-k8s-secrets.sh."
+  sensitive   = true
+  default     = ""
+}
+
+variable "langsmith_admin_password" {
+  type        = string
+  description = "Initial LangSmith organization admin password. Stored in Key Vault: langsmith-admin-password."
+  sensitive   = true
+  default     = ""
+}
+
+variable "langsmith_admin_email" {
+  type        = string
+  description = "Initial LangSmith organization admin email. Set via setup-env.sh — used as initialOrgAdminEmail in Helm values."
+  default     = ""
+}
+
+variable "langsmith_api_key_salt" {
+  type        = string
+  description = "Salt used to hash LangSmith API keys. Generate once: openssl rand -base64 32. Keep stable — changing invalidates all API keys. Stored in Key Vault: langsmith-api-key-salt. Set via setup-env.sh (TF_VAR_langsmith_api_key_salt)."
+  sensitive   = true
+  default     = ""
+}
+
+variable "langsmith_jwt_secret" {
+  type        = string
+  description = "JWT secret for LangSmith Basic Auth sessions. Generate once: openssl rand -base64 32. Keep stable. Stored in Key Vault: langsmith-jwt-secret. Set via setup-env.sh (TF_VAR_langsmith_jwt_secret)."
+  sensitive   = true
+  default     = ""
+}
+
+# ── LangGraph Platform encryption keys ───────────────────────────────────────
+# Stored in Key Vault by Terraform. Surfaced into the cluster by
+# scripts/create-k8s-secrets.sh when the matching feature is enabled via Helm
+# overlays. Generate once and never change.
+
+variable "langsmith_deployments_encryption_key" {
+  type        = string
+  description = "Fernet key for LangSmith Deployments. Stored in Key Vault: langsmith-deployments-encryption-key."
+  sensitive   = true
+  default     = ""
+}
+
+variable "langsmith_agent_builder_encryption_key" {
+  type        = string
+  description = "Fernet key for Agent Builder. Stored in Key Vault: langsmith-agent-builder-encryption-key."
+  sensitive   = true
+  default     = ""
+}
+
+variable "langsmith_insights_encryption_key" {
+  type        = string
+  description = "Fernet key for Insights (Clio). Stored in Key Vault: langsmith-insights-encryption-key. Must stay stable — changing breaks existing insights data."
+  sensitive   = true
+  default     = ""
+}
+
+variable "langsmith_polly_encryption_key" {
+  type        = string
+  description = "Fernet key for Polly agent. Stored in Key Vault: langsmith-polly-encryption-key. Must stay stable — changing breaks existing Polly data."
+  sensitive   = true
+  default     = ""
+}
+
+# ── Diagnostics ───────────────────────────────────────────────────────────────
+
+variable "log_retention_days" {
+  type        = number
+  description = "Log Analytics workspace retention in days."
+  default     = 90
+}
+
+# ── Bastion ───────────────────────────────────────────────────────────────────
+
+variable "bastion_vm_size" {
+  type        = string
+  description = "VM SKU for the bastion host."
+  default     = "Standard_B2s"
+}
+
+variable "bastion_admin_ssh_public_key" {
+  type        = string
+  description = "SSH public key for emergency admin access to the bastion VM."
+  default     = ""
+}
+
+variable "bastion_allowed_ssh_cidrs" {
+  type        = list(string)
+  description = "CIDR ranges allowed inbound SSH to the bastion. Restrict to VPN/corporate ranges in production."
+  default     = ["0.0.0.0/0"]
+}
+
+# ── Multi-AZ ─────────────────────────────────────────────────────────────────
+
+variable "availability_zones" {
+  type        = list(string)
+  description = "Availability zones to deploy into. Use [\"1\",\"2\",\"3\"] for zone-redundant HA. Default [\"1\"] for single-zone."
+  default     = ["1"]
+}
+
+variable "postgres_standby_availability_zone" {
+  type        = string
+  description = "Standby AZ for Postgres HA (ZoneRedundant mode). Leave empty to disable HA standby."
+  default     = ""
+}
+
+variable "postgres_geo_redundant_backup" {
+  type        = bool
+  description = "Enable geo-redundant backups for PostgreSQL."
+  default     = false
+}
+
+# ── Helm / deployment flags (read by bash scripts, not by Terraform) ──────────
+# These variables are declared here only to prevent Terraform from warning
+# about undeclared variables in terraform.tfvars. They are read by
+# helm/scripts/init-values.sh and helm/scripts/deploy.sh.
+
+variable "sizing_profile" {
+  type        = string
+  description = "Helm sizing overlay. One of: minimum | dev | production | production-large. Read by helm/scripts/init-values.sh and deploy.sh — Terraform ignores this value."
+  default     = "production"
+}
+
+variable "enable_deployments" {
+  type        = bool
+  description = "Pass 3 — enable LangGraph Platform (hostBackend, listener, operator). Read by deploy.sh — Terraform ignores this value."
+  default     = false
+}
+
+variable "enable_agent_builder" {
+  type        = bool
+  description = "Pass 4 — enable Agent Builder UI. Read by deploy.sh — Terraform ignores this value."
+  default     = false
+}
+
+variable "enable_insights" {
+  type        = bool
+  description = "Pass 5 — enable Insights / Clio. Read by deploy.sh — Terraform ignores this value."
+  default     = false
+}
+
+variable "enable_polly" {
+  type        = bool
+  description = "Pass 5 — enable Polly AI eval agent. Read by deploy.sh — Terraform ignores this value."
+  default     = false
+}
+
+# ── AKS networking (Azure CNI Overlay / egress) ──────────────────────────────
+# NOTE: network_plugin_mode, network_policy, and outbound_type are hardcoded
+# in main.tf (overlay / cilium / userDefinedRouting). Only the pod CIDR is
+# exposed as a variable since it must not overlap VNet/service ranges.
+
+variable "aks_pod_cidr" {
+  type        = string
+  description = "Pod CIDR for Azure CNI Overlay. Must not overlap the VNet, aks_service_cidr, or peered/on-prem ranges."
+  default     = "10.244.0.0/16"
+}
+
+# ── AKS private API server ────────────────────────────────────────────────────
+
+variable "aks_private_cluster_public_fqdn_enabled" {
+  type        = bool
+  description = "Expose a public FQDN for the private API server. Default false (disabled)."
+  default     = false
+}
+
+variable "aks_private_dns_zone_id" {
+  type        = string
+  description = "Private DNS zone for the private API server. \"\" => \"System\" (AKS-managed). \"None\" => BYO DNS. Or a private DNS zone resource ID. Note: \"None\" requires aks_private_cluster_public_fqdn_enabled = true — AKS does not support \"None\" together with a disabled public FQDN."
+  default     = ""
+}
+
+# ── AKS control-plane (cluster) managed identity ──────────────────────────────
+
+variable "aks_create_cluster_identity" {
+  type        = bool
+  description = "Create a user-assigned managed identity for the AKS control plane and grant it Network Contributor on the VNet — VNet scope so it can join the subnet and link the System private DNS zone for a private cluster. Azure recommends a user-assigned identity for BYO-VNet / userDefinedRouting. Default true (always-user-assigned posture). Mutually exclusive with aks_cluster_identity_id."
+  default     = true
+}
+
+variable "aks_cluster_identity_id" {
+  type        = string
+  description = "Resource ID of an existing user-assigned managed identity to use as the AKS control-plane identity. Required for a custom (BYO) API-server private DNS zone — pre-grant it Private DNS Zone Contributor on the zone and Network Contributor on the VNet/subnet. Mutually exclusive with aks_create_cluster_identity. Empty => system-assigned."
+  default     = ""
+}

--- a/modules/azure-private/infra/versions.tf
+++ b/modules/azure-private/infra/versions.tf
@@ -1,0 +1,30 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+    # Azure Managed Redis (Microsoft.Cache/redisEnterprise) Balanced SKUs aren't
+    # reliably exposed by azurerm yet — the redis module provisions AMR via azapi.
+    azapi = {
+      source  = "Azure/azapi"
+      version = "~> 2.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 3.0"
+    }
+    # Required by the keyvault module for RBAC propagation wait
+    time = {
+      source  = "hashicorp/time"
+      version = "~> 0.10"
+    }
+  }
+}
+
+provider "azurerm" {
+  subscription_id = var.subscription_id
+  features {}
+}

--- a/modules/azure-private/test/hub-spoke/.terraform.lock.hcl
+++ b/modules/azure-private/test/hub-spoke/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/azurerm" {
+  version     = "4.79.0"
+  constraints = "~> 4.0"
+  hashes = [
+    "h1:hEVrA2r7nS0jSd32CwsWNfifS8tV0xhoGuc1T9qU074=",
+    "zh:0129b3fa33289d54f86f150377b19127f85787116b7cc53564fed77c2e2468be",
+    "zh:131427cf40dd3fa4ec52af938b7ab0fd100bcacd75b7137c8e1ea5bf268c4638",
+    "zh:162ebd8f195ac28324d9e9f2e9b39a05d8a946abff21087a43123c83ca807a5d",
+    "zh:209a23777acdcfc674791a4ad37ba4e2110044857afb9db88aa305222fef706c",
+    "zh:21cf740e1fee936de429fa324b86af69c4fe90bbfdbb1f374e6a55118fdff841",
+    "zh:4ad1cde7ad4ef7187633b7fc7b0ed76ef2526b56fbb29f80a6fc54d07ac1204a",
+    "zh:57b942405b27af17cfad9a48d9e4ec75c0bb452f229dd132d6f1d8518ca4a067",
+    "zh:69a4fda56d6405027f303463f796a0d2d250403f67cecf2a25bcdfaeaf731630",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7c21524a423d95a4c84039e06a610f131c0618ee117da9c35e4b4f41d1210c64",
+    "zh:9045f6bb9f764709a5773d8ec65735f56c9995dc9c9ec3f85f2c6adf58654f3c",
+    "zh:e018581ed136640ba733ab583fd0072536b1bc096d66f2215787823cee6cfcdc",
+  ]
+}

--- a/modules/azure-private/test/hub-spoke/README.md
+++ b/modules/azure-private/test/hub-spoke/README.md
@@ -1,0 +1,70 @@
+# Test scaffold — hub-and-spoke + Azure Firewall for `azure-private`
+
+> **This is Path A, step 1.** This scaffold builds the *prerequisite* network so you can
+> test-drive the module without an enterprise VNet. Apply it, grab its output, then continue with
+> the deploy runbook — [`../../DEPLOYMENT.md`](../../DEPLOYMENT.md) from **Phase 1** onward — for
+> the `infra/` apply, the jumpbox bootstrap, and the Helm install.
+
+> **Test-only.** This stands up the *prerequisite* network that `modules/azure-private`
+> consumes (it's a BYO-VNet module). It is **not** part of a production deployment. It deploys
+> into an **existing resource group** (`var.resource_group_name`, default `rg-langsmith-test`) and
+> never creates or deletes that RG — `terraform destroy` removes only the scaffold's resources.
+> **It runs an Azure Firewall and a VM — it costs money while up.** Tear it down when done.
+
+## What it creates
+
+```
+Hub VNet 10.0.0.0/16
+  ├─ AzureFirewallSubnet            (10.0.0.0/26)
+  ├─ AzureFirewallManagementSubnet  (10.0.0.64/26)   ← required by Firewall Basic
+  └─ Azure Firewall (Basic) + policy: allow AKS egress
+        • app rule:  AzureKubernetesService FQDN tag (80/443)
+        • net rules: UDP 1194 + TCP 9000 → AzureCloud, UDP 123 (NTP)
+Spoke VNet 10.1.0.0/16
+  ├─ aks         (10.1.0.0/22)  route table 0.0.0.0/0 → firewall; SE: Storage + KeyVault
+  ├─ postgres-pe (10.1.4.0/24)  private-endpoint subnet (NOT delegated)
+  ├─ redis-pe    (10.1.5.0/24)  private-endpoint subnet
+  └─ jumpbox     (10.1.6.0/24)  apply-host VM (public IP, SSH from your CIDR only)
+Peering hub <-> spoke (forwarded traffic allowed)
+```
+
+## Apply the scaffold (from anywhere)
+
+```bash
+cd modules/azure-private/test/hub-spoke
+cp terraform.tfvars.example terraform.tfvars
+# edit: subscription_id, allowed_ssh_cidr (your IP/32), jumpbox_ssh_public_key
+terraform init
+terraform apply
+
+# Grab the two values the deploy runbook needs:
+terraform output azure_private_tfvars     # paste into ../../infra/terraform.tfvars
+terraform output -raw jumpbox_ssh         # SSH command for the apply host (used at Phase 3)
+```
+
+**Next → [`../../DEPLOYMENT.md`](../../DEPLOYMENT.md) from Phase 1.** Paste `azure_private_tfvars`
+into `infra/terraform.tfvars`, then follow the phases (infra apply → jumpbox bootstrap → secrets →
+Helm). The `jumpbox_ssh` output is your in-VNet apply host for the `bootstrap/` phases.
+
+## Notes
+
+- **CIDR overlap:** `azure-private`'s default `aks_service_cidr` (`10.0.64.0/20`) overlaps the
+  hub `10.0.0.0/16`. The `azure_private_tfvars` output already overrides it to `10.2.0.0/20`
+  (with `aks_pod_cidr = 10.244.0.0/16`) — keep those non-overlapping values.
+- **Two VMs in the jumpbox subnet:** `azure-private` also provisions its own bastion VM (always
+  on) in `bastion_subnet_id`. That's fine — this scaffold's jumpbox is your *apply host*; the
+  module's bastion is for day-2 access.
+- **System private DNS:** with `aks_private_dns_zone_id = ""`, AKS auto-links its API-server
+  zone to the spoke VNet, so the jumpbox resolves the private API. No custom DNS forwarder is
+  needed in this basic setup.
+- **`infra/` is not blocked by the private API.** Apply it from anywhere. Only `bootstrap/`
+  needs VNet connectivity (it uses the Kubernetes and Helm providers).
+
+## Teardown
+
+Tear down the module first (see [`../../DEPLOYMENT.md` § Teardown](../../DEPLOYMENT.md#teardown) —
+`bootstrap/` from the jumpbox, then `infra/`), **then** destroy this scaffold:
+
+```bash
+cd modules/azure-private/test/hub-spoke && terraform destroy
+```

--- a/modules/azure-private/test/hub-spoke/cloud-init.yaml
+++ b/modules/azure-private/test/hub-spoke/cloud-init.yaml
@@ -1,0 +1,25 @@
+#cloud-config
+# Jumpbox bootstrap: install the tools needed to run azure-private from inside
+# the spoke VNet (az / terraform / kubectl / helm).
+package_update: true
+packages:
+  - curl
+  - unzip
+  - git
+  - apt-transport-https
+  - ca-certificates
+  - gnupg
+  - lsb-release
+runcmd:
+  # Azure CLI
+  - curl -sL https://aka.ms/InstallAzureCLIDeb | bash
+  # Terraform (HashiCorp apt repo)
+  - wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg
+  - echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" > /etc/apt/sources.list.d/hashicorp.list
+  - apt-get update && apt-get install -y terraform
+  # kubectl
+  - curl -fsSLo /usr/local/bin/kubectl "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+  - chmod +x /usr/local/bin/kubectl
+  # Helm
+  - curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+final_message: "Jumpbox ready. Run 'az login', clone the repo, and apply modules/azure-private from here."

--- a/modules/azure-private/test/hub-spoke/main.tf
+++ b/modules/azure-private/test/hub-spoke/main.tf
@@ -1,0 +1,356 @@
+# ══════════════════════════════════════════════════════════════════════════════
+# TEST SCAFFOLD — hub-and-spoke + Azure Firewall (Basic) + jumpbox apply host.
+#
+# Purpose: stand up the prerequisite network that modules/azure-private CONSUMES,
+# so you can test a real private-cluster deployment. This is NOT part of a
+# production deployment — apply it, feed its outputs into azure-private, run the
+# module from the jumpbox, then `terraform destroy` it.
+#
+# Deploys into an EXISTING resource group (var.resource_group_name); region is
+# inherited from that RG. Destroy removes only the scaffold's resources — never
+# the RG itself.
+#
+# Topology:
+#   Hub  10.0.0.0/16  — AzureFirewallSubnet (+ mgmt subnet) + Azure Firewall Basic
+#   Spoke 10.1.0.0/16 — aks / postgres-pe / redis-pe / jumpbox subnets
+#   Peering hub <-> spoke; AKS subnet default-routes 0.0.0.0/0 -> firewall.
+# ══════════════════════════════════════════════════════════════════════════════
+
+locals {
+  # Subnet plan.
+  fw_subnet_cidr      = cidrsubnet(var.hub_cidr, 10, 0) # 10.0.0.0/26  (AzureFirewallSubnet, /26 min)
+  fw_mgmt_subnet_cidr = cidrsubnet(var.hub_cidr, 10, 1) # 10.0.0.64/26 (AzureFirewallManagementSubnet)
+
+  aks_subnet_cidr      = cidrsubnet(var.spoke_cidr, 6, 0) # 10.1.0.0/22  (nodes; pods use overlay pod_cidr)
+  postgres_subnet_cidr = cidrsubnet(var.spoke_cidr, 8, 4) # 10.1.4.0/24  (Postgres private endpoint)
+  redis_subnet_cidr    = cidrsubnet(var.spoke_cidr, 8, 5) # 10.1.5.0/24  (Redis private endpoint)
+  jumpbox_subnet_cidr  = cidrsubnet(var.spoke_cidr, 8, 6) # 10.1.6.0/24  (jumpbox apply host)
+
+  location = data.azurerm_resource_group.test.location
+}
+
+# Existing resource group — everything in this scaffold deploys here. The scaffold
+# never creates or deletes the RG; `terraform destroy` removes only its resources.
+data "azurerm_resource_group" "test" {
+  name = var.resource_group_name
+}
+
+# ── Hub VNet + Azure Firewall (Basic) ─────────────────────────────────────────
+
+resource "azurerm_virtual_network" "hub" {
+  name                = "${var.prefix}-hub-vnet"
+  location            = local.location
+  resource_group_name = data.azurerm_resource_group.test.name
+  address_space       = [var.hub_cidr]
+  tags                = var.tags
+}
+
+# Azure Firewall requires a subnet named EXACTLY "AzureFirewallSubnet".
+resource "azurerm_subnet" "firewall" {
+  name                 = "AzureFirewallSubnet"
+  resource_group_name  = data.azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.hub.name
+  address_prefixes     = [local.fw_subnet_cidr]
+}
+
+# Firewall Basic SKU additionally requires "AzureFirewallManagementSubnet".
+resource "azurerm_subnet" "firewall_mgmt" {
+  name                 = "AzureFirewallManagementSubnet"
+  resource_group_name  = data.azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.hub.name
+  address_prefixes     = [local.fw_mgmt_subnet_cidr]
+}
+
+resource "azurerm_public_ip" "fw_data" {
+  name                = "${var.prefix}-fw-data-pip"
+  location            = local.location
+  resource_group_name = data.azurerm_resource_group.test.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+  tags                = var.tags
+}
+
+# Basic SKU mandates a separate management public IP.
+resource "azurerm_public_ip" "fw_mgmt" {
+  name                = "${var.prefix}-fw-mgmt-pip"
+  location            = local.location
+  resource_group_name = data.azurerm_resource_group.test.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+  tags                = var.tags
+}
+
+resource "azurerm_firewall_policy" "hub" {
+  name                = "${var.prefix}-fw-policy"
+  resource_group_name = data.azurerm_resource_group.test.name
+  location            = local.location
+  sku                 = "Basic"
+  tags                = var.tags
+}
+
+# Minimal AKS egress allowlist (per "Control egress traffic for AKS"):
+#   • Application rule: the AzureKubernetesService FQDN tag (control-plane, image
+#     pulls, etc. over 80/443).
+#   • Network rules: API server tunnel (UDP 1194 / TCP 9000 to AzureCloud) + NTP.
+resource "azurerm_firewall_policy_rule_collection_group" "aks_egress" {
+  name               = "aks-egress"
+  firewall_policy_id = azurerm_firewall_policy.hub.id
+  priority           = 200
+
+  application_rule_collection {
+    name     = "aks-application"
+    priority = 200
+    action   = "Allow"
+
+    rule {
+      name                  = "aks-fqdn-tag"
+      source_addresses      = [var.spoke_cidr]
+      destination_fqdn_tags = ["AzureKubernetesService"]
+      protocols {
+        type = "Http"
+        port = 80
+      }
+      protocols {
+        type = "Https"
+        port = 443
+      }
+    }
+  }
+
+  network_rule_collection {
+    name     = "aks-network"
+    priority = 210
+    action   = "Allow"
+
+    rule {
+      name                  = "apiserver-udp"
+      protocols             = ["UDP"]
+      source_addresses      = [var.spoke_cidr]
+      destination_addresses = ["AzureCloud"]
+      destination_ports     = ["1194"]
+    }
+    rule {
+      name                  = "apiserver-tcp"
+      protocols             = ["TCP"]
+      source_addresses      = [var.spoke_cidr]
+      destination_addresses = ["AzureCloud"]
+      destination_ports     = ["9000"]
+    }
+    rule {
+      name                  = "ntp"
+      protocols             = ["UDP"]
+      source_addresses      = [var.spoke_cidr]
+      destination_addresses = ["*"]
+      destination_ports     = ["123"]
+    }
+  }
+}
+
+resource "azurerm_firewall" "hub" {
+  name                = "${var.prefix}-fw"
+  location            = local.location
+  resource_group_name = data.azurerm_resource_group.test.name
+  sku_name            = "AZFW_VNet"
+  sku_tier            = "Basic"
+  firewall_policy_id  = azurerm_firewall_policy.hub.id
+  tags                = var.tags
+
+  ip_configuration {
+    name                 = "data"
+    subnet_id            = azurerm_subnet.firewall.id
+    public_ip_address_id = azurerm_public_ip.fw_data.id
+  }
+
+  management_ip_configuration {
+    name                 = "management"
+    subnet_id            = azurerm_subnet.firewall_mgmt.id
+    public_ip_address_id = azurerm_public_ip.fw_mgmt.id
+  }
+}
+
+# ── Spoke VNet + subnets ──────────────────────────────────────────────────────
+
+resource "azurerm_virtual_network" "spoke" {
+  name                = "${var.prefix}-spoke-vnet"
+  location            = local.location
+  resource_group_name = data.azurerm_resource_group.test.name
+  address_space       = [var.spoke_cidr]
+  tags                = var.tags
+}
+
+# AKS node subnet — service endpoints let the Blob/Key Vault default-deny
+# firewalls allowlist this subnet (azure-private requires both).
+resource "azurerm_subnet" "aks" {
+  name                 = "aks"
+  resource_group_name  = data.azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.spoke.name
+  address_prefixes     = [local.aks_subnet_cidr]
+  service_endpoints    = ["Microsoft.Storage", "Microsoft.KeyVault"]
+}
+
+# Postgres private-endpoint subnet (regular subnet, NOT delegated).
+resource "azurerm_subnet" "postgres" {
+  name                 = "postgres-pe"
+  resource_group_name  = data.azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.spoke.name
+  address_prefixes     = [local.postgres_subnet_cidr]
+}
+
+# Redis private-endpoint subnet.
+resource "azurerm_subnet" "redis" {
+  name                 = "redis-pe"
+  resource_group_name  = data.azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.spoke.name
+  address_prefixes     = [local.redis_subnet_cidr]
+}
+
+# Jumpbox subnet (apply host + azure-private's own bastion both land here).
+resource "azurerm_subnet" "jumpbox" {
+  name                 = "jumpbox"
+  resource_group_name  = data.azurerm_resource_group.test.name
+  virtual_network_name = azurerm_virtual_network.spoke.name
+  address_prefixes     = [local.jumpbox_subnet_cidr]
+}
+
+# ── UDR: default-route the AKS subnet through the firewall ─────────────────────
+
+resource "azurerm_route_table" "aks" {
+  name                = "${var.prefix}-aks-rt"
+  location            = local.location
+  resource_group_name = data.azurerm_resource_group.test.name
+  tags                = var.tags
+}
+
+resource "azurerm_route" "default_to_firewall" {
+  name                   = "default-to-firewall"
+  resource_group_name    = data.azurerm_resource_group.test.name
+  route_table_name       = azurerm_route_table.aks.name
+  address_prefix         = "0.0.0.0/0"
+  next_hop_type          = "VirtualAppliance"
+  next_hop_in_ip_address = azurerm_firewall.hub.ip_configuration[0].private_ip_address
+}
+
+resource "azurerm_subnet_route_table_association" "aks" {
+  subnet_id      = azurerm_subnet.aks.id
+  route_table_id = azurerm_route_table.aks.id
+}
+
+# ── Peering hub <-> spoke ─────────────────────────────────────────────────────
+
+resource "azurerm_virtual_network_peering" "hub_to_spoke" {
+  name                         = "hub-to-spoke"
+  resource_group_name          = data.azurerm_resource_group.test.name
+  virtual_network_name         = azurerm_virtual_network.hub.name
+  remote_virtual_network_id    = azurerm_virtual_network.spoke.id
+  allow_virtual_network_access = true
+  allow_forwarded_traffic      = true
+}
+
+resource "azurerm_virtual_network_peering" "spoke_to_hub" {
+  name                         = "spoke-to-hub"
+  resource_group_name          = data.azurerm_resource_group.test.name
+  virtual_network_name         = azurerm_virtual_network.spoke.name
+  remote_virtual_network_id    = azurerm_virtual_network.hub.id
+  allow_virtual_network_access = true
+  allow_forwarded_traffic      = true
+}
+
+# ── Jumpbox apply host ────────────────────────────────────────────────────────
+# A private cluster can't be bootstrapped from your laptop. SSH here (it lands in
+# the spoke), install/clone azure-private, and run `terraform apply` from this VM.
+
+# Gated by var.create_jumpbox. The jumpbox SUBNET stays regardless (azure-private's
+# own bastion uses it as bastion_subnet_id) — only the VM + its NIC/NSG/PIP are
+# optional. Skip it for an infra-only test (the apply runs from outside the VNet).
+resource "azurerm_public_ip" "jumpbox" {
+  count               = var.create_jumpbox ? 1 : 0
+  name                = "${var.prefix}-jumpbox-pip"
+  location            = local.location
+  resource_group_name = data.azurerm_resource_group.test.name
+  allocation_method   = "Static"
+  sku                 = "Standard"
+  tags                = var.tags
+}
+
+resource "azurerm_network_security_group" "jumpbox" {
+  count               = var.create_jumpbox ? 1 : 0
+  name                = "${var.prefix}-jumpbox-nsg"
+  location            = local.location
+  resource_group_name = data.azurerm_resource_group.test.name
+  tags                = var.tags
+
+  security_rule {
+    name                       = "allow-ssh-from-operator"
+    priority                   = 100
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "22"
+    source_address_prefix      = var.allowed_ssh_cidr
+    destination_address_prefix = "*"
+  }
+
+  # Enforce the SSH source restriction only when the jumpbox exists (a counted
+  # resource's precondition is not evaluated when count = 0).
+  lifecycle {
+    precondition {
+      condition     = var.allowed_ssh_cidr != "" && var.allowed_ssh_cidr != "0.0.0.0/0"
+      error_message = "allowed_ssh_cidr must be a specific CIDR (e.g. your IP /32) when create_jumpbox = true; empty or 0.0.0.0/0 is not allowed."
+    }
+  }
+}
+
+resource "azurerm_network_interface" "jumpbox" {
+  count               = var.create_jumpbox ? 1 : 0
+  name                = "${var.prefix}-jumpbox-nic"
+  location            = local.location
+  resource_group_name = data.azurerm_resource_group.test.name
+  tags                = var.tags
+
+  ip_configuration {
+    name                          = "ipconfig"
+    subnet_id                     = azurerm_subnet.jumpbox.id
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = azurerm_public_ip.jumpbox[0].id
+  }
+}
+
+resource "azurerm_network_interface_security_group_association" "jumpbox" {
+  count                     = var.create_jumpbox ? 1 : 0
+  network_interface_id      = azurerm_network_interface.jumpbox[0].id
+  network_security_group_id = azurerm_network_security_group.jumpbox[0].id
+}
+
+resource "azurerm_linux_virtual_machine" "jumpbox" {
+  count                 = var.create_jumpbox ? 1 : 0
+  name                  = "${var.prefix}-jumpbox"
+  location              = local.location
+  resource_group_name   = data.azurerm_resource_group.test.name
+  size                  = var.jumpbox_vm_size
+  admin_username        = var.jumpbox_admin_username
+  network_interface_ids = [azurerm_network_interface.jumpbox[0].id]
+  tags                  = var.tags
+
+  # Key auth only — providing admin_ssh_key with no admin_password disables
+  # password authentication.
+  admin_ssh_key {
+    username   = var.jumpbox_admin_username
+    public_key = var.jumpbox_ssh_public_key
+  }
+
+  os_disk {
+    caching              = "ReadWrite"
+    storage_account_type = "Standard_LRS"
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "ubuntu-24_04-lts"
+    sku       = "server"
+    version   = "latest"
+  }
+
+  # Installs az / terraform / kubectl / helm so you can run azure-private here.
+  custom_data = base64encode(file("${path.module}/cloud-init.yaml"))
+}

--- a/modules/azure-private/test/hub-spoke/outputs.tf
+++ b/modules/azure-private/test/hub-spoke/outputs.tf
@@ -1,0 +1,89 @@
+output "resource_group_name" {
+  description = "RG to pass to azure-private as resource_group_name (it deploys into this same RG)."
+  value       = data.azurerm_resource_group.test.name
+}
+
+output "location" {
+  description = "Region (azure-private inherits region from the RG)."
+  value       = data.azurerm_resource_group.test.location
+}
+
+output "vnet_id" {
+  description = "Spoke VNet ID → azure-private var: vnet_id"
+  value       = azurerm_virtual_network.spoke.id
+}
+
+output "aks_subnet_id" {
+  description = "→ azure-private var: aks_subnet_id"
+  value       = azurerm_subnet.aks.id
+}
+
+output "postgres_subnet_id" {
+  description = "→ azure-private var: postgres_subnet_id (private endpoint subnet)"
+  value       = azurerm_subnet.postgres.id
+}
+
+output "redis_subnet_id" {
+  description = "→ azure-private var: redis_subnet_id (private endpoint subnet)"
+  value       = azurerm_subnet.redis.id
+}
+
+output "bastion_subnet_id" {
+  description = "→ azure-private var: bastion_subnet_id (jumpbox subnet)"
+  value       = azurerm_subnet.jumpbox.id
+}
+
+output "firewall_private_ip" {
+  description = "Firewall private IP the AKS subnet default-routes to (FYI)."
+  value       = azurerm_firewall.hub.ip_configuration[0].private_ip_address
+}
+
+output "jumpbox_public_ip" {
+  description = "Public IP of the jumpbox apply host (null when create_jumpbox = false)."
+  value       = one(azurerm_public_ip.jumpbox[*].ip_address)
+}
+
+output "jumpbox_ssh" {
+  description = "SSH to the apply host (run the bootstrap from here)."
+  value       = var.create_jumpbox ? "ssh ${var.jumpbox_admin_username}@${one(azurerm_public_ip.jumpbox[*].ip_address)}" : "jumpbox not created (create_jumpbox = false)"
+}
+
+# Ready-to-paste azure-private tfvars. Note the CIDRs are chosen to NOT overlap
+# the hub/spoke VNets (azure-private's default aks_service_cidr = 10.0.64.0/20
+# WOULD overlap the hub 10.0.0.0/16, so it is overridden here).
+output "bootstrap_tfvars" {
+  description = "Paste into modules/azure-private/bootstrap/terraform.tfvars (or supply as -var flags). Needs only subscription_id, resource_group_name, and identifier."
+  value       = <<-EOT
+    subscription_id     = "<your-subscription-id>"
+    resource_group_name = "${data.azurerm_resource_group.test.name}"
+    identifier          = "<same identifier used for infra/>"
+  EOT
+}
+
+output "azure_private_tfvars" {
+  description = "Paste into modules/azure-private/infra/terraform.tfvars (fill in subscription_id + secrets)."
+  value       = <<-EOT
+    subscription_id     = "<your-subscription-id>"
+    resource_group_name = "${data.azurerm_resource_group.test.name}"
+
+    vnet_id            = "${azurerm_virtual_network.spoke.id}"
+    aks_subnet_id      = "${azurerm_subnet.aks.id}"
+    postgres_subnet_id = "${azurerm_subnet.postgres.id}"
+    redis_subnet_id    = "${azurerm_subnet.redis.id}"
+    bastion_subnet_id  = "${azurerm_subnet.jumpbox.id}"
+
+    # Non-overlapping with hub (${var.hub_cidr}) / spoke (${var.spoke_cidr}):
+    aks_service_cidr   = "10.2.0.0/20"
+    aks_dns_service_ip = "10.2.0.10"
+    aks_pod_cidr       = "10.244.0.0/16"
+
+    aks_private_dns_zone_id     = ""     # System-managed zone (auto-linked to the spoke VNet)
+    aks_create_cluster_identity = true   # module-created user-assigned identity (default)
+
+    bastion_admin_ssh_public_key = "<ssh-ed25519 ...>"
+    bastion_allowed_ssh_cidrs    = ["<your-operator-cidr/32>"]
+
+    # secrets — supply via TF_VAR_* or setup-env.sh:
+    # postgres_admin_password / langsmith_license_key / langsmith_api_key_salt / langsmith_jwt_secret
+  EOT
+}

--- a/modules/azure-private/test/hub-spoke/terraform.tfvars.example
+++ b/modules/azure-private/test/hub-spoke/terraform.tfvars.example
@@ -1,0 +1,13 @@
+# Test scaffold inputs. Copy to terraform.tfvars and fill in.
+# Deploys into the EXISTING resource group below; region is inherited from it.
+subscription_id     = "00000000-0000-0000-0000-000000000000"
+resource_group_name = "rg-langsmith-test"   # your existing RG (region is inherited from it)
+
+# Lock SSH to the jumpbox down to your operator IP (required; no 0.0.0.0/0).
+allowed_ssh_cidr       = "203.0.113.4/32"
+jumpbox_ssh_public_key = "ssh-ed25519 AAAA... you@host"
+
+# Defaults are usually fine:
+# hub_cidr        = "10.0.0.0/16"
+# spoke_cidr      = "10.1.0.0/16"
+# jumpbox_vm_size = "Standard_B2s"

--- a/modules/azure-private/test/hub-spoke/variables.tf
+++ b/modules/azure-private/test/hub-spoke/variables.tf
@@ -1,0 +1,69 @@
+variable "subscription_id" {
+  type        = string
+  description = "Azure subscription ID to deploy the test scaffold into."
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "EXISTING resource group to deploy the scaffold into (region is inherited from it). The scaffold never creates or deletes this RG."
+  default     = "rg-langsmith-test"
+}
+
+variable "prefix" {
+  type        = string
+  description = "Name prefix for the test scaffold resources."
+  default     = "lsazp-test"
+}
+
+variable "hub_cidr" {
+  type        = string
+  description = "Hub VNet address space (hosts Azure Firewall)."
+  default     = "10.0.0.0/16"
+}
+
+variable "spoke_cidr" {
+  type        = string
+  description = "Spoke VNet address space (hosts AKS + private endpoints + jumpbox). The firewall rules allow egress from this range."
+  default     = "10.1.0.0/16"
+}
+
+# ── Jumpbox apply host ────────────────────────────────────────────────────────
+
+variable "create_jumpbox" {
+  type        = bool
+  description = "Create the jumpbox apply-host VM. Set false for an infra-only test (the infra/ apply runs from outside the VNet). The jumpbox SUBNET is always created (azure-private's own bastion uses it). Default true."
+  default     = true
+}
+
+variable "allowed_ssh_cidr" {
+  type        = string
+  description = "CIDR allowed to SSH to the jumpbox (your operator IP, e.g. \"203.0.113.4/32\"). Required when create_jumpbox = true (must not be empty or 0.0.0.0/0 — enforced by a precondition on the jumpbox NSG)."
+  default     = ""
+}
+
+variable "jumpbox_ssh_public_key" {
+  type        = string
+  description = "SSH public key for the jumpbox admin user (key auth only). Required when create_jumpbox = true."
+  default     = ""
+}
+
+variable "jumpbox_vm_size" {
+  type        = string
+  description = "Jumpbox VM size."
+  default     = "Standard_B2s"
+}
+
+variable "jumpbox_admin_username" {
+  type        = string
+  description = "Admin username on the jumpbox VM."
+  default     = "azureuser"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Tags applied to all scaffold resources."
+  default = {
+    purpose    = "azure-private-test-scaffold"
+    managed_by = "terraform"
+  }
+}

--- a/modules/azure-private/test/hub-spoke/versions.tf
+++ b/modules/azure-private/test/hub-spoke/versions.tf
@@ -1,0 +1,15 @@
+# Test scaffold — pin providers independently of the module under test.
+terraform {
+  required_version = ">= 1.5"
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {}
+  subscription_id = var.subscription_id
+}


### PR DESCRIPTION
Private Azure / AKS Landing Zone Template

Self-contained, forkable enterprise landing zone, split into two Terraform roots:
- infra/ (azurerm-only): private AKS (CNI Overlay+Cilium, userDefinedRouting egress), Postgres + Redis via Private Endpoint, Blob, Key Vault, user-assigned control-plane identity, bastion, diagnostics. No Kubernetes/Helm providers; runs from anywhere.
- bootstrap/ (kubernetes/helm): namespace, K8s secrets, network policies, cert-manager, KEDA, internal NGINX. Discovers the cluster + secrets via Azure data sources + Key Vault (no shared Terraform state with infra/); runs from an in-VNet jumpbox.

Includes a hub-spoke + Azure Firewall test scaffold (test/hub-spoke, create_jumpbox toggle) and docs (README, DEPLOYMENT, PRIVATE_DNS) + design spec/plan.

Validated end-to-end against a real Azure resource group: private cluster, overlay/Cilium/UDR, Private-Endpoint Postgres/Redis, user-assigned identity + System DNS-zone link. modules/azure is unchanged from main.