### PR TITLE
fix(azure): setup-env.sh prompts were invisible and looked hung

### DIFF
--- a/modules/azure/.gitignore
+++ b/modules/azure/.gitignore
@@ -16,6 +16,7 @@ secrets.auto.tfvars
 plan.out
 
 # Local secret files generated before Key Vault exists
+infra/.pg_password
 infra/.api_key_salt
 infra/.jwt_secret
 infra/.deployments_key

--- a/modules/azure/BUILDING_LIGHT_LANGSMITH.md
+++ b/modules/azure/BUILDING_LIGHT_LANGSMITH.md
@@ -223,7 +223,7 @@ make setup-env
 ```
 
 **On first run**, the script:
-1. Prompts for: PostgreSQL admin password, LangSmith license key, admin password, admin email
+1. Prompts for: PostgreSQL admin password, LangSmith license key, admin password, admin email. Press Enter at the PostgreSQL prompt to have a compliant password generated for you — the script prints where to read it back.
 2. Generates (or reads from local fallback files): API key salt, JWT secret, 4 Fernet encryption keys
 3. Writes everything to `secrets.auto.tfvars` (automatically picked up by Terraform, chmod 600, gitignored)
 
@@ -237,10 +237,16 @@ LangSmith — secret bootstrap
   identifier : -demo
   key_vault  : langsmith-kv-demo
 
-PostgreSQL admin password  : ****
-LangSmith license key      : ****
-LangSmith admin password   : ****
+  Passwords are hidden as you type. Press Enter on the PostgreSQL prompt
+  to have one generated for you — this script prints where to view it.
+
+PostgreSQL admin password (Enter = generate):
+LangSmith license key      :
+LangSmith admin password   :
 Initial org admin email    : you@example.com
+
+  Key Vault langsmith-kv-demo not reachable (not created yet, not logged in,
+  or no network) — using local files.
 
   Resolving stable secrets...
   Generated langsmith-api-key-salt → .api_key_salt (Terraform stores in Key Vault on apply)
@@ -251,7 +257,7 @@ Initial org admin email    : you@example.com
   Wrote secrets.auto.tfvars (chmod 600)
 ```
 
-> **Important:** The script uses environment variable overrides to skip prompts. If you need to run non-interactively (CI/CD), set: `LANGSMITH_PG_PASSWORD`, `LANGSMITH_LICENSE_KEY`, `LANGSMITH_ADMIN_PASSWORD`, `LANGSMITH_ADMIN_EMAIL` before running the script.
+> **Important:** The script uses environment variable overrides to skip prompts. If you need to run non-interactively — CI/CD, or a sandboxed shell such as Cursor's, where there is no terminal to prompt on — set `LANGSMITH_LICENSE_KEY`, `LANGSMITH_ADMIN_PASSWORD`, and `LANGSMITH_ADMIN_EMAIL` before running the script. `LANGSMITH_PG_PASSWORD` is optional; leave it unset and a password is generated. Without those three the script exits with a message naming what is missing.
 
 ---
 

--- a/modules/azure/infra/scripts/clean.sh
+++ b/modules/azure/infra/scripts/clean.sh
@@ -80,7 +80,7 @@ _rm "$INFRA_DIR/terraform.tfvars"
 _rm "$INFRA_DIR/secrets.auto.tfvars"
 
 # Temp secret files written by setup-env.sh before Key Vault exists
-for f in .api_key_salt .jwt_secret .deployments_key .agent_builder_key .insights_key .polly_key; do
+for f in .pg_password .api_key_salt .jwt_secret .deployments_key .agent_builder_key .insights_key .polly_key; do
   _rm "$INFRA_DIR/$f"
 done
 

--- a/modules/azure/infra/scripts/setup-env.sh
+++ b/modules/azure/infra/scripts/setup-env.sh
@@ -31,29 +31,89 @@ if [[ -f "terraform.tfvars" ]]; then
 fi
 _kv_name="langsmith-kv${_identifier}"
 
+# LANGSMITH_PG_PASSWORD is not listed — it is generated when left blank.
+_REQUIRED_VARS="LANGSMITH_LICENSE_KEY LANGSMITH_ADMIN_PASSWORD LANGSMITH_ADMIN_EMAIL"
+
 # ── Prompt helper (skips if env var already set) ──────────────────────────────
