### PR TITLE
Make Envoy Gateway the default AWS ingress and fix Envoy target port

### DIFF
--- a/modules/aws/README.md
+++ b/modules/aws/README.md
@@ -359,9 +359,9 @@ For "bring your own infra" — skip `make init-app` and set all variables manual
 
 ---
 
-## Envoy Gateway — Alternative Ingress (Gateway API)
+## Envoy Gateway (Gateway API)
 
-By default, LangSmith uses the AWS Load Balancer Controller (ALB) for ingress. Set `enable_envoy_gateway = true` in `terraform.tfvars` to install Envoy Gateway instead.
+Envoy Gateway is the default ingress mode, both in Terraform (`enable_envoy_gateway` defaults to `true`) and in `make quickstart` for new deployments. When rerun, quickstart keeps your existing ingress selection. Set `enable_envoy_gateway = false` to fall back to a standard ALB-backed Kubernetes Ingress.
 
 When enabled, the `k8s-bootstrap` module:
 1. Installs the Envoy Gateway Helm chart (`envoyproxy/gateway-helm` v1.3.0) in the `envoy-gateway-system` namespace.

--- a/modules/aws/README.md
+++ b/modules/aws/README.md
@@ -361,9 +361,19 @@ For "bring your own infra" — skip `make init-app` and set all variables manual
 
 ## Envoy Gateway (Gateway API)
 
-Envoy Gateway is the default ingress mode, both in Terraform (`enable_envoy_gateway` defaults to `true`) and in `make quickstart` for new deployments. When rerun, quickstart keeps your existing ingress selection. Set `enable_envoy_gateway = false` to fall back to a standard ALB-backed Kubernetes Ingress.
+Envoy Gateway is the default ingress mode, both in Terraform and in `make quickstart` for new deployments. When rerun, quickstart keeps your existing ingress selection. Set `enable_envoy_gateway = false` to fall back to a standard ALB-backed Kubernetes Ingress.
 
-> **Upgrading an existing deployment?** If your `terraform.tfvars` doesn't set `enable_envoy_gateway`, your next `terraform apply` will switch you from ALB Ingress to Envoy Gateway. Set `enable_envoy_gateway = false` explicitly first if you want to stay on ALB. Always review `terraform plan` before applying.
+`enable_envoy_gateway` is unset by default and derived rather than hardcoded to `true`:
+
+| `terraform.tfvars` | Result |
+| --- | --- |
+| No gateway flags at all | Envoy Gateway |
+| `enable_istio_gateway = true` or `enable_nginx_ingress = true` | That controller, Envoy stays off |
+| `enable_envoy_gateway` set explicitly | Your value always wins |
+
+Enabling two controllers is rejected at plan time by a precondition in `infra/main.tf`, because all gateway modes share a single ALB target group and only one port can be health-checked on it.
+
+**Upgrading an existing deployment?** Istio and NGINX deployments are unaffected - the derivation leaves Envoy off for them without any `terraform.tfvars` edit. Only a configuration with no gateway flags at all changes: it switches from ALB Ingress to Envoy Gateway on the next `terraform apply`, which recreates the ALB target group on port `10080` and causes a brief traffic blip. Set `enable_envoy_gateway = false` to stay on ALB, and always review `terraform plan` before applying.
 
 When enabled, the `k8s-bootstrap` module:
 1. Installs the Envoy Gateway Helm chart (`envoyproxy/gateway-helm` v1.3.0) in the `envoy-gateway-system` namespace.

--- a/modules/aws/README.md
+++ b/modules/aws/README.md
@@ -363,6 +363,8 @@ For "bring your own infra" — skip `make init-app` and set all variables manual
 
 Envoy Gateway is the default ingress mode, both in Terraform (`enable_envoy_gateway` defaults to `true`) and in `make quickstart` for new deployments. When rerun, quickstart keeps your existing ingress selection. Set `enable_envoy_gateway = false` to fall back to a standard ALB-backed Kubernetes Ingress.
 
+> **Upgrading an existing deployment?** If your `terraform.tfvars` doesn't set `enable_envoy_gateway`, your next `terraform apply` will switch you from ALB Ingress to Envoy Gateway. Set `enable_envoy_gateway = false` explicitly first if you want to stay on ALB. Always review `terraform plan` before applying.
+
 When enabled, the `k8s-bootstrap` module:
 1. Installs the Envoy Gateway Helm chart (`envoyproxy/gateway-helm` v1.3.0) in the `envoy-gateway-system` namespace.
 2. Creates a `GatewayClass` named `eg` and a `Gateway` named `langsmith-gateway` in the `langsmith` namespace.

--- a/modules/aws/helm/scripts/deploy.sh
+++ b/modules/aws/helm/scripts/deploy.sh
@@ -289,6 +289,9 @@ helm repo update langchain
 
 # Guard: recover from broken release states before proceeding.
 #   - pending-upgrade: left by a Ctrl+C'd helm upgrade --wait. Roll back to clear.
