### PR TITLE
fix(aws): correct Envoy Gateway proxy target port (8080 -> 10080)

### DIFF
--- a/modules/aws/infra/main.tf
+++ b/modules/aws/infra/main.tf
@@ -413,8 +413,8 @@ resource "aws_vpc_security_group_ingress_rule" "alb_to_envoy" {
   # The cluster primary SG is on the control plane only — not on worker nodes.
   security_group_id            = module.eks.node_security_group_id
   referenced_security_group_id = module.alb.security_group_id
-  from_port                    = 8080
-  to_port                      = 8080
+  from_port                    = module.alb.gateway_target_port
+  to_port                      = module.alb.gateway_target_port
   ip_protocol                  = "tcp"
   description                  = "Allow ALB to reach Envoy Gateway proxy pods on HTTP (target-type: ip)"
 
@@ -426,8 +426,8 @@ resource "aws_vpc_security_group_ingress_rule" "alb_to_istio" {
 
   security_group_id            = module.eks.node_security_group_id
   referenced_security_group_id = module.alb.security_group_id
-  from_port                    = 80
-  to_port                      = 80
+  from_port                    = module.alb.gateway_target_port
+  to_port                      = module.alb.gateway_target_port
   ip_protocol                  = "tcp"
   description                  = "Allow ALB to reach Istio ingress gateway pods on HTTP (target-type: ip)"
 
@@ -439,8 +439,8 @@ resource "aws_vpc_security_group_ingress_rule" "alb_to_nginx" {
 
   security_group_id            = module.eks.node_security_group_id
   referenced_security_group_id = module.alb.security_group_id
-  from_port                    = 80
-  to_port                      = 80
+  from_port                    = module.alb.gateway_target_port
+  to_port                      = module.alb.gateway_target_port
   ip_protocol                  = "tcp"
   description                  = "Allow ALB to reach NGINX ingress controller pods on HTTP (target-type: ip)"
 

--- a/modules/aws/infra/modules/alb/main.tf
+++ b/modules/aws/infra/modules/alb/main.tf
@@ -20,10 +20,12 @@ data "aws_elb_service_account" "current" {}
 
 locals {
   gateway_enabled = var.enable_envoy_gateway || var.enable_istio_gateway || var.enable_nginx_ingress
-  # Envoy Gateway v1.0+: pods listen on port 8080 (matches the Gateway listener port; no offset).
+  # Envoy Gateway v1.3+: the managed proxy Service exposes port 80 -> targetPort 10080
+  # (the proxy pods run non-root and listen on 10080/10443), so the ALB target group,
+  # its health check, and the node security-group rule must all target 10080.
   # Istio ingress gateway: listens directly on port 80 (envoy with NET_BIND_SERVICE).
   # NGINX ingress controller: listens on port 80.
-  gateway_target_port = var.enable_envoy_gateway ? 8080 : 80
+  gateway_target_port = var.enable_envoy_gateway ? 10080 : 80
 }
 
 # ── Access Logs S3 Bucket ──────────────────────────────────────────────────────

--- a/modules/aws/infra/modules/alb/outputs.tf
+++ b/modules/aws/infra/modules/alb/outputs.tf
@@ -37,3 +37,8 @@ output "gateway_target_group_arn" {
   description = "ARN of the target group for gateway proxy (Envoy or Istio). Null when gateway mode is not enabled."
   value       = local.gateway_enabled ? aws_lb_target_group.gateway[0].arn : null
 }
+
+output "gateway_target_port" {
+  description = "Port on the gateway proxy pods that the ALB target group forwards to and health-checks (Envoy Gateway 10080, Istio/NGINX 80). Single source of truth for the matching node security-group ingress rule."
+  value       = local.gateway_target_port
+}

--- a/modules/aws/infra/modules/k8s-bootstrap/main.tf
+++ b/modules/aws/infra/modules/k8s-bootstrap/main.tf
@@ -532,7 +532,7 @@ MANIFEST
 # "envoy-<gateway-namespace>-<gateway-name>" in envoy-gateway-system.
 # For a Gateway named "langsmith-gateway" in the "langsmith" namespace:
 #   service: envoy-langsmith-langsmith-gateway (namespace: envoy-gateway-system)
-#   service port: 8080 (matches the Gateway resource's listener port)
+#   service port: 80 (the Service port; the LB controller resolves it to the proxy targetPort 10080)
 #
 # The TargetGroupBinding is in envoy-gateway-system (same namespace as the service).
 # Cross-namespace TargetGroupBindings are not supported by the AWS LB controller.
@@ -592,7 +592,7 @@ metadata:
 spec:
   serviceRef:
     name: $_svc_name
-    port: 8080
+    port: 80
   targetGroupARN: ${var.gateway_target_group_arn}
   targetType: ip
 MANIFEST


### PR DESCRIPTION
## Summary

`enable_envoy_gateway = true` currently yields an ALB with no healthy targets (503/504). Envoy Gateway v1.3 (pinned in this module) runs the managed proxy non-root, so its Service exposes `port 80 -> targetPort 10080` and the pods listen on `10080`. The module hardcoded `8080` for the Envoy path in three coupled places, so the ALB registered/health-checked the wrong port and the node security group never opened `10080`. Istio and NGINX modes were already correct (port 80).

## Root cause

Three independent literals assumed the Envoy proxy listens on `8080`:
- `modules/aws/infra/modules/alb/main.tf` - `gateway_target_port` (feeds the target group port and its health-check port)
- `modules/aws/infra/main.tf` - `alb_to_envoy` node security-group ingress rule
- `modules/aws/infra/modules/k8s-bootstrap/main.tf` - Envoy `TargetGroupBinding` `serviceRef.port`

Because they were separate literals, they could drift apart.

## Fix

- alb: `gateway_target_port` for Envoy `8080 -> 10080`.
- alb: expose `gateway_target_port` as a module output (single source of truth).
- infra: `alb_to_{envoy,istio,nginx}` node SG rules now reference `module.alb.gateway_target_port` instead of hardcoded ports, so the SG port can no longer drift from the target group port.
- k8s-bootstrap: Envoy `TargetGroupBinding` `serviceRef.port 8080 -> 80` (the k8s Service port, consistent with the istio/nginx bindings; the AWS LB controller resolves it to `targetPort 10080`).

Istio and NGINX resolve `module.alb.gateway_target_port` to `80`, so those modes are unchanged.

## Test plan

- Reproduced on an EKS sandbox (eu-central-1, EKS 1.35, Envoy Gateway v1.3): with `enable_envoy_gateway` the gateway target group had no healthy targets and the ALB returned 503/504.
- Confirmed the Envoy proxy Service maps `port 80 -> targetPort 10080`, and that the node SG only allowed the ALB SG on `8080`.
- With this change the target group / health check / node SG rule / TGB service port are all consistent (target registers on `10080` and health-checks pass); the ALB then reaches the proxy.
- Istio and NGINX paths unaffected (resolve to `80`).
- `terraform fmt -check -recursive modules/aws` clean.