-# If stdin is not a tty and the env var is not set, exit with a clear error
-# rather than silently storing empty/garbage values in secrets.auto.tfvars.
+# Prompt text goes to stderr: stdout is the return channel for the value, so
+# anything printed there is swallowed by the caller's command substitution.
 _prompt() {
   local env_var="$1"
   local prompt_text="$2"
+  local mode="${3:-}"   # "" = required secret | optional = may be left blank | visible = echo input
   local val="${!env_var:-}"
-  if [[ -z "$val" ]]; then
-    if [[ ! -t 0 ]]; then
-      echo "ERROR: setup-env.sh requires interactive input (stdin is not a tty)." >&2
-      echo "       Set env vars to skip prompts:" >&2
-      echo "         export LANGSMITH_PG_PASSWORD=..." >&2
-      echo "         export LANGSMITH_LICENSE_KEY=..." >&2
-      echo "         export LANGSMITH_ADMIN_PASSWORD=..." >&2
-      echo "         export LANGSMITH_ADMIN_EMAIL=..." >&2
-      echo "       Then re-run: make setup-env" >&2
-      exit 1
+  if [[ -z "$val" && -t 0 ]]; then
+    printf "%s: " "$prompt_text" >&2
+    if [[ "$mode" == "visible" ]]; then
+      read -r val || val=""   # Ctrl-D / EOF — handled by the empty check below
+    else
+      read -rs val || val=""
+      echo >&2                # -s also swallows the newline the user typed
     fi
-    printf "%s: " "$prompt_text"
-    read -rs val
-    echo
+  fi
+  if [[ -z "$val" && "$mode" != "optional" ]]; then
+    echo "ERROR: No value provided for $env_var." >&2
+    return 1
   fi
   echo "$val"
+}
+
+# ── Non-interactive guard ─────────────────────────────────────────────────────
+# A sandboxed shell (Cursor, CI, `make` under a pipe) has no tty, so prompting
+# is impossible. Checked here at top level, and reported on stdout: _prompt
+# cannot report anything itself because its stdout is captured by the caller,
+# and a harness that shows only stdout would otherwise display nothing at all.
+if [[ ! -t 0 ]]; then
+  _missing=""
+  for _v in $_REQUIRED_VARS; do
+    [[ -n "${!_v:-}" ]] || _missing="$_missing $_v"
+  done
+  if [[ -n "$_missing" ]]; then
+    echo "ERROR: stdin is not a tty, so setup-env.sh cannot prompt for secrets."
+    echo "       Missing:$_missing"
+    echo ""
+    echo "       Run it from a real terminal, or pre-set the values:"
+    for _v in $_missing; do
+      echo "         export $_v='<value>'"
+    done
+    echo ""
+    echo "       Then re-run: make setup-env"
+    exit 1
+  fi
+fi
+
+# ── Key Vault reachability (probed once, not per secret) ──────────────────────
+# Bounded by timeout(1) when available so a sandbox with blocked egress fails
+# fast instead of stalling on a TCP timeout. timeout is not in the macOS base
+# install, and gtimeout is the Homebrew coreutils name; run bare if neither.
+_timeout_bin=""
+for _t in timeout gtimeout; do
+  if command -v "$_t" >/dev/null 2>&1; then _timeout_bin="$_t"; break; fi
+done
+_az() {
+  if [[ -n "$_timeout_bin" ]]; then
+    "$_timeout_bin" 30 az "$@"
+  else
+    az "$@"
+  fi
+}
+
+# Probed at top level (see below), never first from inside _kv_secret: that runs
+# in a command-substitution subshell, so a result cached there would be lost and
+# every secret would re-probe.
+_kv_reachable=""   # "" until probed, then "yes" or "no"
+_kv_probe() {
+  if [[ -z "$_kv_reachable" ]]; then
+    if _az keyvault show --name "$_kv_name" --output none 2>/dev/null; then
+      _kv_reachable="yes"
+      echo "  Key Vault $_kv_name is reachable — reading existing secrets." >&2
+    else
+      _kv_reachable="no"
+      echo "  Key Vault $_kv_name not reachable (not created yet, not logged in," >&2
+      echo "  or no network) — using local files." >&2
+    fi
+  fi
+  [[ "$_kv_reachable" == "yes" ]]
 }
 
 # ── Stable secret: read from Key Vault or local fallback, generate if missing ──