+#   - pending-install: left by a disrupted initial install (e.g. transient EKS API
+#                      errors during make apply). No revision exists to roll back
+#                      to, so uninstall and let the deploy recreate it.
 #   - failed: left by a timed-out post-install hook or resource readiness check.
 #             helm upgrade works fine on a failed release — just log and continue.
 _release_status=$(helm list -n "$NAMESPACE" --filter "^${RELEASE_NAME}$" --output json 2>/dev/null \
@@ -297,6 +300,11 @@ if [[ "$_release_status" == "pending-upgrade" ]]; then
   echo "WARNING: Prior Helm release '${RELEASE_NAME}' is in 'pending-upgrade' state (interrupted upgrade)."
   echo "         Rolling back to clear the lock..."
   helm rollback "$RELEASE_NAME" -n "$NAMESPACE" --wait --timeout 5m
+  echo ""
+elif [[ "$_release_status" == "pending-install" ]]; then
+  echo "WARNING: Prior Helm release '${RELEASE_NAME}' is in 'pending-install' state (disrupted initial install)."
+  echo "         No revision exists to roll back to. Uninstalling to clear the lock..."
+  helm uninstall "$RELEASE_NAME" -n "$NAMESPACE" --wait --timeout 5m
   echo ""
 elif [[ "$_release_status" == "failed" ]]; then
   echo "WARNING: Prior Helm release '${RELEASE_NAME}' is in 'failed' state."

--- a/modules/aws/helm/scripts/deploy.sh
+++ b/modules/aws/helm/scripts/deploy.sh
@@ -116,9 +116,6 @@ _enable_polly=false
 _enable_fleet=false
 _enable_standalone_polly=false
 _enable_standalone_insights=false
-_enable_envoy_gateway=false
-_enable_istio_gateway=false
-_enable_nginx_ingress=false
 _tfvar_is_true "enable_deployments"   && _enable_deployments=true
 _tfvar_is_true "enable_agent_builder" && _enable_agent_builder=true
 _tfvar_is_true "enable_insights"      && _enable_insights=true
@@ -126,9 +123,13 @@ _tfvar_is_true "enable_polly"         && _enable_polly=true
 _tfvar_is_true "enable_fleet"               && _enable_fleet=true
 _tfvar_is_true "enable_standalone_polly"    && _enable_standalone_polly=true
 _tfvar_is_true "enable_standalone_insights" && _enable_standalone_insights=true
-_tfvar_is_true "enable_envoy_gateway" && _enable_envoy_gateway=true
-_tfvar_is_true "enable_istio_gateway" && _enable_istio_gateway=true
-_tfvar_is_true "enable_nginx_ingress" && _enable_nginx_ingress=true
+
+# Gateway flags come from the Terraform outputs, not the tfvars text: enable_envoy_gateway
+# is derived (unset = on unless Istio/NGINX was chosen), and getting this wrong sends the
+# hostname resolution below to the Ingress status instead of the Terraform ALB.
+_enable_envoy_gateway=$(_read_gateway_flag "enable_envoy_gateway")
+_enable_istio_gateway=$(_read_gateway_flag "enable_istio_gateway")
+_enable_nginx_ingress=$(_read_gateway_flag "enable_nginx_ingress")
 
 # Classic ALB Ingress mode = none of the gateway/nginx routing modes are enabled.
 # In that mode the AWS Load Balancer Controller creates and owns the ALB, so the

--- a/modules/aws/helm/scripts/init-values.sh
+++ b/modules/aws/helm/scripts/init-values.sh
@@ -147,6 +147,14 @@ EXISTING_HOSTNAME=""
 if [[ -f "$OUT_FILE" ]]; then
   EXISTING_HOSTNAME=$(grep -E '^\s*hostname:' "$OUT_FILE" 2>/dev/null \
     | sed 's/.*:[[:space:]]*"\(.*\)".*/\1/' | tr -d '[:space:]') || EXISTING_HOSTNAME=""
+  # HOSTNAME must stay bare: the output block writes "${_protocol}://${HOSTNAME}",
+  # so reusing the stored value verbatim prepends a second scheme on every re-run
+  # ("http://http://alb..."), which breaks OAuth redirects and deployment URLs.
+  # Loop rather than strip once so an already-corrupted file self-heals.
+  while [[ "$EXISTING_HOSTNAME" =~ ^https?:// ]]; do
+    EXISTING_HOSTNAME="${EXISTING_HOSTNAME#http://}"
+    EXISTING_HOSTNAME="${EXISTING_HOSTNAME#https://}"
+  done
 fi
 if [[ -n "$_langsmith_domain" ]]; then
   HOSTNAME="$_langsmith_domain"

--- a/modules/aws/helm/scripts/init-values.sh
+++ b/modules/aws/helm/scripts/init-values.sh
@@ -52,21 +52,21 @@ _redis_source=$(_parse_tfvar "redis_source") || _redis_source="external"
 _clickhouse_source=$(_parse_tfvar "clickhouse_source") || _clickhouse_source="in-cluster"
 _sizing_profile=$(_parse_tfvar "sizing_profile") || _sizing_profile="default"
 _langsmith_domain=$(_parse_tfvar "langsmith_domain") || _langsmith_domain=""
-_enable_envoy_gateway=false
-_tfvar_is_true "enable_envoy_gateway" && _enable_envoy_gateway=true
-
-_enable_istio_gateway=false
-_tfvar_is_true "enable_istio_gateway" && _enable_istio_gateway=true
-
-_enable_nginx_ingress=false
-_tfvar_is_true "enable_nginx_ingress" && _enable_nginx_ingress=true
+# Gateway mode comes from the Terraform outputs, not the tfvars text: enable_envoy_gateway
+# is derived (unset = on unless Istio/NGINX was chosen), so a tfvars that never mentions
+# Envoy still deploys it. Reading the applied state keeps this script in agreement with
+# what Terraform actually built.
+_enable_envoy_gateway=$(_read_gateway_flag "enable_envoy_gateway")
+_enable_istio_gateway=$(_read_gateway_flag "enable_istio_gateway")
+_enable_nginx_ingress=$(_read_gateway_flag "enable_nginx_ingress")
 
 _gateway_modes=0
 [[ "$_enable_envoy_gateway" == "true" ]] && _gateway_modes=$(( _gateway_modes + 1 )) || true
 [[ "$_enable_istio_gateway" == "true" ]] && _gateway_modes=$(( _gateway_modes + 1 )) || true
 [[ "$_enable_nginx_ingress" == "true" ]] && _gateway_modes=$(( _gateway_modes + 1 )) || true
 if (( _gateway_modes > 1 )); then
-  echo "ERROR: Only one of enable_envoy_gateway / enable_istio_gateway / enable_nginx_ingress can be true in terraform.tfvars." >&2
+  echo "ERROR: Only one of enable_envoy_gateway / enable_istio_gateway / enable_nginx_ingress can be true." >&2
+  echo "       Envoy Gateway is the default when enable_envoy_gateway is unset — set it to false explicitly in terraform.tfvars to run Istio or NGINX, then re-apply." >&2
   exit 1
 fi
 

--- a/modules/aws/helm/scripts/test-e2e.sh
+++ b/modules/aws/helm/scripts/test-e2e.sh
@@ -38,8 +38,9 @@ RELEASE_NAME="${RELEASE_NAME:-langsmith}"
 # ── Resolve test URL ──────────────────────────────────────────────────────────
 _langsmith_domain=$(_parse_tfvar "langsmith_domain") || _langsmith_domain=""
 _tls_source=$(_parse_tfvar "tls_certificate_source") || _tls_source="none"
-_enable_envoy_gateway=false
-_tfvar_is_true "enable_envoy_gateway" && _enable_envoy_gateway=true
+# Derived in Terraform (unset = on unless Istio/NGINX was chosen), so read the
+# applied output rather than the tfvars text.
+_enable_envoy_gateway=$(_read_gateway_flag "enable_envoy_gateway")
 
 _protocol="http"
 [[ "$_tls_source" == "acm" || "$_tls_source" == "letsencrypt" ]] && _protocol="https"

--- a/modules/aws/infra/locals.tf
+++ b/modules/aws/infra/locals.tf
@@ -39,4 +39,11 @@ locals {
   private_subnets = var.create_vpc ? module.vpc[0].private_subnets : var.private_subnets
   public_subnets  = var.create_vpc ? module.vpc[0].public_subnets : var.public_subnets
   vpc_cidr_block  = var.create_vpc ? module.vpc[0].vpc_cidr_block : var.vpc_cidr_block
+
+  # Envoy Gateway is the default ingress mode, but a bare default of `true` would
+  # silently add a second gateway controller to every existing Istio/NGINX tfvars
+  # that never mentioned Envoy. Deriving it instead means "Envoy unless you already
+  # chose something else", so only configurations with no gateway controller at all
+  # change behaviour. An explicit true/false in terraform.tfvars still wins.
+  enable_envoy_gateway = var.enable_envoy_gateway != null ? var.enable_envoy_gateway : !(var.enable_istio_gateway || var.enable_nginx_ingress)
 }

--- a/modules/aws/infra/main.tf
+++ b/modules/aws/infra/main.tf
@@ -413,8 +413,8 @@ resource "aws_vpc_security_group_ingress_rule" "alb_to_envoy" {
   # The cluster primary SG is on the control plane only — not on worker nodes.
   security_group_id            = module.eks.node_security_group_id
   referenced_security_group_id = module.alb.security_group_id
-  from_port                    = 8080
-  to_port                      = 8080
+  from_port                    = 10080
+  to_port                      = 10080
   ip_protocol                  = "tcp"
   description                  = "Allow ALB to reach Envoy Gateway proxy pods on HTTP (target-type: ip)"
 

--- a/modules/aws/infra/main.tf
+++ b/modules/aws/infra/main.tf
@@ -125,6 +125,18 @@ resource "terraform_data" "validate_inputs" {
       condition     = !var.create_cert_manager_irsa || var.letsencrypt_email != ""
       error_message = "letsencrypt_email is required when create_cert_manager_irsa = true (DNS-01 Let's Encrypt path)."
     }
+
+    # Two gateway controllers share one ALB target group (all three
+    # TargetGroupBindings in k8s-bootstrap reference gateway_target_group_arn), and
+    # gateway_target_port can only describe one of them, so a second controller
+    # leaves both permanently unhealthy. init-values.sh rejects this combination
+    # too, but only after apply — fail at plan time instead.
+    precondition {
+      condition = length([
+        for enabled in [local.enable_envoy_gateway, var.enable_istio_gateway, var.enable_nginx_ingress] : true if enabled
+      ]) <= 1
+      error_message = "Only one of enable_envoy_gateway / enable_istio_gateway / enable_nginx_ingress can be true. Envoy Gateway is the default when enable_envoy_gateway is unset, so set enable_envoy_gateway = false explicitly to run Istio or NGINX."
+    }
   }
 }
 
@@ -388,7 +400,7 @@ module "alb" {
   acm_certificate_arn    = var.acm_certificate_arn != "" ? var.acm_certificate_arn : (local.dns_enabled && var.tls_certificate_source == "acm" ? module.dns[0].certificate_arn : "")
   access_logs_enabled    = var.alb_access_logs_enabled
   bucket_suffix          = random_id.bucket_suffix.hex
-  enable_envoy_gateway   = var.enable_envoy_gateway
+  enable_envoy_gateway   = local.enable_envoy_gateway
   enable_istio_gateway   = var.enable_istio_gateway
   enable_nginx_ingress   = var.enable_nginx_ingress
   tags                   = local.common_tags
@@ -407,7 +419,7 @@ module "alb" {
 # NGINX Ingress:  port 80    (ingress-nginx-controller)
 
 resource "aws_vpc_security_group_ingress_rule" "alb_to_envoy" {
-  count = var.enable_envoy_gateway ? 1 : 0
+  count = local.enable_envoy_gateway ? 1 : 0
 
   # Target the NODE security group (attached to EC2 instances and pod ENIs via VPC-CNI).
   # The cluster primary SG is on the control plane only — not on worker nodes.
@@ -538,7 +550,7 @@ module "k8s_bootstrap" {
 
   eso_irsa_role_arn = aws_iam_role.eso.arn
 
-  enable_envoy_gateway     = var.enable_envoy_gateway
+  enable_envoy_gateway     = local.enable_envoy_gateway
   enable_istio_gateway     = var.enable_istio_gateway
   enable_nginx_ingress     = var.enable_nginx_ingress
   gateway_target_group_arn = module.alb.gateway_target_group_arn != null ? module.alb.gateway_target_group_arn : ""

--- a/modules/aws/infra/modules/alb/main.tf
+++ b/modules/aws/infra/modules/alb/main.tf
@@ -20,10 +20,11 @@ data "aws_elb_service_account" "current" {}
 
 locals {
   gateway_enabled = var.enable_envoy_gateway || var.enable_istio_gateway || var.enable_nginx_ingress
-  # Envoy Gateway v1.0+: pods listen on port 8080 (matches the Gateway listener port; no offset).
+  # Envoy Gateway: pods listen on port 10080 (Gateway listener port 80 + 10000 offset,
+  # Envoy runs non-root and can't bind to privileged ports below 1024).
   # Istio ingress gateway: listens directly on port 80 (envoy with NET_BIND_SERVICE).
   # NGINX ingress controller: listens on port 80.
-  gateway_target_port = var.enable_envoy_gateway ? 8080 : 80
+  gateway_target_port = var.enable_envoy_gateway ? 10080 : 80
 }
 
 # ── Access Logs S3 Bucket ──────────────────────────────────────────────────────

--- a/modules/aws/infra/modules/k8s-bootstrap/main.tf
+++ b/modules/aws/infra/modules/k8s-bootstrap/main.tf
@@ -657,6 +657,32 @@ resource "helm_release" "istio_base" {
   version          = "1.23.0"
 }
 
+# Istio GatewayClasses are not removed by Helm. Use terraform_data so the
+# destroy provisioner can reference self.input (helm_release cannot use
+# var.* in destroy-time provisioners).
+resource "terraform_data" "istio_gatewayclass_cleanup" {
+  count = var.enable_istio_gateway ? 1 : 0
+
+  input = {
+    cluster_name = var.cluster_name
+    region       = var.region
+  }
+
+  provisioner "local-exec" {
+    when        = destroy
+    interpreter = ["bash", "-c"]
+    command     = <<-EOT
+      _ctx=$(kubectl config current-context 2>/dev/null || echo "")
+      if ! echo "$_ctx" | grep -qF '${self.input.cluster_name}'; then
+        aws eks update-kubeconfig --name ${self.input.cluster_name} --region ${self.input.region} 2>/dev/null || true
+      fi
+      kubectl delete gatewayclass istio istio-remote --ignore-not-found=true 2>/dev/null || true
+    EOT
+  }
+
+  depends_on = [helm_release.istio_base]
+}
+
 resource "helm_release" "istiod" {
   count = var.enable_istio_gateway ? 1 : 0
 

--- a/modules/aws/infra/modules/k8s-bootstrap/main.tf
+++ b/modules/aws/infra/modules/k8s-bootstrap/main.tf
@@ -532,7 +532,7 @@ MANIFEST
 # "envoy-<gateway-namespace>-<gateway-name>" in envoy-gateway-system.
 # For a Gateway named "langsmith-gateway" in the "langsmith" namespace:
 #   service: envoy-langsmith-langsmith-gateway (namespace: envoy-gateway-system)
-#   service port: 8080 (matches the Gateway resource's listener port)
+#   service port: 80 (matches the Gateway resource's listener port)
 #
 # The TargetGroupBinding is in envoy-gateway-system (same namespace as the service).
 # Cross-namespace TargetGroupBindings are not supported by the AWS LB controller.
@@ -592,7 +592,7 @@ metadata:
 spec:
   serviceRef:
     name: $_svc_name
-    port: 8080
+    port: 80
   targetGroupARN: ${var.gateway_target_group_arn}
   targetType: ip
 MANIFEST

--- a/modules/aws/infra/outputs.tf
+++ b/modules/aws/infra/outputs.tf
@@ -245,8 +245,18 @@ output "enable_polly" {
 }
 
 output "enable_envoy_gateway" {
-  description = "Whether Envoy Gateway is installed for Kubernetes Gateway API routing"
-  value       = var.enable_envoy_gateway
+  description = "Whether Envoy Gateway is installed for Kubernetes Gateway API routing. Reflects the derived value, so the deploy scripts can read the mode that was actually applied rather than re-deriving it from terraform.tfvars."
+  value       = local.enable_envoy_gateway
+}
+
+output "enable_istio_gateway" {
+  description = "Whether the Istio ingress gateway path is enabled"
+  value       = var.enable_istio_gateway
+}
+
+output "enable_nginx_ingress" {
+  description = "Whether the NGINX ingress controller path is enabled"
+  value       = var.enable_nginx_ingress
 }
 
 output "gateway_target_group_arn" {

--- a/modules/aws/infra/scripts/_common.sh
+++ b/modules/aws/infra/scripts/_common.sh
@@ -10,6 +10,7 @@
 #
 # Provides:
 #   _parse_tfvar <key>        — Read a value from terraform.tfvars
+#   _read_gateway_flag <key>  — Resolve an applied gateway flag from Terraform outputs
 #   _quickstart_gateway_default — Resolve fresh/update gateway menu default
 #   _resolve_infra_dir        — Set INFRA_DIR relative to this script
 #   Color helpers: _bold, _green, _red, _yellow, _cyan, _dim
@@ -48,6 +49,23 @@ _tfvar_is_true() {
   local val
   val=$(_parse_tfvar "$1") || return 1
   [[ "$val" == "true" ]]
+}
+
+# Resolve a gateway controller flag (enable_envoy_gateway / enable_istio_gateway /
+# enable_nginx_ingress) for post-apply scripts.
+#
+# enable_envoy_gateway is derived in Terraform — unset means "on unless Istio or
+# NGINX was chosen" — so terraform.tfvars text alone cannot tell you which mode was
+# applied. Read the Terraform output instead, and fall back to tfvars only when no
+# state exists yet (pre-apply callers such as preflight).
+_read_gateway_flag() {
+  local key="$1" val
+  val=$(terraform -chdir="$INFRA_DIR" output -raw "$key" 2>/dev/null) || val=""
+  if [[ "$val" != "true" && "$val" != "false" ]]; then
+    val=false
+    _tfvar_is_true "$key" && val=true
+  fi
+  echo "$val"
 }
 
 # Return the gateway menu choice for quickstart.

--- a/modules/aws/infra/scripts/_common.sh
+++ b/modules/aws/infra/scripts/_common.sh
@@ -10,6 +10,7 @@
 #
 # Provides:
 #   _parse_tfvar <key>        — Read a value from terraform.tfvars
+#   _quickstart_gateway_default — Resolve fresh/update gateway menu default
 #   _resolve_infra_dir        — Set INFRA_DIR relative to this script
 #   Color helpers: _bold, _green, _red, _yellow, _cyan, _dim
 #   Status helpers: pass, warn, fail, skip, info, header, action
@@ -47,6 +48,28 @@ _tfvar_is_true() {
   local val
   val=$(_parse_tfvar "$1") || return 1
   [[ "$val" == "true" ]]
+}
+
+# Return the gateway menu choice for quickstart.
+# Fresh configurations recommend Envoy (1). Updates preserve the existing
+# controller; ALB is represented by all three controller flags being false (2).
+_quickstart_gateway_default() {
+  local update_mode="$1"
+  local envoy_enabled="$2"
+  local istio_enabled="$3"
+  local nginx_enabled="$4"
+
+  if [[ "$update_mode" != "true" ]]; then
+    echo "1"
+  elif [[ "$envoy_enabled" == "true" ]]; then
+    echo "1"
+  elif [[ "$nginx_enabled" == "true" ]]; then
+    echo "3"
+  elif [[ "$istio_enabled" == "true" ]]; then
+    echo "4"
+  else
+    echo "2"
+  fi
 }
 
 # ── AWS credential helpers ───────────────────────────────────────────────────

--- a/modules/aws/infra/scripts/quickstart.sh
+++ b/modules/aws/infra/scripts/quickstart.sh
@@ -410,7 +410,7 @@ _gw_default=$(_quickstart_gateway_default \
 _ask_choice --default "$_gw_default" "Ingress / Gateway mode:" \
   "Envoy Gateway (Kubernetes Gateway API) — HTTPRoutes, split dataplane support (recommended for new configurations)" \
   "ALB (Application Load Balancer) — standard, TLS via ACM or Let's Encrypt HTTP-01" \
-  "NGINX Ingress Controller — ALB → NGINX → pods via TargetGroupBinding" \
+  "NGINX Ingress Controller — ALB → NGINX → pods via TargetGroupBinding (legacy, not recommended)" \
   "Istio Gateway — VirtualServices, split dataplane, TLS via Let's Encrypt DNS-01"
 
 GATEWAY_MODE="envoy"

--- a/modules/aws/infra/scripts/quickstart.sh
+++ b/modules/aws/infra/scripts/quickstart.sh
@@ -146,10 +146,11 @@ _validate_conflicts() {
     printf "  Both paths create ClusterIssuer/letsencrypt-prod. Pick one in Section 7.\n"
   fi
 
-  # ACM cert with non-ALB gateway — ACM requires ALB for certificate attachment
-  if [[ "$tls" == "acm" && ( "$envoy" == "true" || "$istio" == "true" ) ]]; then
-    _conflict_warn "tls_certificate_source = \"acm\" with Istio or Envoy Gateway."
-    printf "  ACM certificates attach to ALB only. Use DNS-01 for Istio, or switch to ALB.\n"
+  # ACM terminates at the ALB, which can forward to Envoy but not to an
+  # independently managed Istio NLB.
+  if [[ "$tls" == "acm" && "$istio" == "true" ]]; then
+    _conflict_warn "tls_certificate_source = \"acm\" with Istio Gateway."
+    printf "  Use DNS-01 for Istio, or switch to ALB/Envoy.\n"
   fi
 
   # DNS-01 IRSA enabled but no Istio — cert-manager would issue a cert with no Gateway to use it
@@ -397,32 +398,31 @@ _section "6. Ingress / Gateway Mode"
 echo ""
 printf "  ${DIM}Choose how traffic reaches LangSmith. These options are mutually exclusive:${RESET}\n"
 printf "  ${DIM}only one gateway controller can be active at a time.${RESET}\n"
-printf "  ${DIM}ALB is the default and simplest. Istio/Envoy needed for split dataplane.${RESET}\n"
+printf "  ${DIM}Envoy Gateway is recommended for new configurations. ALB is simplest if${RESET}\n"
+printf "  ${DIM}you don't need Gateway API. Istio is another split-dataplane option.${RESET}\n"
 
 _ex_envoy=$(_existing "enable_envoy_gateway" "false")
 _ex_istio=$(_existing "enable_istio_gateway" "false")
 _ex_nginx=$(_existing "enable_nginx_ingress" "false")
-_gw_default=1
-[[ "$_ex_nginx" == "true" ]] && _gw_default=2
-[[ "$_ex_envoy" == "true" ]] && _gw_default=3
-[[ "$_ex_istio" == "true" ]] && _gw_default=4
+_gw_default=$(_quickstart_gateway_default \
+  "$UPDATE_MODE" "$_ex_envoy" "$_ex_istio" "$_ex_nginx")
 
 _ask_choice --default "$_gw_default" "Ingress / Gateway mode:" \
+  "Envoy Gateway (Kubernetes Gateway API) — HTTPRoutes, split dataplane support (recommended for new configurations)" \
   "ALB (Application Load Balancer) — standard, TLS via ACM or Let's Encrypt HTTP-01" \
   "NGINX Ingress Controller — ALB → NGINX → pods via TargetGroupBinding" \
-  "Envoy Gateway (Kubernetes Gateway API) — HTTPRoutes, split dataplane support" \
   "Istio Gateway — VirtualServices, split dataplane, TLS via Let's Encrypt DNS-01"
 
-GATEWAY_MODE="alb"
-ENABLE_ENVOY="false"
+GATEWAY_MODE="envoy"
+ENABLE_ENVOY="true"
 ENABLE_ISTIO="false"
 ENABLE_NGINX="false"
 
 case "$_CHOICE" in
-  1) GATEWAY_MODE="alb" ;;
-  2) GATEWAY_MODE="nginx"; ENABLE_NGINX="true" ;;
-  3) GATEWAY_MODE="envoy"; ENABLE_ENVOY="true" ;;
-  4) GATEWAY_MODE="istio"; ENABLE_ISTIO="true" ;;
+  1) GATEWAY_MODE="envoy"; ENABLE_ENVOY="true" ;;
+  2) GATEWAY_MODE="alb"; ENABLE_ENVOY="false" ;;
+  3) GATEWAY_MODE="nginx"; ENABLE_ENVOY="false"; ENABLE_NGINX="true" ;;
+  4) GATEWAY_MODE="istio"; ENABLE_ENVOY="false"; ENABLE_ISTIO="true" ;;
 esac
 
 # For NGINX: brief note (ALB TGB wires automatically, no extra input needed)
@@ -456,9 +456,9 @@ _ex_domain=$(_existing "langsmith_domain" "")
 _ex_acm=$(_existing "acm_certificate_arn" "")
 _ex_le_email=$(_existing "letsencrypt_email" "")
 
-# For Istio and Envoy, only DNS-01 works on EKS (HTTP-01 fails due to NLB hairpin NAT).
-# ACM is also unavailable for both — ACM certificates attach to ALB only.
-# Offer a restricted 2-option menu for both NLB-backed gateway modes.
+# Istio uses DNS-01 because HTTP-01 fails through its NLB hairpin path and ACM
+# cannot attach to the in-cluster gateway. Envoy remains behind the
+# Terraform-managed ALB, so ACM can terminate TLS before traffic reaches Envoy.
 if [[ "$GATEWAY_MODE" == "istio" ]]; then
   echo ""
   printf "  ${DIM}On EKS, Istio requires DNS-01 (Let's Encrypt via Route 53) for TLS.${RESET}\n"
@@ -476,18 +476,17 @@ if [[ "$GATEWAY_MODE" == "istio" ]]; then
   TLS_MODE="$_CHOICE"  # 1=dns01, 2=no_tls
 elif [[ "$GATEWAY_MODE" == "envoy" ]]; then
   echo ""
-  printf "  ${DIM}On EKS, Envoy Gateway uses an NLB. HTTP-01 is not shown: EKS NLBs block${RESET}\n"
-  printf "  ${DIM}hairpin traffic, so cert-manager cannot complete the self-check.${RESET}\n"
-  printf "  ${DIM}ACM is also not shown: ACM attaches to ALB only, not Envoy NLB.${RESET}\n"
-  _tls_default_envoy=2; [[ "$_ex_tls" == "none" || -z "$_ex_tls" ]] || _tls_default_envoy=1
+  printf "  ${DIM}The existing ALB terminates TLS and forwards HTTP to Envoy Gateway.${RESET}\n"
+  printf "  ${DIM}Let's Encrypt is not shown because the automated DNS-01 path is Istio-only.${RESET}\n"
+  _tls_default_envoy=2; [[ "$_ex_tls" == "acm" ]] && _tls_default_envoy=1
   _ask_choice --default "$_tls_default_envoy" "TLS certificate (Envoy mode):" \
-    "Let's Encrypt DNS-01 via Route 53 — fully automated, recommended" \
+    "ACM — AWS Certificate Manager (TLS terminates at the ALB, recommended)" \
     "None — HTTP only (useful for initial deploy, add TLS later)"
   case "$_CHOICE" in
-    1) TLS_SOURCE="none"   ;; # tls_certificate_source stays "none"; cert-manager handles it
+    1) TLS_SOURCE="acm"  ;;
     2) TLS_SOURCE="none"   ;;
   esac
