### PR TITLE
Standardize EKS cluster version to 1.34, fix three unrelated deploy blockers hit while testing

### DIFF
--- a/modules/aws/README.md
+++ b/modules/aws/README.md
@@ -209,7 +209,7 @@ environment = "prod"
 region = "us-west-2"
 
 # EKS
-eks_cluster_version = "1.31"
+eks_cluster_version = "1.34"
 eks_managed_node_groups = {
   default = {
     name           = "node-group-default"
@@ -941,7 +941,7 @@ aws eks update-kubeconfig --name <cluster_name> --region <region>
 | `vpc_cidr_block` | `null` | when !create_vpc | Existing VPC CIDR block |
 | `enable_public_eks_cluster` | `true` | no | Enable public EKS API endpoint |
 | `eks_public_access_cidrs` | `["0.0.0.0/0"]` | no | CIDRs allowed to reach the public EKS API endpoint |
-| `eks_cluster_version` | `1.31` | no | EKS Kubernetes version |
+| `eks_cluster_version` | `1.34` | no | EKS Kubernetes version |
 | `eks_managed_node_group_defaults` | `{ami_type: AL2023}` | no | Default config for managed node groups |
 | `eks_managed_node_groups` | `{default: m5.4xlarge}` | no | Managed node group definitions |
 | `create_gp3_storage_class` | `true` | no | Create and set gp3 as default StorageClass |

--- a/modules/aws/helm/scripts/init-values.sh
+++ b/modules/aws/helm/scripts/init-values.sh
@@ -159,6 +159,10 @@ elif [[ -n "$ALB_DNS_NAME" ]]; then
 else
   HOSTNAME=""
 fi
+# Strip any scheme — it's re-added below via ${_protocol}, and reusing an
+# already-generated hostname verbatim (which includes one) would double it.
+HOSTNAME="${HOSTNAME#http://}"
+HOSTNAME="${HOSTNAME#https://}"
 
 # ── Admin email ───────────────────────────────────────────────────────────────
 EXISTING_EMAIL=""

--- a/modules/aws/infra/modules/eks/variables.tf
+++ b/modules/aws/infra/modules/eks/variables.tf
@@ -6,7 +6,7 @@ variable "cluster_name" {
 variable "cluster_version" {
   type        = string
   description = "The EKS version of the cluster"
-  default     = "1.31"
+  default     = "1.34"
 }
 
 variable "vpc_id" {

--- a/modules/aws/infra/scripts/_common.sh
+++ b/modules/aws/infra/scripts/_common.sh
@@ -32,11 +32,11 @@ _parse_tfvar() {
   # Quoted string: key = "value"
   val=$(echo "$raw" | sed -n 's/.*=[[:space:]]*"\([^"]*\)".*/\1/p' | tr -d '[:space:]')
   if [[ -z "$val" ]]; then
-    # Unquoted value: key = true / key = 42 / key = {}
+    # Unquoted value: key = true / key = 42 / key = {} / key = ["m5.2xlarge"]
     # Strip any trailing `# comment` BEFORE collapsing whitespace, otherwise
     # `enable_fleet = true # note` parses to `true#note` and breaks _tfvar_is_true
     # (migration issue #1).
-    val=$(echo "$raw" | sed 's/.*=[[:space:]]*//; s/#.*//' | tr -d '[:space:]"')
+    val=$(echo "$raw" | sed 's/.*=[[:space:]]*//; s/#.*//' | tr -d '[:space:]"[]')
   fi
   [[ -n "$val" ]] || return 1
   echo "$val"

--- a/modules/aws/infra/scripts/preflight.sh
+++ b/modules/aws/infra/scripts/preflight.sh
@@ -173,7 +173,7 @@ run_post_infra_checks() {
   # ── 2. Cluster reachability ─────────────────────────────────────────────────
   info "--- Cluster Reachability ---"
   local version_out
-  version_out=$(kubectl version --short 2>&1 || kubectl version 2>&1 || true)
+  version_out=$(kubectl version 2>&1 || true)
   if echo "$version_out" | grep -qi "error\|unable to connect\|refused\|timed out"; then
     error "Cannot reach the cluster: $version_out"
     error "Check VPN/network access and re-run 'make kubeconfig'."

--- a/modules/aws/infra/scripts/quickstart.sh
+++ b/modules/aws/infra/scripts/quickstart.sh
@@ -291,7 +291,7 @@ fi
 
 _section "4. EKS Cluster"
 
-_ask "EKS Kubernetes version" "$(_existing "eks_cluster_version" "1.31")"
+_ask "EKS Kubernetes version" "$(_existing "eks_cluster_version" "1.34")"
 EKS_VERSION="$_REPLY"
 
 EKS_PUBLIC="true"; EKS_PUBLIC_CIDRS=""; CREATE_BASTION="false"

--- a/modules/aws/infra/scripts/test-orchestrator.sh
+++ b/modules/aws/infra/scripts/test-orchestrator.sh
@@ -81,7 +81,7 @@ fi
 # the calling shell (setup-env.sh must have been sourced before this script).
 
 export WORKER_REGION;         WORKER_REGION="${WORKER_REGION:-$(_parse_tfvar "region" 2>/dev/null || echo "us-west-2")}"
-export WORKER_EKS_VERSION;    WORKER_EKS_VERSION="${WORKER_EKS_VERSION:-$(_parse_tfvar "eks_cluster_version" 2>/dev/null || echo "1.31")}"
+export WORKER_EKS_VERSION;    WORKER_EKS_VERSION="${WORKER_EKS_VERSION:-$(_parse_tfvar "eks_cluster_version" 2>/dev/null || echo "1.34")}"
 # Workers always use in-cluster Postgres/Redis — cheap, fast, no per-worker RDS/ElastiCache
 # Env var overrides take precedence over terraform.tfvars (useful for one-off domain/email overrides)
 export WORKER_DOMAIN;         WORKER_DOMAIN="${WORKER_DOMAIN:-$(_parse_tfvar "langsmith_domain" 2>/dev/null || echo "")}"

--- a/modules/aws/infra/scripts/test-worker.sh
+++ b/modules/aws/infra/scripts/test-worker.sh
@@ -14,7 +14,7 @@
 #
 # Required env vars (exported by orchestrator, inherited automatically):
 #   WORKER_REGION           — AWS region
-#   WORKER_EKS_VERSION      — Kubernetes version (default: 1.31)
+#   WORKER_EKS_VERSION      — Kubernetes version (default: 1.34)
 #   WORKER_PG_SOURCE        — postgres_source: external|in-cluster (default: external)
 #   WORKER_REDIS_SOURCE     — redis_source:    external|in-cluster (default: external)
 #   WORKER_DOMAIN           — langsmith_domain  (can be empty)
@@ -50,7 +50,7 @@ DRY_RUN_FLAG="${4:-}"
 # ── Required env vars ─────────────────────────────────────────────────────────
 
 REGION="${WORKER_REGION:?WORKER_REGION env var required (set by orchestrator or manually)}"
-EKS_VERSION="${WORKER_EKS_VERSION:-1.31}"
+EKS_VERSION="${WORKER_EKS_VERSION:-1.34}"
 # Workers always use in-cluster Postgres + Redis — test clusters are lightweight
 # and short-lived. RDS/ElastiCache per worker would be expensive and slow to spin up.
 # The gateway/TLS permutations don't test backend service provisioning.

--- a/modules/aws/infra/terraform.tfvars.dev
+++ b/modules/aws/infra/terraform.tfvars.dev
@@ -32,7 +32,7 @@ create_vpc = true
 # EKS — public API for easy kubectl access from your laptop
 #------------------------------------------------------------------------------
 enable_public_eks_cluster = true
-eks_cluster_version       = "1.31"
+eks_cluster_version       = "1.34"
 
 # Smaller node group for dev — 3 nodes, autoscales to 6.
 eks_managed_node_groups = {

--- a/modules/aws/infra/terraform.tfvars.example
+++ b/modules/aws/infra/terraform.tfvars.example
@@ -150,7 +150,7 @@ create_vpc = true
 
 # Kubernetes version. Check AWS docs for supported versions:
 # https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html
-eks_cluster_version = "1.33"
+eks_cluster_version = "1.34"
 
 # Public API endpoint — controls whether the EKS API server is reachable
 # from outside the VPC.

--- a/modules/aws/infra/terraform.tfvars.minimum
+++ b/modules/aws/infra/terraform.tfvars.minimum
@@ -41,7 +41,7 @@ create_vpc = true
 # EKS — public API for easy kubectl access
 #------------------------------------------------------------------------------
 enable_public_eks_cluster = true
-eks_cluster_version       = "1.31"
+eks_cluster_version       = "1.34"
 
 # Single node, autoscales to 2 during deploys when bootstrap inflates
 # operator-managed pods temporarily.

--- a/modules/aws/infra/terraform.tfvars.production
+++ b/modules/aws/infra/terraform.tfvars.production
@@ -32,7 +32,7 @@ create_vpc = true
 # EKS — private API endpoint (kubectl requires VPN or bastion)
 #------------------------------------------------------------------------------
 enable_public_eks_cluster = false
-eks_cluster_version       = "1.31"
+eks_cluster_version       = "1.34"
 
 # Production node group — 6 nodes min so all pods schedule immediately.
 # m5.4xlarge required for in-cluster ClickHouse (16 vCPU, 64 GB).

--- a/modules/aws/infra/variables.tf
+++ b/modules/aws/infra/variables.tf
@@ -88,11 +88,11 @@ variable "eks_public_access_cidrs" {
 variable "eks_cluster_version" {
   type        = string
   description = "The EKS version of the kubernetes cluster"
-  default     = "1.33"
+  default     = "1.34"
 
   validation {
     condition     = can(regex("^[0-9]+\\.[0-9]+$", var.eks_cluster_version))
-    error_message = "EKS cluster version must be in format X.Y (e.g., 1.31)."
+    error_message = "EKS cluster version must be in format X.Y (e.g., 1.34)."
   }
 }
 


### PR DESCRIPTION
Found while deploying self-hosted LangSmith on AWS to test EKS/cluster-autoscaler version compatibility. All changes were verified live on this branch.

**1. Inconsistent EKS version defaults across the module — standardized to 1.34**

The default EKS Kubernetes version disagreed depending on how you deployed: `make quickstart` (the wizard) defaulted to `1.31`, while `terraform.tfvars.example` and the bare `variables.tf` default (used if you skip the wizard and apply directly) defaulted to `1.33`. Neither value had ever been reconciled — `variables.tf`/`.example` were introduced with `1.33` at the same commit that also set every other profile (`README`, `dev`/`minimum`/`production` tfvars) to `1.31`, and nothing since had touched either value. Bumped all of them to a single consistent `1.34`, across `variables.tf`, `modules/eks/variables.tf`, `terraform.tfvars.{dev,example,minimum,production}`, `README.md`, and the parallel-test-harness fallbacks (`quickstart.sh`, `test-orchestrator.sh`, `test-worker.sh`).

**2. `preflight.sh`: false "cluster unreachable" error on newer kubectl clients**

`kubectl version --short` was removed in kubectl 1.28+. The check's fallback let the failed `--short` attempt's stderr leak into the captured string, and a later grep matched that leaked text — so `make preflight-post` reported the cluster as unreachable even when it was actually up. Hit this directly running `make preflight-post` against a live 1.34 cluster with kubectl 1.36. Dropped the `--short` fallback entirely.

**3. `init-values.sh`: doubled `http://` in generated hostname on re-run**

The script always writes the hostname with its protocol prefix, but when reusing a previously-generated value, it read that already-prefixed string back and prepended the protocol again — producing `http://http://<alb-dns-name>`, which failed Ingress host validation on `make deploy`. Hit this directly on a second `make init-values` run. Normalized the hostname once, right before the protocol is added.

**4. `_parse_tfvar`: list-typed tfvars read back with brackets still attached**

`_parse_tfvar` strips whitespace and quotes from a value but left square brackets in place, so `instance_types = ["m5.2xlarge"]` read back as `[m5.2xlarge]`. On a wizard re-run the value is read and rewritten, producing `instance_types = ["[m5.2xlarge]"]` — an instance type that does not exist. Added `[` and `]` to the `tr` delete set so brackets come off together with the quotes in a single pass.

Two notes for reviewers:

- The bracketed list reaches the unquoted branch even though it contains quotes, because the quoted-string pattern above it requires a `"` immediately after the `=` and finds a `[` instead. That is why the fix belongs in the unquoted branch.
- Only single-element lists round-trip to a scalar. Multi-element lists come back comma-separated, which is exactly the form the wizard's own `_tf_list` helper expects for `private_subnets`/`public_subnets` — so this change fixes that path too rather than breaking it (previously those read back as `[subnet-aaa,subnet-bbb]` with the brackets glued on).

Only affects re-runs against an existing `terraform.tfvars`; a first run never reads the file back.

**Test plan:**
- [x] Deployed self-hosted LangSmith on AWS (eu-west-1, dev profile, HTTP-only) with `eks_cluster_version = 1.34` end-to-end: `terraform apply` succeeded (141 resources), cluster reachable
- [x] Fix #2 confirmed required — failed before, passed after
- [x] Fix #3 confirmed required — reproduced the failure before, `make deploy` proceeded past it after
- [x] Fix #4 verified against a fixture tfvars: `instance_types` now round-trips as `["m5.2xlarge"]` instead of `["[m5.2xlarge]"]`, and `enable_fleet = true # note` still parses correctly (no regression to the existing trailing-comment fix in the same function)
- [ ] Full `make test-parallel` (8 ingress/TLS permutation suite) not run this pass