@@ -66,8 +126,8 @@ _kv_secret() {
   local val=""
 
   # 1. Read from Key Vault (available after terraform apply)
-  if az keyvault show --name "$_kv_name" --output none 2>/dev/null; then
-    val=$(az keyvault secret show \
+  if _kv_probe; then
+    val=$(_az keyvault secret show \
       --vault-name "$_kv_name" \
       --name "$kv_secret_name" \
       --query value -o tsv 2>/dev/null) || val=""
@@ -80,8 +140,18 @@ _kv_secret() {
 
   # 3. Generate fresh — write to local file only; Terraform stores in Key Vault on apply
   if [[ -z "$val" ]]; then
-    val=$(eval "$generator")
+    val=$(eval "$generator") || {
+      echo "ERROR: Secret generator failed for $kv_secret_name." >&2
+      echo "       Command: $generator" >&2
+      echo "       Ensure required tools are installed (openssl, python3)." >&2
+      return 1
+    }
+    if [[ -z "$val" ]]; then
+      echo "ERROR: Secret generator for $kv_secret_name produced empty output." >&2
+      return 1
+    fi
     echo "$val" > "$fallback_file"
+    chmod 600 "$fallback_file"
     echo "  Generated $kv_secret_name → $fallback_file (Terraform stores in Key Vault on apply)" >&2
   fi
 
@@ -97,17 +167,37 @@ except ImportError:
     print(base64.urlsafe_b64encode(os.urandom(32)).decode())
 "'
 
+# Azure Postgres Flexible Server requires 8–128 characters from 3 of 4 character
+# classes, so the random body carries a fixed prefix that guarantees the mix.
+_pg_generator='printf "Ls1!%s\n" "$(openssl rand -base64 32 | tr -dc "A-Za-z0-9" | cut -c1-24)"'
+
 # ── Collect secrets ───────────────────────────────────────────────────────────
 echo ""
 echo "LangSmith — secret bootstrap"
 echo "  identifier : ${_identifier:-(empty)}"
 echo "  key_vault  : $_kv_name"
 echo ""
+echo "  Passwords are hidden as you type. Press Enter on the PostgreSQL prompt"
+echo "  to have one generated for you — this script prints where to view it."
+echo ""
 
-pg_password=$(_prompt "LANGSMITH_PG_PASSWORD"     "PostgreSQL admin password  ")
+pg_password=$(_prompt "LANGSMITH_PG_PASSWORD"      "PostgreSQL admin password (Enter = generate)" optional)
 license_key=$(_prompt "LANGSMITH_LICENSE_KEY"      "LangSmith license key      ")
 admin_password=$(_prompt "LANGSMITH_ADMIN_PASSWORD" "LangSmith admin password   ")
-admin_email=$(_prompt "LANGSMITH_ADMIN_EMAIL"      "Initial org admin email    ")
+admin_email=$(_prompt "LANGSMITH_ADMIN_EMAIL"      "Initial org admin email    " visible)
+
+echo ""
+_kv_probe || true   # once, in the parent shell — result is reused by every _kv_secret call
+
+# Generated Postgres password goes through _kv_secret so it stays stable across
+# runs: Key Vault after the first apply, .pg_password before it.
+_pg_generated=false
+if [[ -z "$pg_password" ]]; then
+  echo ""
+  echo "  No PostgreSQL password given — generating one..."
+  pg_password=$(_kv_secret "postgres-admin-password" ".pg_password" "$_pg_generator")
+  _pg_generated=true
+fi
 
 echo ""
 echo "  Resolving stable secrets..."
@@ -140,6 +230,14 @@ chmod 600 "$SECRETS_FILE"
 # ── Summary ───────────────────────────────────────────────────────────────────
 echo ""
 echo "  Wrote $SECRETS_FILE (chmod 600)"
+if [[ "$_pg_generated" == "true" ]]; then
+  echo ""
+  echo "  A PostgreSQL admin password was generated for you. View it with:"
+  echo "    grep postgres_admin_password $SECRETS_FILE"
+  echo "  After terraform apply it is also in Key Vault:"
+  echo "    az keyvault secret show --vault-name $_kv_name \\"
+  echo "      --name postgres-admin-password --query value -o tsv"
+fi
 echo ""
 echo "Next:"
 echo "  terraform init    # first run only"

--- a/modules/azure/infra/scripts/setup-env.sh
+++ b/modules/azure/infra/scripts/setup-env.sh
@@ -191,12 +191,12 @@ _kv_probe || true   # once, in the parent shell — result is reused by every _k
 
 # Generated Postgres password goes through _kv_secret so it stays stable across
 # runs: Key Vault after the first apply, .pg_password before it.
-_pg_generated=false
+_pg_resolved=false
 if [[ -z "$pg_password" ]]; then
   echo ""
-  echo "  No PostgreSQL password given — generating one..."
+  echo "  No PostgreSQL password given — resolving one..."
   pg_password=$(_kv_secret "postgres-admin-password" ".pg_password" "$_pg_generator")
-  _pg_generated=true
+  _pg_resolved=true
 fi
 
 echo ""
@@ -230,9 +230,9 @@ chmod 600 "$SECRETS_FILE"
 # ── Summary ───────────────────────────────────────────────────────────────────
 echo ""
 echo "  Wrote $SECRETS_FILE (chmod 600)"
-if [[ "$_pg_generated" == "true" ]]; then
+if [[ "$_pg_resolved" == "true" ]]; then
   echo ""
-  echo "  A PostgreSQL admin password was generated for you. View it with:"
+  echo "  The PostgreSQL admin password was set for you. View it with:"
   echo "    grep postgres_admin_password $SECRETS_FILE"
   echo "  After terraform apply it is also in Key Vault:"
   echo "    az keyvault secret show --vault-name $_kv_name \\"


### PR DESCRIPTION
## Problem

A customer ran `make setup-env` for the Azure module and reported that nothing happened.

Every `_prompt` call is wrapped in command substitution:

```bash
pg_password=$(_prompt "LANGSMITH_PG_PASSWORD" "PostgreSQL admin password  ")
```

but the prompt text was written to **stdout**, which that substitution captures. The prompt never reached the terminal, and `read -rs` echoes nothing as you type, so the script printed its header and then sat at a bare cursor with no indication it was waiting for input.

The same bug corrupted the secret. The captured value was the prompt text plus the typed value, so `secrets.auto.tfvars` got:

```hcl
postgres_admin_password = "PostgreSQL admin password  : 
hunter2"
```

AWS and GCP are unaffected: their `setup-env.sh` is sourced and exports variables, so nothing captures stdout. Only Azure switched to command substitution.

## Changes

`modules/azure/infra/scripts/setup-env.sh`

- Prompt text and the post-read newline go to stderr. Stdout stays the return channel for the value.
- The non-tty check moved out of `_prompt` to top level. Inside a function whose stdout is captured it could never be seen, so a sandboxed shell that surfaces only stdout (Cursor, CI) displayed nothing before exiting 1. It now prints on stdout and names exactly which variables to export.
- Errors are reported instead of exiting silently: a failed or empty secret generator, a blank required answer, and Ctrl-D at a prompt each print a message and exit. Previously `set -e` killed the script wordlessly, and a blank answer wrote an empty secret into tfvars. This matches what `modules/aws/infra/scripts/setup-env.sh` already does.
- Key Vault is probed once in the parent shell instead of once per secret, and bounded by `timeout(1)`/`gtimeout` when present so a sandbox with blocked egress fails fast instead of stalling on a TCP timeout. Caching the result inside `_kv_secret` cannot work, since it runs in a command-substitution subshell.
- Leaving the PostgreSQL prompt blank generates a password. The fixed `Ls1!` prefix guarantees the 3-of-4 character classes Azure Flexible Server requires, which random bytes alone do not. It routes through `_kv_secret` with a `.pg_password` fallback file so the value stays stable across runs rather than changing on every apply, and the summary prints both the `grep` and the `az keyvault secret show` command to read it back.
- The admin email echoes as you type. `_prompt` now takes a mode: default hidden, `visible` for the email, `optional` for Postgres.

`modules/azure/.gitignore` — ignore the new `infra/.pg_password` fallback file.

`modules/azure/infra/scripts/clean.sh` — remove `infra/.pg_password` too. `make clean` deletes the fallback secret files by name, so without this a generated Postgres admin password survives cleanup in plaintext.

`modules/azure/BUILDING_LIGHT_LANGSMITH.md` — updated sample output, the optional Postgres password, and the non-interactive note (`LANGSMITH_PG_PASSWORD` is no longer required; the other three are).

## Testing

Run against a throwaway directory with a stub `az` on `PATH` that always fails, standing in for a machine without Key Vault access.

- Driven over a real pty with `expect`: prompts render, password fields stay hidden, the email echoes, a blank PostgreSQL prompt generates a password, and a second run produces the same password.
- Non-interactive with nothing preset: exits 1 with the missing variables listed on stdout, verified with stderr discarded.
- Non-interactive with the three required variables set: completes and writes a correct `secrets.auto.tfvars`.
- Blank required field: reports `No value provided for LANGSMITH_LICENSE_KEY` instead of writing an empty secret.
- `bash -n` clean.
- `clean.sh` run against a throwaway infra dir seeded with all seven fallback files: all seven removed.

The `Ls1!` prefix is also the only safe shape here, not an arbitrary one. `infra/modules/postgres/outputs.tf` builds the connection URL with `replace(password, "!", "%21")`, a hand-rolled escape for exactly one character rather than `urlencode`. A password whose only non-alphanumeric character is `!` round-trips; an `@`, `:`, `/`, or `#` from a more conventional generator would corrupt the URI.

Not exercised: a live Azure Key Vault read-back. The Key Vault branch was only reordered behind `_kv_probe`, and the `az` invocations are unchanged apart from the optional `timeout` wrapper.