-  TLS_MODE="$_CHOICE"  # 1=dns01, 2=no_tls
+  TLS_MODE="$_CHOICE"  # 1=acm, 2=no_tls
 else
   _tls_default_alb=3
   [[ "$_ex_tls" == "acm" ]]        && _tls_default_alb=1
@@ -520,16 +519,14 @@ DOMAIN="$_REPLY"
 
 # Let's Encrypt email (HTTP-01 or DNS-01)
 if [[ "$TLS_SOURCE" == "letsencrypt" ]] || \
-   [[ "$GATEWAY_MODE" == "istio" && "$TLS_MODE" == "1" ]] || \
-   [[ "$GATEWAY_MODE" == "envoy" && "$TLS_MODE" == "1" ]]; then
+   [[ "$GATEWAY_MODE" == "istio" && "$TLS_MODE" == "1" ]]; then
   echo ""
   _ask "Email for Let's Encrypt expiry notifications" "$_ex_le_email"
   LE_EMAIL="$_REPLY"
 fi
 
-# cert-manager IRSA for DNS-01 (Istio and Envoy)
-if [[ "$GATEWAY_MODE" == "istio" && "$TLS_MODE" == "1" ]] || \
-   [[ "$GATEWAY_MODE" == "envoy" && "$TLS_MODE" == "1" ]]; then
+# cert-manager IRSA for DNS-01 (Istio)
+if [[ "$GATEWAY_MODE" == "istio" && "$TLS_MODE" == "1" ]]; then
   CREATE_CERT_MANAGER="true"
   echo ""
   printf "  ${DIM}cert-manager uses IRSA (no static credentials) to create DNS TXT records.${RESET}\n"
