### PR TITLE
fix(aws): keep the Envoy Gateway proxy Service internal

### DIFF
--- a/modules/aws/infra/modules/k8s-bootstrap/main.tf
+++ b/modules/aws/infra/modules/k8s-bootstrap/main.tf
@@ -451,6 +451,11 @@ resource "helm_release" "envoy_gateway" {
 # (which normally creates it) runs with a short TTL and may not re-run on
 # subsequent applies. Without a GatewayClass, the Gateway stays in "Waiting
 # for controller" state indefinitely.
+#
+# Istio and NGINX keep their proxy Service internal with a one-line Helm value.
+# Envoy cannot: its Service is created per Gateway at runtime, so the override
+# must be an EnvoyProxy on the GatewayClass. Without it the Service defaults to
+# LoadBalancer and AWS provisions an NLB that never receives traffic.
 resource "terraform_data" "envoy_gateway_resource" {
   count = var.enable_envoy_gateway ? 1 : 0
 
@@ -470,12 +475,29 @@ resource "terraform_data" "envoy_gateway_resource" {
       ${local._ctx_check}
       kubectl create namespace ${var.namespace} --dry-run=client -o yaml | kubectl apply -f -
       cat <<'MANIFEST' | kubectl apply -f -
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: langsmith-proxy
+  namespace: envoy-gateway-system
+spec:
+  provider:
+    type: Kubernetes
+    kubernetes:
+      envoyService:
+        type: ClusterIP
+---
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
   name: eg
 spec:
   controllerName: gateway.envoyproxy.io/gatewayclass-controller
+  parametersRef:
+    group: gateway.envoyproxy.io
+    kind: EnvoyProxy
+    name: langsmith-proxy
+    namespace: envoy-gateway-system
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway

--- a/modules/aws/infra/modules/k8s-bootstrap/main.tf
+++ b/modules/aws/infra/modules/k8s-bootstrap/main.tf
@@ -539,6 +539,7 @@ MANIFEST
       fi
       kubectl delete gateway langsmith-gateway -n ${self.input.namespace} --ignore-not-found=true --wait=true --timeout=180s 2>/dev/null || true
       kubectl delete gatewayclass eg --ignore-not-found=true 2>/dev/null || true
+      kubectl delete envoyproxy langsmith-proxy -n envoy-gateway-system --ignore-not-found=true 2>/dev/null || true
     EOT
   }
 


### PR DESCRIPTION
Found while deploying self-hosted LangSmith on AWS with Envoy Gateway. Verified live on this branch.

**An unused NLB is created alongside the ALB**

With `enable_envoy_gateway = true`, the Envoy Gateway controller creates a proxy Service per Gateway. Its type defaults to `LoadBalancer`, so the AWS Load Balancer Controller provisions an internal NLB.

That NLB never receives traffic. The Terraform-managed ALB reaches the proxy pods directly via `TargetGroupBinding` with `targetType: ip`, so the Service's own load balancer is never used. Per deployment this leaves an idle internal NLB, two generated target groups, and one target that reads permanently `unhealthy` on any node without an Envoy pod — so target-health alarms never clear.

The other ingress paths already avoid this: Istio sets `defaults.service.type = ClusterIP`, NGINX sets `controller.service.type = ClusterIP`, and `init-values.sh` sets the frontend Service to `ClusterIP` in all three modes. Only the Envoy path sets nothing.

A Helm value can't fix it — the chart installs only the controller, and the proxy Service is created per Gateway at runtime rather than from a chart template (`envoy-gateway-config` has no `envoyService` field in v1.3.0). The supported override is an `EnvoyProxy` resource referenced from the `GatewayClass` via `parametersRef`, which was previously unset. Added both to the existing `kubectl apply` block.

Safe because the `TargetGroupBinding` registers pod IPs and never used the Service's ports. `ClusterIP` keeps the Service with the same name and labels, so the label-based lookup that discovers it still resolves.

**Test plan:**
- [x] `terraform fmt -check` and `terraform validate` pass
- [x] Applied against a live cluster running Envoy Gateway + ACM: proxy Service flipped `LoadBalancer` → `ClusterIP` within 5s
- [x] NLB deleted; no network load balancers remaining
- [x] ALB target group still healthy on the same pod IP; HTTPS returned `200` before, during and after; zero pod restarts
- [ ] Full `terraform apply` on a scratch deployment — manifests were applied directly to isolate the mechanism, so this remains unverified