### PR TITLE
fix(azure): validate subscription_id is a GUID

### DIFF
--- a/modules/azure/app/variables.tf
+++ b/modules/azure/app/variables.tf
@@ -10,6 +10,15 @@ variable "subscription_id" {
   description = "Azure subscription ID"
   type        = string
   default     = null
+
+  # A non-GUID value is only rejected once azurerm builds its authorizer, which
+  # reports it as an opaque auth failure against the provider block. Catch the
+  # shape here instead. null stays valid: it is the not-yet-supplied sentinel
+  # that the plan-time precondition reports.
+  validation {
+    condition     = var.subscription_id == null || can(regex("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$", var.subscription_id))
+    error_message = "subscription_id must be a GUID, not a subscription name or list index. Get it with: az account show --query id -o tsv"
+  }
 }
 
 variable "resource_group_name" {

--- a/modules/azure/infra/scripts/preflight.sh
+++ b/modules/azure/infra/scripts/preflight.sh
@@ -146,6 +146,8 @@ else
     VALUE=$(grep "^${FIELD}" "$TFVARS" 2>/dev/null | head -1 | cut -d'"' -f2 || echo "")
     if [ -z "$VALUE" ] || [[ "$VALUE" == *"<"* ]]; then
       fail "terraform.tfvars: ${FIELD} is empty or still a placeholder"
+    elif [ "$FIELD" = "subscription_id" ] && ! [[ "$VALUE" =~ ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$ ]]; then
+      fail "terraform.tfvars: subscription_id is \"${VALUE}\", which is not a GUID. Get it with: az account show --query id -o tsv"
     else
       pass "terraform.tfvars: ${FIELD} is set"
     fi

--- a/modules/azure/infra/scripts/quickstart.sh
+++ b/modules/azure/infra/scripts/quickstart.sh
@@ -154,12 +154,18 @@ _run_section_2() {
     AUTO_SUB=$(az account show --query id --output tsv 2>/dev/null) || AUTO_SUB=""
   fi
 
-  if [[ -n "$AUTO_SUB" ]]; then
-    _ask "Azure subscription ID" "$AUTO_SUB"
-  else
-    _ask "Azure subscription ID (az account show --query id -o tsv)" ""
-  fi
-  SUBSCRIPTION_ID="$_REPLY"
+  while true; do
+    if [[ -n "$AUTO_SUB" ]]; then
+      _ask "Azure subscription ID" "$AUTO_SUB"
+    else
+      _ask "Azure subscription ID (az account show --query id -o tsv)" ""
+    fi
+    SUBSCRIPTION_ID="$_REPLY"
+    if [[ "$SUBSCRIPTION_ID" =~ ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$ ]]; then
+      break
+    fi
+    _red "  ERROR: must be a GUID, not a subscription name or a row number from 'az account list -o table'."
+  done
 
   while true; do
     _ask "Identifier suffix (lowercase, starts with hyphen, e.g. -prod, -staging, -myco)" "-dev"

--- a/modules/azure/infra/variables.tf
+++ b/modules/azure/infra/variables.tf
@@ -85,6 +85,14 @@ variable "location" {
 variable "subscription_id" {
   type        = string
   description = "The subscription id of the LangSmith deployment"
+
+  # A non-GUID value (e.g. the row number from `az account list -o table`) is
+  # only rejected once azurerm builds its authorizer, which reports it as an
+  # opaque auth failure. Catch the shape here instead.
+  validation {
+    condition     = can(regex("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$", var.subscription_id))
+    error_message = "subscription_id must be a GUID, not a subscription name or list index. Get it with: az account show --query id -o tsv"
+  }
 }
 
 variable "create_vnet" {


### PR DESCRIPTION
## Problem

A non-GUID `subscription_id` reaches the azurerm provider unchecked and fails at plan time as an opaque authorizer error:

```
Error: unable to build authorizer for Resource Manager API: could not configure
AzureCli Authorizer: the provided subscription ID "2" is not known by Azure CLI

  with provider["registry.terraform.io/hashicorp/azurerm"],
  on versions.tf line 35, in provider "azurerm":
  35: provider "azurerm" {
```

Hit during a customer deployment: the operator typed the row number from `az account list -o table` instead of the ID. Nothing between the prompt and the provider catches it.

- `quickstart.sh` accepts any string for the subscription prompt and writes it to `terraform.tfvars`
- `preflight.sh` only checks the field is non-empty and not a `<placeholder>`
- `variable "subscription_id"` has no format constraint, in either the `infra` or the `app` root

So the bad value survives `quickstart` → `preflight` → `init` and only surfaces at `plan`, pointing at the provider block rather than at the field the operator typed.

## Change

A GUID check at each point the value can enter, each naming the command that produces the right value:

| File | Behavior |
|---|---|
| `infra/variables.tf` | `validation` block. Fails at plan with `subscription_id must be a GUID, not a subscription name or list index. Get it with: az account show --query id -o tsv` |
| `app/variables.tf` | Same check on the second root, which feeds `local.subscription_id` into its own azurerm provider. `null` stays valid, since that is the not-yet-supplied sentinel `make init-app` and the plan-time preconditions rely on |
| `infra/scripts/preflight.sh` | Reports the offending value: `subscription_id is "2", which is not a GUID` |
| `infra/scripts/quickstart.sh` | Re-prompts until the answer is a GUID, matching the existing identifier-suffix retry loop directly below it |

Side effect worth noting: `infra/terraform.tfvars.example` ships `subscription_id = "your-azure-subscription-id"`, which contains no angle brackets and so slipped past preflight's existing `<placeholder>` test. A straight `cp` of the example used to pass preflight. It now fails there.

## Verification

Terraform validation, exercised against a standalone copy of each variable:

```
infra:  2                                    => Error: Invalid value for variable
        My Subscription                      => Error: Invalid value for variable
        3f2504e0-4f89-11d3-9a0c-0305e82c3301 => No changes.

app:    (unset / null)                       => No changes.
        2                                    => Error: Invalid value for variable
        My Subscription                      => Error: Invalid value for variable
        3f2504e0-4f89-11d3-9a0c-0305e82c3301 => Changes to Outputs
        3F2504E0-4F89-11D3-9A0C-0305E82C3301 => Changes to Outputs
```

Shell regex under bash 3.2 (the macOS system bash these scripts run on), both cases:

```
REJECT: 2
REJECT: My Subscription
PASS:   3f2504e0-4f89-11d3-9a0c-0305e82c3301
PASS:   3F2504E0-4F89-11D3-9A0C-0305E82C3301
```

The new `quickstart.sh` retry loop terminates on EOF rather than spinning: `set -e` plus `read` returning non-zero exits the script, verified under bash 3.2.57 with `< /dev/null` and with bad values piped in.

`terraform fmt -check -recursive` clean, `bash -n` clean on both scripts, `shellcheck -S warning` clean.