@@ -541,21 +538,21 @@ if [[ "$GATEWAY_MODE" == "istio" && "$TLS_MODE" == "1" ]] || \
   fi
 fi
 
-if [[ "$TLS_SOURCE" == "none" && "$PROFILE" == "prod" && "$GATEWAY_MODE" == "alb" ]]; then
+if [[ "$TLS_SOURCE" == "none" && "$PROFILE" == "prod" ]]; then
   echo ""
   _yellow "WARNING"; printf ": Running production without TLS is not recommended.\n"
 fi
 
-# Early exit: ACM is incompatible with Envoy/Istio (ACM attaches to ALB listeners only)
-if [[ ("$ENABLE_ENVOY" == "true" || "$ENABLE_ISTIO" == "true") && "$TLS_SOURCE" == "acm" ]]; then
+# Early exit: ACM is incompatible with Istio's independently managed gateway.
+if [[ "$ENABLE_ISTIO" == "true" && "$TLS_SOURCE" == "acm" ]]; then
   echo ""
-  _red "ERROR"; printf ": ACM certificates require ALB and cannot be used with Envoy or Istio Gateway.\n"
+  _red "ERROR"; printf ": ACM certificates cannot be used with Istio Gateway.\n"
   echo ""
-  printf "  ACM attaches to ALB listeners only. Envoy and Istio use their own\n"
-  printf "  load balancers (NLB/Gateway API) and cannot reference ACM certificates.\n"
+  printf "  ACM attaches to ALB listeners. Use DNS-01 for Istio, or choose\n"
+  printf "  ALB/Envoy so the Terraform-managed ALB can terminate TLS.\n"
   echo ""
   printf "  Re-run:  ${CYAN}make quickstart${RESET}\n"
