### PR TITLE
Fix 3 bugs found testing AWS self-hosted Sandboxes E2E

### DIFF
--- a/modules/aws/helm/scripts/deploy.sh
+++ b/modules/aws/helm/scripts/deploy.sh
@@ -40,8 +40,8 @@ CHART_VERSION="${CHART_VERSION:-~0.15.1}"
 _chart_version_supports_sandboxes() {
   local version
   version="$(printf '%s' "$1" | tr -d '[:space:]')"
-  version="${version#~>}"
-  version="${version#~}"
+  version="${version#\~>}"
+  version="${version#\~}"
   version="${version#v}"
 
   case "$version" in

--- a/modules/aws/helm/scripts/init-values.sh
+++ b/modules/aws/helm/scripts/init-values.sh
@@ -113,6 +113,9 @@ ALB_ARN=$(terraform -chdir="$INFRA_DIR" output -raw alb_arn 2>/dev/null) || ALB_
 ALB_DNS_NAME=$(terraform -chdir="$INFRA_DIR" output -raw alb_dns_name 2>/dev/null) || ALB_DNS_NAME=""
 ALB_SCHEME=$(terraform -chdir="$INFRA_DIR" output -raw alb_scheme 2>/dev/null) || ALB_SCHEME="$_alb_scheme"
 ACM_CERT_ARN=$(terraform -chdir="$INFRA_DIR" output -raw acm_certificate_arn 2>/dev/null) || ACM_CERT_ARN=""
+CLUSTER_NAME=$(terraform -chdir="$INFRA_DIR" output -raw cluster_name 2>/dev/null) || {
+  echo "ERROR: Could not read cluster_name. Is 'terraform apply' complete?" >&2; exit 1
+}
 # Fallback to tfvars if the output isn't available (older infra module)
 if [[ -z "$ACM_CERT_ARN" && -n "$_acm_arn" ]]; then
   ACM_CERT_ARN="$_acm_arn"

--- a/modules/aws/infra/modules/eks/main.tf
+++ b/modules/aws/infra/modules/eks/main.tf
@@ -21,7 +21,8 @@ module "eks" {
   # AWS CLI or console) and the state already reflects the new values.
   eks_managed_node_groups = {
     for k, v in var.eks_managed_node_groups : k => merge(v, {
-      desired_size = coalesce(v.desired_size, v.min_size)
+      desired_size             = coalesce(v.desired_size, v.min_size)
+      iam_role_use_name_prefix = coalesce(v.iam_role_use_name_prefix, true)
     })
   }
 


### PR DESCRIPTION
Found and fixed 3 bugs while running an end-to-end AWS test of this branch's self-hosted Sandboxes support:

1. **`deploy.sh`** — `_chart_version_supports_sandboxes()` used an unescaped `~` in a parameter expansion, so the script's own documented `CHART_VERSION='~0.16.0'` syntax always failed the check.
2. **`init-values.sh`** — `$CLUSTER_NAME` was used to populate the sandbox config but never fetched, crashing with `CLUSTER_NAME: unbound variable` on every sandbox deploy. Added the missing fetch, matching the GCP module's existing pattern.
3. **`eks/main.tf`** — the new `iam_role_use_name_prefix` field has no default, so any node group that doesn't set it explicitly gets `null`, which the upstream AWS EKS module rejects (`Error: Null condition`). Defaulted it to `true` via `coalesce()`, same pattern already used for `desired_size` on the line above.

All three verified live against a real EKS cluster.