### PR TITLE
fix(byoc): allow TagResource with CreateSecret for langsmith secrets

### DIFF
--- a/modules/byoc/aws/langsmith-byoc-role/policies/secrets_manager.json
+++ b/modules/byoc/aws/langsmith-byoc-role/policies/secrets_manager.json
@@ -2,7 +2,10 @@
   {
     "Sid": "SecretsManagerCreateForRDS",
     "Effect": "Allow",
-    "Action": ["secretsmanager:CreateSecret"],
+    "Action": [
+      "secretsmanager:CreateSecret",
+      "secretsmanager:TagResource"
+    ],
     "Resource": "arn:aws:secretsmanager:*:${account_id}:secret:rds!*"
   },
   {

--- a/modules/byoc/aws/langsmith-byoc-role/policies/secrets_manager.json
+++ b/modules/byoc/aws/langsmith-byoc-role/policies/secrets_manager.json
@@ -24,7 +24,10 @@
   {
     "Sid": "SecretsManagerCreateForLangsmith",
     "Effect": "Allow",
-    "Action": ["secretsmanager:CreateSecret"],
+    "Action": [
+      "secretsmanager:CreateSecret",
+      "secretsmanager:TagResource"
+    ],
     "Resource": "arn:aws:secretsmanager:*:${account_id}:secret:langsmith/*"
   },
   {


### PR DESCRIPTION
## Summary
- Add `secretsmanager:TagResource` to both create statements in the customer BYOC role:
  - `SecretsManagerCreateForLangsmith` (`langsmith/*`)
  - `SecretsManagerCreateForRDS` (`rds!*`)
- smith-go / Crossplane already tag secrets with `managed_by=langsmith` at create; without TagResource on the create statement those creates (and tagging untagged secrets in those namespaces) are denied.

## Test plan
- [ ] Customers re-apply / bump the `langsmith-byoc-role` Terraform module
- [ ] Create a dataplane and confirm `langsmith/<id>/…` secrets have `managed_by=langsmith`
- [ ] Confirm RDS-managed secrets created with tags succeed under the customer role