-  printf "  Choose:  Let's Encrypt (DNS-01 for Istio, HTTP-01 for Envoy) or None\n"
+  printf "  Choose:  Let's Encrypt DNS-01 or None\n"
   echo ""
   exit 1
 fi
@@ -686,8 +683,8 @@ _pre_write_guard() {
     _red "ABORT"; printf ": HTTP-01 (tls_certificate_source=letsencrypt) and DNS-01 (create_cert_manager_irsa=true) are mutually exclusive.\n"
     abort=1
   fi
-  if [[ "$TLS_SOURCE" == "acm" && ( "$ENABLE_ENVOY" == "true" || "$ENABLE_ISTIO" == "true" ) ]]; then
-    _red "ABORT"; printf ": ACM certificates require ALB and cannot be used with Istio or Envoy Gateway.\n"
+  if [[ "$TLS_SOURCE" == "acm" && "$ENABLE_ISTIO" == "true" ]]; then
+    _red "ABORT"; printf ": ACM is not supported by the quickstart Istio path; use DNS-01 or None.\n"
     abort=1
   fi
   if (( abort )); then

--- a/modules/aws/infra/terraform.tfvars.example
+++ b/modules/aws/infra/terraform.tfvars.example
@@ -482,13 +482,13 @@ langsmith_namespace = "langsmith"
 #------------------------------------------------------------------------------
 # Three mutually exclusive options (only one should be true at a time):
 #
-#   ALB only (default)
+#   ALB only
 #     enable_envoy_gateway = false
 #     enable_istio_gateway = false
 #     → Chart creates a standard Kubernetes Ingress; the AWS LB Controller
 #       provisions an Application Load Balancer.
 #
-#   Envoy Gateway
+#   Envoy Gateway (default)
 #     enable_envoy_gateway = true
 #     enable_istio_gateway = false
 #     → Chart creates HTTPRoutes (Gateway API); Envoy Gateway proxies traffic.
@@ -501,7 +501,7 @@ langsmith_namespace = "langsmith"
 #       Gateway resource already installed in the cluster.
 #       Also opens port 15017 on the node SG for the istiod webhook.
 #
-enable_envoy_gateway = false
+enable_envoy_gateway = true
 enable_istio_gateway = false
 
 #------------------------------------------------------------------------------

--- a/modules/aws/infra/terraform.tfvars.example
+++ b/modules/aws/infra/terraform.tfvars.example
@@ -480,7 +480,9 @@ langsmith_namespace = "langsmith"
 #------------------------------------------------------------------------------
 # INGRESS / GATEWAY MODE
 #------------------------------------------------------------------------------
-# Three mutually exclusive options (only one should be true at a time):
+# Three mutually exclusive options — enabling two is rejected at plan time,
+# because all gateway modes share one ALB target group and only one port can be
+# health-checked on it.
 #
 #   ALB only
 #     enable_envoy_gateway = false
@@ -501,6 +503,10 @@ langsmith_namespace = "langsmith"
 #       Gateway resource already installed in the cluster.
 #       Also opens port 15017 on the node SG for the istiod webhook.
 #
+# enable_envoy_gateway has no hardcoded default. Leave it out entirely and Envoy
+# Gateway is enabled unless enable_istio_gateway or enable_nginx_ingress is true,
+# so existing Istio/NGINX configurations keep working untouched. Setting it
+# explicitly — as below — always wins over that derivation.
 enable_envoy_gateway = true
 enable_istio_gateway = false
 

--- a/modules/aws/infra/variables.tf
+++ b/modules/aws/infra/variables.tf
@@ -621,8 +621,8 @@ variable "enable_usage_telemetry" {
 
 variable "enable_envoy_gateway" {
   type        = bool
-  description = "Install Envoy Gateway for in-cluster routing via Kubernetes Gateway API HTTPRoutes. When enabled, the LangSmith Helm chart creates HTTPRoutes instead of Ingress resources."
-  default     = false
+  description = "Install Envoy Gateway for in-cluster routing via Kubernetes Gateway API HTTPRoutes. When enabled, the LangSmith Helm chart creates HTTPRoutes instead of Ingress resources. Default ingress mode; set to false (with ALB left as the fallback) to use a standard Kubernetes Ingress instead."
+  default     = true
 }
 
 variable "enable_istio_gateway" {

--- a/modules/aws/infra/variables.tf
+++ b/modules/aws/infra/variables.tf
@@ -621,8 +621,11 @@ variable "enable_usage_telemetry" {
 
 variable "enable_envoy_gateway" {
   type        = bool
-  description = "Install Envoy Gateway for in-cluster routing via Kubernetes Gateway API HTTPRoutes. When enabled, the LangSmith Helm chart creates HTTPRoutes instead of Ingress resources. Default ingress mode; set to false (with ALB left as the fallback) to use a standard Kubernetes Ingress instead."
-  default     = true
+  description = "Install Envoy Gateway for in-cluster routing via Kubernetes Gateway API HTTPRoutes. When enabled, the LangSmith Helm chart creates HTTPRoutes instead of Ingress resources. This is the default ingress mode: leave it unset and Envoy Gateway is enabled unless enable_istio_gateway or enable_nginx_ingress is true. Set it to false to use a standard ALB-backed Kubernetes Ingress instead."
+  # Unset (null) means "derive" — see local.enable_envoy_gateway in locals.tf.
+  # An explicit true or false in terraform.tfvars always wins over the derivation,
+  # so existing Istio/NGINX deployments keep working without a tfvars edit.
+  default = null
 }
 
 variable "enable_istio_gateway" {


### PR DESCRIPTION
## Summary
- Make Envoy Gateway the actual Terraform default for AWS ingress (`enable_envoy_gateway` default flipped to `true` in `variables.tf` — previously only the quickstart wizard and `.tfvars.example` template defaulted to Envoy, so a bare `terraform apply` still deployed ALB-only).
- Update `quickstart.sh`/`_common.sh` so the wizard pre-selects Envoy for fresh configs, preserves the existing controller choice on updates, and recommends ACM (instead of Let's Encrypt DNS-01) for TLS termination in Envoy mode.
- Fix the Envoy Gateway target port bug still present on `main`: ALB/security-group target was `8080`, but Envoy runs non-root and can't bind under 1024, so pods actually listen on `10080` (listener port 80 + 10000 offset). This matches the equivalent fix already merged into PR #70 via PR #85 — verified byte-identical for the shared lines, so no conflict expected when both land on `main`.
- Update `README.md` and `terraform.tfvars.example` to describe Envoy Gateway as the default ingress mode.
- Label NGINX as legacy, not recommended, in the ingress menu.

## ⚠️ Upgrade note for existing AWS deployments
- If your `terraform.tfvars` doesn't set `enable_envoy_gateway`, your next `terraform apply` will switch you from ALB Ingress to Envoy Gateway. Set `enable_envoy_gateway = false` explicitly first if you want to stay on ALB.
- If you're already on Envoy Gateway, this apply will recreate the ALB target group (port fix), causing a brief traffic blip. Apply during a maintenance window.
- Always review `terraform plan` output before applying.

## Test plan
- [ ] `terraform fmt -check -diff` passes on edited `.tf` files
- [ ] `git merge-tree` against `origin/chore/aws-eks-version-bump` (PR #88) produces a clean merge with both fixes intact — verified locally
- [ ] Fresh `make quickstart` run pre-selects Envoy Gateway and writes `enable_envoy_gateway = true`
- [ ] `terraform apply` with a fresh `terraform.tfvars` (no `enable_envoy_gateway` override) deploys Envoy Gateway, and ALB health checks against port `10080` succeed

