### PR TITLE
feat(azure): make bring-your-own subnet IDs optional per subnet

### DIFF
--- a/modules/azure/ARCHITECTURE.md
+++ b/modules/azure/ARCHITECTURE.md
@@ -154,6 +154,25 @@ langsmith-vnet<identifier>
 
 All subnets are private. Postgres and Redis are accessible only from within the VNet via private DNS resolution. No public endpoints.
 
+### Bring your own VNet (`create_vnet = false`)
+
+```
+<your existing VNet>
+├── <existing subnet>            supplied via aks_subnet_id / postgres_subnet_id / redis_subnet_id
+└── langsmith-vnet<id>-subnet-*  created by Terraform for whichever IDs you left out
+```
+
+Each subnet is independently either supplied or created, so a VNet where the
+network team owns only some of the subnets still works. Subnets Terraform
+creates go into the existing VNet's resource group, and carry the same settings
+as the create path: the Storage and Key Vault service endpoints on the AKS
+subnet, the `Microsoft.DBforPostgreSQL/flexibleServers` delegation on the
+Postgres subnet, and no delegation on the Redis subnet, which holds the Azure
+Managed Redis private endpoint.
+
+Bastion and AGIC subnets have no bring-your-own input and exist only when
+Terraform manages the VNet. See [README.md](README.md#bring-your-own-vnet).
+
 ---
 
 ## Secret Flow

--- a/modules/azure/ARCHITECTURE.md
+++ b/modules/azure/ARCHITECTURE.md
@@ -170,6 +170,10 @@ subnet, the `Microsoft.DBforPostgreSQL/flexibleServers` delegation on the
 Postgres subnet, and no delegation on the Redis subnet, which holds the Azure
 Managed Redis private endpoint.
 
+The Application Gateway and bastion subnets are the exception: Terraform carves
+those only out of a VNet it owns, so on this path they are supplied through
+`agic_subnet_id` and `bastion_subnet_id` or the feature is rejected at plan time.
+
 Bastion and AGIC subnets have no bring-your-own input and exist only when
 Terraform manages the VNet. See [README.md](README.md#bring-your-own-vnet).
 

--- a/modules/azure/ARCHITECTURE.md
+++ b/modules/azure/ARCHITECTURE.md
@@ -158,8 +158,8 @@ All subnets are private. Postgres and Redis are accessible only from within the 
 
 ```
 <your existing VNet>
-├── <existing subnet>            supplied via aks_subnet_id / postgres_subnet_id / redis_subnet_id
-└── langsmith-vnet<id>-subnet-*  created by Terraform for whichever IDs you left out
+├── <existing subnet>                    supplied via aks_subnet_id / postgres_subnet_id / redis_subnet_id
+└── langsmith-vnet<identifier>-subnet-*  created by Terraform for whichever IDs you left out
 ```
 
 Each subnet is independently either supplied or created, so a VNet where the

--- a/modules/azure/README.md
+++ b/modules/azure/README.md
@@ -687,7 +687,7 @@ azure/
 
 | Module | Required | Description |
 |--------|----------|-------------|
-| `networking` | yes | VNet, subnets (main, postgres, redis, bastion, agic). AGIC subnet (`10.0.96.0/24`) is created automatically when `ingress_controller = "agic"`. Multi-AZ zone pinning supported. |
+| `networking` | yes | VNet, subnets (main, postgres, redis, bastion, agic). AGIC subnet (`10.0.96.0/24`) is created automatically when `ingress_controller = "agic"`. Multi-AZ zone pinning supported. Can also create subnets inside a VNet you already own — see [Bring your own VNet](#bring-your-own-vnet). |
 | `k8s-cluster` | yes | AKS cluster, node pools, OIDC issuer, managed identity, federated credentials (Workload Identity centralized here). Installs ingress controller via Helm: nginx / istio / istio-addon / agic (App Gateway v2 + AGIC chart) / envoy-gateway. |
 | `k8s-bootstrap` | yes | Kubernetes namespace, ServiceAccount, cert-manager, KEDA, postgres/redis K8s secrets. |
 | `storage` | yes | Azure Blob storage account + container. |
@@ -702,6 +702,58 @@ azure/
 > **Workload Identity** is centralized in `k8s-cluster`. Federated credentials for blob-accessing pods (backend, platform-backend, queue, ingest-queue, host-backend, listener, agent-builder-tool-server, agent-builder-trigger-server) are registered there. Adding a new pod that needs Blob access requires updating `service_accounts_for_workload_identity` in `k8s-cluster` and running `terraform apply -target=module.aks`.
 >
 > **AGIC Workload Identity** uses a separate managed identity (`<cluster>-agic-identity`) with Contributor on the App Gateway and Reader on the resource group. The federated credential binds to `system:serviceaccount:ingress-basic:ingress-azure`.
+
+---
+
+## Bring your own VNet
+
+By default Terraform creates the VNet and every subnet. To deploy into a VNet
+your network team already manages, set `create_vnet = false` and name it:
+
+```hcl
+create_vnet = false
+vnet_id     = "/subscriptions/<sub>/resourceGroups/net-rg/providers/Microsoft.Network/virtualNetworks/corp-vnet"
+```
+
+Each subnet is then independent. Supply an ID to reuse a subnet you already
+have, or leave it out and Terraform creates that subnet inside your VNet from
+the matching address prefix:
+
+```hcl
+# Reuse an existing Postgres subnet, let Terraform carve the other two.
+postgres_subnet_id             = "/subscriptions/.../virtualNetworks/corp-vnet/subnets/pg"
+aks_subnet_address_prefix      = ["10.42.0.0/19"]
+redis_subnet_address_prefix    = ["10.42.32.0/20"]
+```
+
+Subnets Terraform creates land in the existing VNet's resource group, not the
+LangSmith one, and get the settings each service needs:
+
+| Subnet | What Terraform applies |
+|--------|------------------------|
+| AKS | `Microsoft.Storage` and `Microsoft.KeyVault` service endpoints, so the storage and Key Vault default-deny firewalls can allowlist the subnet |
+| Postgres | Delegation to `Microsoft.DBforPostgreSQL/flexibleServers` — Flexible Server injects its NICs here, and no other resource may share the subnet |
+| Redis | No delegation. Azure Managed Redis is reached through a private endpoint placed in this subnet; a delegated subnet would reject it |
+
+Address prefixes must fit inside your VNet's address space, must not overlap an
+existing subnet, and must not overlap `aks_service_cidr` (default `10.0.64.0/20`).
+
+### What Terraform checks before applying
+
+These fail at plan time with an actionable message rather than partway through
+an apply:
+
+- `vnet_id` is present and is a well-formed VNet resource ID
+- every supplied subnet is a subnet of `vnet_id` — one in a different VNet would
+  be unreachable, since the private DNS zones are linked to `vnet_id`
+- a supplied Postgres subnet already carries the `flexibleServers` delegation
+- subnet IDs are not set while `create_vnet = true`, where they would be ignored
+
+### Not supported with an existing VNet
+
+`create_bastion = true` and `ingress_controller = "agic"` both need a dedicated
+subnet with no bring-your-own input, so they only work when Terraform manages
+the VNet. Plan rejects either combination.
 
 ---
 

--- a/modules/azure/README.md
+++ b/modules/azure/README.md
@@ -737,16 +737,20 @@ LangSmith one, and get the settings each service needs:
 
 The default prefixes above are sized against the `10.0.0.0/17` VNet Terraform
 builds, so they are a starting point rather than a default that fits your
-network. Each must sit inside your VNet's address space, must not overlap an
-existing subnet, and must not overlap `aks_service_cidr`. The AKS prefix also
-has to be large enough for the node pools, and plan checks that whether the
-subnet is one you supplied or one Terraform carves.
+network. Plan reads your VNet and rejects a prefix that falls outside its
+address space, and rejects an AKS prefix too small for the node pools whether
+the subnet is one you supplied or one Terraform carves. What it cannot check is
+whether a prefix collides with a subnet that already exists in the VNet, because
+Azure's VNet read returns subnet names and not their ranges — so pick ranges you
+know are free.
 
 `aks_service_cidr` is required on this path. Kubernetes assigns ClusterIPs from
 it, and AKS requires a range that nothing on or connected to your VNet uses. The
 `10.0.64.0/20` default only avoids the VNet Terraform builds, and an overlap with
 your own address space can be accepted when the cluster is created and break
-later, so plan makes you name one. `aks_dns_service_ip` follows from it
+later, so plan makes you name one and rejects one that lands inside your VNet.
+Peered and on-premises ranges are still yours to keep clear of, since plan only
+sees the VNet itself. `aks_dns_service_ip` follows from `aks_service_cidr`
 automatically as the eleventh address unless you set one.
 
 ### What a subnet you supply must already have
@@ -776,12 +780,20 @@ an apply:
   supplied it or Terraform creates it. Undersizing is the one mistake that
   survives apply: the cluster starts, and the autoscaler later stalls short of
   `max_count` once the subnet runs dry
-- `aks_service_cidr` is set
+- every prefix Terraform is about to carve sits inside your VNet's address
+  space. The defaults describe the VNet Terraform builds, so this is usually the
+  first thing to change on a network of your own
+- `aks_service_cidr` is set, and does not overlap your VNet's address space
 - subnet IDs are not set while `create_vnet = true`, where they would be ignored
 
-The checks that inspect a supplied subnet read it at plan time, so whoever runs
-`terraform plan` needs read access to whichever subnets you supply. They usually
-sit in the network team's resource group rather than the LangSmith one.
+Whoever runs Terraform needs two kinds of access to the VNet, which normally
+lives in the network team's resource group rather than the LangSmith one:
+
+- **read** on `vnet_id` and on whichever subnets you supply, at plan time, for
+  the checks above
+- **`Microsoft.Network/virtualNetworks/subnets/write`** on `vnet_id` for every
+  subnet you leave Terraform to create. This is the larger ask of a network
+  team, and it fails at apply rather than at plan, so settle it first
 
 ### Not supported with an existing VNet
 

--- a/modules/azure/README.md
+++ b/modules/azure/README.md
@@ -760,10 +760,13 @@ automatically as the eleventh address unless you set one.
 | AKS | Both the `Microsoft.Storage` and `Microsoft.KeyVault` service endpoints. The blob storage firewall is hardcoded to default-deny and allowlists this subnet by ID, and Azure rejects a subnet rule when the matching endpoint is missing. Required whatever `keyvault_default_action` is set to. Must also be large enough for the configured node pools, since Azure CNI draws both node and pod IPs from it: `(max_count + 1) × (max_pods + 1)` addresses per pool, which is 764 at the defaults and needs a `/22` or larger |
 | Postgres | Delegation to `Microsoft.DBforPostgreSQL/flexibleServers`, with the `Microsoft.Network/virtualNetworks/subnets/join/action` action, and no other resources in the subnet. Azure's floor for a delegated subnet is `/28` |
 | Redis | No delegation, since it holds a private endpoint and Azure allows no other resource type in a delegated subnet |
+| AGIC | The subnet to itself. Application Gateway v2 shares with nothing, and Azure recommends a `/24`. Only needed when `ingress_controller = "agic"` |
+| Bastion | The name `AzureBastionSubnet`, exactly, and `/26` or larger. Azure refuses any other name. Only needed when `create_bastion = true` |
 
-Supply three different subnets. Sharing one between services fails during apply,
-because the Postgres subnet is delegated and Azure permits nothing else inside a
-delegated subnet.
+Every subnet you supply must be a different subnet. Sharing one fails during
+apply, because the Postgres subnet is delegated and Azure permits nothing else
+inside a delegated subnet, and because Application Gateway and Bastion each
+require a subnet of their own.
 
 ### What Terraform checks before applying
 
@@ -773,9 +776,13 @@ an apply:
 - `vnet_id` is present and is a well-formed VNet resource ID
 - every supplied subnet is a subnet of `vnet_id` — one in a different VNet would
   be unreachable, since the private DNS zones are linked to `vnet_id`
-- the supplied subnet IDs are three different subnets
+- every supplied subnet ID names a different subnet
 - a supplied Postgres subnet already carries the `flexibleServers` delegation
 - a supplied AKS subnet carries both service endpoints
+- a supplied bastion subnet is named `AzureBastionSubnet`, which Azure requires
+  and a well-formed resource ID does not guarantee
+- `agic_subnet_id` is set when AGIC is on, and `bastion_subnet_id` when the
+  bastion is, since neither is carved inside a VNet you own
 - the AKS subnet has enough addresses for the configured node pools, whether you
   supplied it or Terraform creates it. Undersizing is the one mistake that
   survives apply: the cluster starts, and the autoscaler later stalls short of
@@ -795,11 +802,22 @@ lives in the network team's resource group rather than the LangSmith one:
   subnet you leave Terraform to create. This is the larger ask of a network
   team, and it fails at apply rather than at plan, so settle it first
 
-### Not supported with an existing VNet
+### AGIC and the bastion are supply-only here
 
-`create_bastion = true` and `ingress_controller = "agic"` both need a dedicated
-subnet with no bring-your-own input, so they only work when Terraform manages
-the VNet. Plan rejects either combination.
+`create_bastion = true` and `ingress_controller = "agic"` each need a subnet to
+themselves. Terraform carves those two only out of a VNet it owns, so on this
+path you name subnets that already exist:
+
+```hcl
+agic_subnet_id    = "/subscriptions/.../virtualNetworks/corp-vnet/subnets/appgw"
+bastion_subnet_id = "/subscriptions/.../virtualNetworks/corp-vnet/subnets/AzureBastionSubnet"
+```
+
+Unlike the other three there is no carve fallback, so plan rejects either
+feature when `create_vnet = false` and its subnet ID is empty. Application
+Gateway v2 wants the subnet to itself and Azure recommends a `/24`. Azure Bastion
+requires the subnet be named exactly `AzureBastionSubnet` and be `/26` or larger;
+plan checks the name, and Azure enforces the size at apply.
 
 ---
 

--- a/modules/azure/README.md
+++ b/modules/azure/README.md
@@ -735,16 +735,31 @@ LangSmith one, and get the settings each service needs:
 | Postgres | Delegation to `Microsoft.DBforPostgreSQL/flexibleServers` — Flexible Server injects its NICs here, and no other resource may share the subnet |
 | Redis | No delegation. Azure Managed Redis is reached through a private endpoint placed in this subnet; a delegated subnet would reject it |
 
-Address prefixes must fit inside your VNet's address space, must not overlap an
-existing subnet, and must not overlap `aks_service_cidr` (default `10.0.64.0/20`).
+The default prefixes above are sized against the `10.0.0.0/17` VNet Terraform
+builds, so they are a starting point rather than a default that fits your
+network. Each must sit inside your VNet's address space, must not overlap an
+existing subnet, and must not overlap `aks_service_cidr`. The AKS prefix also
+has to be large enough for the node pools, and plan checks that whether the
+subnet is one you supplied or one Terraform carves.
+
+`aks_service_cidr` is required on this path. Kubernetes assigns ClusterIPs from
+it, and AKS requires a range that nothing on or connected to your VNet uses. The
+`10.0.64.0/20` default only avoids the VNet Terraform builds, and an overlap with
+your own address space can be accepted when the cluster is created and break
+later, so plan makes you name one. `aks_dns_service_ip` follows from it
+automatically as the eleventh address unless you set one.
 
 ### What a subnet you supply must already have
 
 | Subnet | Requirement |
 |--------|-------------|
-| AKS | Both the `Microsoft.Storage` and `Microsoft.KeyVault` service endpoints. The blob storage firewall is hardcoded to default-deny and allowlists this subnet by ID, and Azure rejects a subnet rule when the matching endpoint is missing. Required whatever `keyvault_default_action` is set to |
-| Postgres | Delegation to `Microsoft.DBforPostgreSQL/flexibleServers`, with the `Microsoft.Network/virtualNetworks/subnets/join/action` action, and no other resources in the subnet |
-| Redis | No delegation |
+| AKS | Both the `Microsoft.Storage` and `Microsoft.KeyVault` service endpoints. The blob storage firewall is hardcoded to default-deny and allowlists this subnet by ID, and Azure rejects a subnet rule when the matching endpoint is missing. Required whatever `keyvault_default_action` is set to. Must also be large enough for the configured node pools, since Azure CNI draws both node and pod IPs from it: `(max_count + 1) × (max_pods + 1)` addresses per pool, which is 764 at the defaults and needs a `/22` or larger |
+| Postgres | Delegation to `Microsoft.DBforPostgreSQL/flexibleServers`, with the `Microsoft.Network/virtualNetworks/subnets/join/action` action, and no other resources in the subnet. Azure's floor for a delegated subnet is `/28` |
+| Redis | No delegation, since it holds a private endpoint and Azure allows no other resource type in a delegated subnet |
+
+Supply three different subnets. Sharing one between services fails during apply,
+because the Postgres subnet is delegated and Azure permits nothing else inside a
+delegated subnet.
 
 ### What Terraform checks before applying
 
@@ -754,13 +769,19 @@ an apply:
 - `vnet_id` is present and is a well-formed VNet resource ID
 - every supplied subnet is a subnet of `vnet_id` — one in a different VNet would
   be unreachable, since the private DNS zones are linked to `vnet_id`
+- the supplied subnet IDs are three different subnets
 - a supplied Postgres subnet already carries the `flexibleServers` delegation
 - a supplied AKS subnet carries both service endpoints
+- the AKS subnet has enough addresses for the configured node pools, whether you
+  supplied it or Terraform creates it. Undersizing is the one mistake that
+  survives apply: the cluster starts, and the autoscaler later stalls short of
+  `max_count` once the subnet runs dry
+- `aks_service_cidr` is set
 - subnet IDs are not set while `create_vnet = true`, where they would be ignored
 
-The last two checks read the subnets you supplied, so whoever runs `terraform
-plan` needs read access to them. They usually sit in the network team's resource
-group rather than the LangSmith one.
+The checks that inspect a supplied subnet read it at plan time, so whoever runs
+`terraform plan` needs read access to whichever subnets you supply. They usually
+sit in the network team's resource group rather than the LangSmith one.
 
 ### Not supported with an existing VNet
 

--- a/modules/azure/README.md
+++ b/modules/azure/README.md
@@ -757,7 +757,7 @@ automatically as the eleventh address unless you set one.
 
 | Subnet | Requirement |
 |--------|-------------|
-| AKS | Both the `Microsoft.Storage` and `Microsoft.KeyVault` service endpoints. The blob storage firewall is hardcoded to default-deny and allowlists this subnet by ID, and Azure rejects a subnet rule when the matching endpoint is missing. Required whatever `keyvault_default_action` is set to. Must also be large enough for the configured node pools, since Azure CNI draws both node and pod IPs from it: `(max_count + 1) × (max_pods + 1)` addresses per pool, which is 764 at the defaults and needs a `/22` or larger |
+| AKS | Both the `Microsoft.Storage` and `Microsoft.KeyVault` service endpoints, unless you let Terraform add them (below). The blob storage firewall is hardcoded to default-deny and allowlists this subnet by ID, and Azure rejects a subnet rule when the matching endpoint is missing. Required whatever `keyvault_default_action` is set to. Must also be large enough for the configured node pools, since Azure CNI draws both node and pod IPs from it: `(max_count + 1) × (max_pods + 1)` addresses per pool, which is 764 at the defaults and needs a `/22` or larger |
 | Postgres | Delegation to `Microsoft.DBforPostgreSQL/flexibleServers`, with the `Microsoft.Network/virtualNetworks/subnets/join/action` action, and no other resources in the subnet. Azure's floor for a delegated subnet is `/28` |
 | Redis | No delegation, since it holds a private endpoint and Azure allows no other resource type in a delegated subnet |
 | AGIC | The subnet to itself. Application Gateway v2 shares with nothing, and Azure recommends a `/24`. Only needed when `ingress_controller = "agic"` |
@@ -767,6 +767,32 @@ Every subnet you supply must be a different subnet. Sharing one fails during
 apply, because the Postgres subnet is delegated and Azure permits nothing else
 inside a delegated subnet, and because Application Gateway and Bastion each
 require a subnet of their own.
+
+#### Letting Terraform add the AKS service endpoints
+
+The service endpoints are the one requirement on that list Terraform can satisfy
+for you. Set `manage_byo_subnet_service_endpoints = true` and it patches the two
+missing endpoints onto the subnet during apply, appending to whatever is already
+there rather than replacing the list, and the plan-time check stands down.
+
+It patches only that property. Address prefixes, delegations, and NSG and route
+table associations stay with whoever owns the subnet — `azurerm` has no
+standalone service-endpoint resource, so this goes through `azapi` rather than
+adopting the subnet into state and taking the rest of it along.
+
+Leave it off, which is the default, when the subnet belongs to a network team
+that granted read and not `Microsoft.Network/virtualNetworks/subnets/write`, or
+when their own tooling sets the endpoints and the two would rewrite the property
+against each other on every run. Add them yourself instead, repeating any already
+present since the flag replaces the whole list:
+
+```bash
+az network vnet subnet update --ids <subnet-id> \
+  --service-endpoints Microsoft.Storage Microsoft.KeyVault
+```
+
+`terraform destroy` leaves the endpoints on the subnet — `azapi_update_resource`
+performs no operation on delete, and the subnet was never Terraform's to revert.
 
 ### What Terraform checks before applying
 
@@ -778,7 +804,8 @@ an apply:
   be unreachable, since the private DNS zones are linked to `vnet_id`
 - every supplied subnet ID names a different subnet
 - a supplied Postgres subnet already carries the `flexibleServers` delegation
-- a supplied AKS subnet carries both service endpoints
+- a supplied AKS subnet carries both service endpoints, unless
+  `manage_byo_subnet_service_endpoints` is on and Terraform is adding them
 - a supplied bastion subnet is named `AzureBastionSubnet`, which Azure requires
   and a well-formed resource ID does not guarantee
 - `agic_subnet_id` is set when AGIC is on, and `bastion_subnet_id` when the

--- a/modules/azure/README.md
+++ b/modules/azure/README.md
@@ -738,6 +738,14 @@ LangSmith one, and get the settings each service needs:
 Address prefixes must fit inside your VNet's address space, must not overlap an
 existing subnet, and must not overlap `aks_service_cidr` (default `10.0.64.0/20`).
 
+### What a subnet you supply must already have
+
+| Subnet | Requirement |
+|--------|-------------|
+| AKS | Both the `Microsoft.Storage` and `Microsoft.KeyVault` service endpoints. The blob storage firewall is hardcoded to default-deny and allowlists this subnet by ID, and Azure rejects a subnet rule when the matching endpoint is missing. Required whatever `keyvault_default_action` is set to |
+| Postgres | Delegation to `Microsoft.DBforPostgreSQL/flexibleServers`, with the `Microsoft.Network/virtualNetworks/subnets/join/action` action, and no other resources in the subnet |
+| Redis | No delegation |
+
 ### What Terraform checks before applying
 
 These fail at plan time with an actionable message rather than partway through
@@ -747,7 +755,12 @@ an apply:
 - every supplied subnet is a subnet of `vnet_id` — one in a different VNet would
   be unreachable, since the private DNS zones are linked to `vnet_id`
 - a supplied Postgres subnet already carries the `flexibleServers` delegation
+- a supplied AKS subnet carries both service endpoints
 - subnet IDs are not set while `create_vnet = true`, where they would be ignored
+
+The last two checks read the subnets you supplied, so whoever runs `terraform
+plan` needs read access to them. They usually sit in the network team's resource
+group rather than the LangSmith one.
 
 ### Not supported with an existing VNet
 

--- a/modules/azure/TEARDOWN.md
+++ b/modules/azure/TEARDOWN.md
@@ -64,6 +64,14 @@ Runs `terraform destroy -auto-approve` from `azure/infra/`.
 - VNet + subnets
 - Resource group
 
+**Left behind under `create_vnet = false`:** your VNet and any subnets you
+supplied, since Terraform never owned them. If you also set
+`manage_byo_subnet_service_endpoints = true`, the `Microsoft.Storage` and
+`Microsoft.KeyVault` endpoints it added to the AKS subnet stay on it —
+`azapi_update_resource` performs no operation on delete. To take them back off,
+run `az network vnet subnet update --ids <subnet-id> --service-endpoints` with
+only the endpoints you want to keep, since the flag replaces the whole list.
+
 ---
 
 ## Step 3 — Clean Up Generated Files

--- a/modules/azure/infra/main.tf
+++ b/modules/azure/infra/main.tf
@@ -86,6 +86,19 @@ locals {
     var.bastion_subnet_id,
   ]
 
+  # The endpoints the storage and Key Vault firewalls need on whichever subnet
+  # AKS ends up in. Terraform puts both on a subnet it carves (see the
+  # networking module), so this only matters for one you supply.
+  required_aks_service_endpoints = ["Microsoft.Storage", "Microsoft.KeyVault"]
+
+  manage_aks_subnet_endpoints = local.byo_aks_subnet && var.manage_byo_subnet_service_endpoints
+
+  # Read through azapi rather than the azurerm_subnet above, which reports the
+  # service names but not the locations scoping each one. Azure replaces the
+  # whole list on write, so a body rebuilt from names alone would quietly drop
+  # that scoping from endpoints belonging to the subnet's other workloads.
+  byo_aks_subnet_service_endpoints = try(data.azapi_resource.byo_aks_subnet_endpoints[0].output.properties.serviceEndpoints, [])
+
   # ── AKS ClusterIP range ─────────────────────────────────────────────────────
   # The create path gets the default here rather than on the variable, so that
   # the variable can be required under bring-your-own without breaking it.
@@ -283,14 +296,53 @@ data "azurerm_virtual_network" "byo_vnet" {
   resource_group_name = local.byo_vnet_parts[4]
 }
 
-# Reads an operator-supplied AKS subnet to confirm the service endpoints the
-# storage and Key Vault firewalls depend on. azurerm_subnet does expose
-# service_endpoints, so this needs no azapi.
+# Reads an operator-supplied AKS subnet for its address prefixes, and for the
+# service endpoints the storage and Key Vault firewalls depend on when Terraform
+# is only checking for them.
 data "azurerm_subnet" "byo_aks_subnet" {
   count                = local.byo_aks_subnet ? 1 : 0
   name                 = local.byo_aks_subnet_parts[10]
   virtual_network_name = local.byo_aks_subnet_parts[8]
   resource_group_name  = local.byo_aks_subnet_parts[4]
+}
+
+# ── Service endpoints on a supplied AKS subnet ────────────────────────────────
+# Only when manage_byo_subnet_service_endpoints is on. Reads the endpoints
+# already on the subnet so the patch below appends to them instead of replacing
+# them, and so the body settles: after the apply the read returns what was
+# added, the contains guard skips it, and the next plan is empty.
+data "azapi_resource" "byo_aks_subnet_endpoints" {
+  count                  = local.manage_aks_subnet_endpoints ? 1 : 0
+  type                   = "Microsoft.Network/virtualNetworks/subnets@2023-11-01"
+  resource_id            = var.aks_subnet_id
+  response_export_values = ["properties.serviceEndpoints"]
+}
+
+# Patches the one property. azurerm has no standalone service-endpoint resource
+# (service_endpoints is an attribute of azurerm_subnet), so doing this in azurerm
+# would mean importing the operator's subnet and owning its prefixes,
+# delegations, NSG and route table associations along with it.
+resource "azapi_update_resource" "byo_aks_subnet_endpoints" {
+  count       = local.manage_aks_subnet_endpoints ? 1 : 0
+  type        = "Microsoft.Network/virtualNetworks/subnets@2023-11-01"
+  resource_id = var.aks_subnet_id
+
+  body = {
+    properties = {
+      serviceEndpoints = concat(
+        local.byo_aks_subnet_service_endpoints,
+        [
+          for service in local.required_aks_service_endpoints : { service = service }
+          if !contains([for e in local.byo_aks_subnet_service_endpoints : try(e.service, "")], service)
+        ]
+      )
+    }
+  }
+
+  # Azure serializes writes per VNet, and azapi does not share the subnet lock
+  # azurerm holds internally. Reachable whenever one subnet is supplied and
+  # another is carved into the same VNet.
+  depends_on = [module.vnet]
 }
 
 resource "terraform_data" "validate_network" {
@@ -354,13 +406,14 @@ resource "terraform_data" "validate_network" {
     # (hardcoded default-deny) and the Key Vault firewall. Azure rejects a subnet
     # rule whose subnet lacks the matching service endpoint, and azurerm exposes
     # no way to skip that check, so both endpoints are required regardless of
-    # keyvault_default_action.
+    # keyvault_default_action. Skipped when Terraform is the one adding them,
+    # since checking first would fail the plan that would fix it.
     precondition {
-      condition = length(data.azurerm_subnet.byo_aks_subnet) == 0 || alltrue([
-        for endpoint in ["Microsoft.Storage", "Microsoft.KeyVault"] :
+      condition = local.manage_aks_subnet_endpoints || length(data.azurerm_subnet.byo_aks_subnet) == 0 || alltrue([
+        for endpoint in local.required_aks_service_endpoints :
         contains(data.azurerm_subnet.byo_aks_subnet[0].service_endpoints, endpoint)
       ])
-      error_message = "The subnet given as aks_subnet_id must carry both the Microsoft.Storage and Microsoft.KeyVault service endpoints. Without them the storage and Key Vault firewalls cannot allowlist the subnet and LangSmith pods lose access to blobs and secrets. Add both endpoints to the subnet, or clear aks_subnet_id and let Terraform create one."
+      error_message = "The subnet given as aks_subnet_id must carry both the Microsoft.Storage and Microsoft.KeyVault service endpoints. Without them the storage and Key Vault firewalls cannot allowlist the subnet and LangSmith pods lose access to blobs and secrets. Add both endpoints to the subnet, set manage_byo_subnet_service_endpoints = true to have Terraform add them, or clear aks_subnet_id and let Terraform create a subnet."
     }
 
     # Each service needs its own subnet. Postgres is the reason this is fatal
@@ -545,6 +598,10 @@ module "blob" {
   allowed_ips        = var.storage_allowed_ips
 
   tags = local.common_tags
+
+  # A subnet ID is a plain string and creates no dependency, so the firewall rule
+  # has to be told to wait for the endpoint that makes it valid.
+  depends_on = [azapi_update_resource.byo_aks_subnet_endpoints]
 }
 
 # ── Key Vault ─────────────────────────────────────────────────────────────────
@@ -592,7 +649,7 @@ module "keyvault" {
 
   tags = local.common_tags
 
-  depends_on = [module.blob]
+  depends_on = [module.blob, azapi_update_resource.byo_aks_subnet_endpoints]
 }
 
 # ── Kubernetes Bootstrap ───────────────────────────────────────────────────────

--- a/modules/azure/infra/main.tf
+++ b/modules/azure/infra/main.tf
@@ -43,6 +43,8 @@ locals {
   byo_aks_subnet      = !var.create_vnet && var.aks_subnet_id != ""
   byo_postgres_subnet = !var.create_vnet && var.postgres_subnet_id != ""
   byo_redis_subnet    = !var.create_vnet && var.redis_subnet_id != ""
+  byo_agic_subnet     = !var.create_vnet && var.agic_subnet_id != ""
+  byo_bastion_subnet  = !var.create_vnet && var.bastion_subnet_id != ""
 
   # A subnet is created only when it is needed by an enabled service and the
   # operator has not supplied one.
@@ -55,10 +57,12 @@ locals {
   postgres_subnet_id = local.byo_postgres_subnet ? var.postgres_subnet_id : module.vnet.subnet_postgres_id
   redis_subnet_id    = local.byo_redis_subnet ? var.redis_subnet_id : module.vnet.subnet_redis_id
 
-  # Bastion and AGIC have no bring-your-own input, so their subnets exist only
-  # on the create_vnet path. The preconditions below enforce that.
-  agic_subnet_id    = module.vnet.subnet_agic_id
-  bastion_subnet_id = module.vnet.subnet_bastion_id
+  # Bastion and AGIC are supply-only under bring-your-own: Terraform carves their
+  # subnets out of a VNet it owns, and reuses a supplied one otherwise. There is
+  # no carve path inside someone else's VNet, so the preconditions below require
+  # an ID whenever create_vnet = false.
+  agic_subnet_id    = local.byo_agic_subnet ? var.agic_subnet_id : module.vnet.subnet_agic_id
+  bastion_subnet_id = local.byo_bastion_subnet ? var.bastion_subnet_id : module.vnet.subnet_bastion_id
 
   # Subnet IDs are fixed-shape, and the variable validation anchors that shape
   # before this runs, so index positionally:
@@ -69,8 +73,17 @@ locals {
   # Every supplied subnet ID, lowercased for comparison since Azure treats
   # resource IDs case-insensitively. Used to reject the same subnet twice.
   supplied_subnet_ids = [
-    for id in [var.aks_subnet_id, var.postgres_subnet_id, var.redis_subnet_id] :
-    lower(id) if id != ""
+    for id in local.byo_subnet_ids : lower(id) if id != ""
+  ]
+
+  # Every bring-your-own subnet input, in one list so the shape checks below do
+  # not have to be extended each time another is added.
+  byo_subnet_ids = [
+    var.aks_subnet_id,
+    var.postgres_subnet_id,
+    var.redis_subnet_id,
+    var.agic_subnet_id,
+    var.bastion_subnet_id,
   ]
 
   # ── AKS ClusterIP range ─────────────────────────────────────────────────────
@@ -88,10 +101,35 @@ locals {
   # (nodes + surge) * (max_pods + 1). One surge node per pool covers upgrades.
   # Additional pools do not set max_pods, so they get the Azure CNI default.
   aks_default_pool_max_pods = 30
-  aks_required_ips = sum(concat(
-    [(var.default_node_pool_max_count + 1) * (var.default_node_pool_max_pods + 1)],
-    [for pool in var.additional_node_pools : (pool.max_count + 1) * (local.aks_default_pool_max_pods + 1)]
-  ))
+
+  # Held per pool rather than as a single total, so the number and the error
+  # message that has to justify it are built from the same place.
+  aks_pool_sizing = merge(
+    {
+      default = {
+        nodes              = var.default_node_pool_max_count + 1
+        addresses_per_node = var.default_node_pool_max_pods + 1
+      }
+    },
+    {
+      for name, pool in var.additional_node_pools : name => {
+        nodes              = pool.max_count + 1
+        addresses_per_node = local.aks_default_pool_max_pods + 1
+      }
+    }
+  )
+  aks_required_ips = sum([for pool in local.aks_pool_sizing : pool.nodes * pool.addresses_per_node])
+
+  # One row per pool, so an operator can see which pool dominates the total
+  # instead of being handed a number and two variable names.
+  aks_demand_rows = [
+    for name, pool in local.aks_pool_sizing :
+    format("  %-14s %4d x %3d = %5d", "${name}:", pool.nodes, pool.addresses_per_node, pool.nodes * pool.addresses_per_node)
+  ]
+
+  # Smallest prefix that holds the requirement plus Azure's five reserved
+  # addresses. ceil(log(n, 2)) is the host-bit count that covers n.
+  aks_smallest_prefix = 32 - ceil(log(local.aks_required_ips + 5, 2))
 
   # Whichever prefixes the AKS subnet ends up with: read back from a supplied
   # subnet, or the ones Terraform is about to carve. Both paths are checked,
@@ -205,11 +243,13 @@ module "vnet" {
   postgres_subnet_address_prefix = var.postgres_subnet_address_prefix
   redis_subnet_address_prefix    = var.redis_subnet_address_prefix
 
-  enable_bastion     = var.create_bastion
+  # Both are carved only out of a VNet Terraform owns. Under bring-your-own the
+  # operator supplies the subnet instead, and local.*_subnet_id selects it.
+  enable_bastion     = var.create_bastion && var.create_vnet
   availability_zones = var.availability_zones
 
   # AGIC subnet: provisioned only when ingress_controller = "agic"
-  enable_agic                = var.ingress_controller == "agic"
+  enable_agic                = var.ingress_controller == "agic" && var.create_vnet
   agic_subnet_address_prefix = var.agic_subnet_address_prefix
 
   tags = local.common_tags
@@ -263,8 +303,8 @@ resource "terraform_data" "validate_network" {
     # BYO subnet IDs are meaningless on the create path — fail loudly instead of
     # building a VNet the operator did not expect and ignoring what they set.
     precondition {
-      condition     = !var.create_vnet || (var.aks_subnet_id == "" && var.postgres_subnet_id == "" && var.redis_subnet_id == "")
-      error_message = "aks_subnet_id, postgres_subnet_id and redis_subnet_id only apply when create_vnet = false. Set create_vnet = false to reuse existing subnets, or clear these to let Terraform create the network."
+      condition     = !var.create_vnet || alltrue([for id in local.byo_subnet_ids : id == ""])
+      error_message = "The aks, postgres, redis, agic and bastion subnet ID inputs only apply when create_vnet = false. Set create_vnet = false to reuse existing subnets, or clear these to let Terraform create the network."
     }
 
     # Every supplied subnet must belong to vnet_id. A subnet in a different VNet
@@ -275,21 +315,29 @@ resource "terraform_data" "validate_network" {
     # in others. Only the comparison is lowered; Azure still gets the original.
     precondition {
       condition = var.create_vnet || alltrue([
-        for id in [var.aks_subnet_id, var.postgres_subnet_id, var.redis_subnet_id] :
+        for id in local.byo_subnet_ids :
         id == "" || startswith(lower(id), lower("${var.vnet_id}/subnets/"))
       ])
       error_message = "Every supplied subnet ID must be a subnet of vnet_id. Private DNS zones and AKS routing are wired to vnet_id, so a subnet in another VNet would be unreachable."
     }
 
-    # Both subnets are create-path only — neither has a bring-your-own input.
+    # Both subnets are carved only out of a VNet Terraform owns, so under
+    # bring-your-own the operator has to name one that already exists.
     precondition {
-      condition     = !var.create_bastion || var.create_vnet
-      error_message = "create_bastion = true requires create_vnet = true. There is no bastion_subnet_id input, so the bastion subnet can only be carved out of a Terraform-managed VNet."
+      condition     = !var.create_bastion || var.create_vnet || var.bastion_subnet_id != ""
+      error_message = "create_bastion = true with create_vnet = false requires bastion_subnet_id. Terraform will not carve a bastion subnet inside a VNet it does not own, so supply one that already exists, named AzureBastionSubnet and /26 or larger."
+    }
+
+    # Azure rejects any other name outright, and it is the one bastion mistake
+    # that a well-formed resource ID still lets through.
+    precondition {
+      condition     = !local.byo_bastion_subnet || lower(element(split("/", var.bastion_subnet_id), 10)) == "azurebastionsubnet"
+      error_message = "bastion_subnet_id must point at a subnet named AzureBastionSubnet, and names '${element(split("/", var.bastion_subnet_id), 10)}'. Azure Bastion requires that exact name and will not deploy into a subnet called anything else."
     }
 
     precondition {
-      condition     = var.ingress_controller != "agic" || var.create_vnet
-      error_message = "ingress_controller = 'agic' requires create_vnet = true. Application Gateway needs its own /24 subnet and there is no agic_subnet_id input."
+      condition     = var.ingress_controller != "agic" || var.create_vnet || var.agic_subnet_id != ""
+      error_message = "ingress_controller = 'agic' with create_vnet = false requires agic_subnet_id. Application Gateway v2 needs a subnet to itself, Azure recommends a /24, and Terraform will not carve one inside a VNet it does not own."
     }
 
     # A Postgres Flexible Server can only be injected into a subnet delegated to
@@ -321,15 +369,25 @@ resource "terraform_data" "validate_network" {
     # delegation check above and then fails partway through a long apply.
     precondition {
       condition     = length(local.supplied_subnet_ids) == length(distinct(local.supplied_subnet_ids))
-      error_message = "aks_subnet_id, postgres_subnet_id and redis_subnet_id must be three different subnets. The Postgres subnet is delegated to Microsoft.DBforPostgreSQL/flexibleServers and Azure allows no other resource type inside a delegated subnet, so a shared subnet fails during apply."
+      error_message = "Every supplied subnet ID must name a different subnet. Postgres is the reason this is fatal rather than untidy: its subnet is delegated to Microsoft.DBforPostgreSQL/flexibleServers and Azure allows no other resource type inside a delegated subnet, so a shared subnet fails during apply. Application Gateway v2 and Azure Bastion each need a subnet to themselves as well."
     }
 
     # Undersizing is the one network mistake that survives apply: the cluster
     # comes up, and the autoscaler later stalls partway to max_count once the
     # subnet runs out of addresses. Check it here instead.
     precondition {
-      condition     = local.aks_usable_ips >= local.aks_required_ips
-      error_message = "The AKS subnet holds ${local.aks_usable_ips} usable addresses, short of the ${local.aks_required_ips} that Azure CNI needs for the configured node pools. Nodes and pods both draw IPs from this subnet, so the autoscaler would stall before reaching max_count. Widen the subnet (a /22 or larger covers the defaults), or lower default_node_pool_max_count and default_node_pool_max_pods."
+      condition = local.aks_usable_ips >= local.aks_required_ips
+      error_message = join("\n", concat(
+        [
+          "The AKS subnet holds ${local.aks_usable_ips} usable addresses, short of the ${local.aks_required_ips} that Azure CNI needs for the configured node pools. Nodes and pods both draw IPs from this subnet, at (max_count + 1) nodes x (max_pods + 1) addresses per pool:",
+          "",
+        ],
+        local.aks_demand_rows,
+        [
+          "",
+          "Undersized, the cluster still starts and the autoscaler stalls short of max_count later, once the subnet runs dry. Widen the subnet to a /${local.aks_smallest_prefix} or larger, the smallest prefix that holds ${local.aks_required_ips} plus the 5 addresses Azure reserves. Or lower the default pool: one off default_node_pool_max_count frees ${var.default_node_pool_max_pods + 1} addresses, and one off default_node_pool_max_pods frees ${var.default_node_pool_max_count + 1}.",
+        ]
+      ))
     }
 
     # 10.0.64.0/20 only avoids the VNet that Terraform builds. Inside someone

--- a/modules/azure/infra/main.tf
+++ b/modules/azure/infra/main.tf
@@ -60,6 +60,12 @@ locals {
   agic_subnet_id    = module.vnet.subnet_agic_id
   bastion_subnet_id = module.vnet.subnet_bastion_id
 
+  # Subnet IDs are fixed-shape, and the variable validation anchors that shape
+  # before this runs, so index positionally:
+  #   0:"" 1:subscriptions 2:<sub> 3:resourceGroups 4:<rg>
+  #   5:providers 6:Microsoft.Network 7:virtualNetworks 8:<vnet> 9:subnets 10:<name>
+  byo_aks_subnet_parts = split("/", var.aks_subnet_id)
+
   # ── Common tags ─────────────────────────────────────────────────────────────
   # Applied to every Azure resource in every sub-module.
   # Sub-modules merge their own { module = "..." } tag on top.
@@ -123,6 +129,9 @@ module "vnet" {
 # express. These fire at plan time with an actionable message rather than
 # surfacing as an opaque Azure API error partway through an apply.
 
+# Both reads run at plan time, so whoever runs plan needs read access to the
+# supplied subnets — they usually live in the network team's resource group.
+
 # Reads an operator-supplied Postgres subnet to confirm the flexibleServers
 # delegation is present. The azurerm_subnet data source does not expose
 # delegations, so this goes through azapi.
@@ -131,6 +140,16 @@ data "azapi_resource" "byo_postgres_subnet" {
   type                   = "Microsoft.Network/virtualNetworks/subnets@2023-11-01"
   resource_id            = var.postgres_subnet_id
   response_export_values = ["properties.delegations"]
+}
+
+# Reads an operator-supplied AKS subnet to confirm the service endpoints the
+# storage and Key Vault firewalls depend on. azurerm_subnet does expose
+# service_endpoints, so this needs no azapi.
+data "azurerm_subnet" "byo_aks_subnet" {
+  count                = local.byo_aks_subnet ? 1 : 0
+  name                 = local.byo_aks_subnet_parts[10]
+  virtual_network_name = local.byo_aks_subnet_parts[8]
+  resource_group_name  = local.byo_aks_subnet_parts[4]
 }
 
 resource "terraform_data" "validate_network" {
@@ -150,10 +169,13 @@ resource "terraform_data" "validate_network" {
     # Every supplied subnet must belong to vnet_id. A subnet in a different VNet
     # would leave Postgres and Redis unreachable: the private DNS zones are
     # linked to vnet_id, and AKS could not route to them.
+    # Compared lowercased because Azure treats resource IDs as case-insensitive
+    # and will hand back "resourcegroups" in some contexts and "resourceGroups"
+    # in others. Only the comparison is lowered; Azure still gets the original.
     precondition {
       condition = var.create_vnet || alltrue([
         for id in [var.aks_subnet_id, var.postgres_subnet_id, var.redis_subnet_id] :
-        id == "" || startswith(id, "${var.vnet_id}/subnets/")
+        id == "" || startswith(lower(id), lower("${var.vnet_id}/subnets/"))
       ])
       error_message = "Every supplied subnet ID must be a subnet of vnet_id. Private DNS zones and AKS routing are wired to vnet_id, so a subnet in another VNet would be unreachable."
     }
@@ -177,6 +199,19 @@ resource "terraform_data" "validate_network" {
         try(d.properties.serviceName, "")
       ], "Microsoft.DBforPostgreSQL/flexibleServers")
       error_message = "The subnet given as postgres_subnet_id is not delegated to Microsoft.DBforPostgreSQL/flexibleServers. Add that delegation (action Microsoft.Network/virtualNetworks/subnets/join/action) to the subnet, or clear postgres_subnet_id and let Terraform create a correctly delegated subnet."
+    }
+
+    # The AKS subnet is allowlisted by ID on both the blob storage firewall
+    # (hardcoded default-deny) and the Key Vault firewall. Azure rejects a subnet
+    # rule whose subnet lacks the matching service endpoint, and azurerm exposes
+    # no way to skip that check, so both endpoints are required regardless of
+    # keyvault_default_action.
+    precondition {
+      condition = length(data.azurerm_subnet.byo_aks_subnet) == 0 || alltrue([
+        for endpoint in ["Microsoft.Storage", "Microsoft.KeyVault"] :
+        contains(data.azurerm_subnet.byo_aks_subnet[0].service_endpoints, endpoint)
+      ])
+      error_message = "The subnet given as aks_subnet_id must carry both the Microsoft.Storage and Microsoft.KeyVault service endpoints. Without them the storage and Key Vault firewalls cannot allowlist the subnet and LangSmith pods lose access to blobs and secrets. Add both endpoints to the subnet, or clear aks_subnet_id and let Terraform create one."
     }
   }
 }

--- a/modules/azure/infra/main.tf
+++ b/modules/azure/infra/main.tf
@@ -66,6 +66,46 @@ locals {
   #   5:providers 6:Microsoft.Network 7:virtualNetworks 8:<vnet> 9:subnets 10:<name>
   byo_aks_subnet_parts = split("/", var.aks_subnet_id)
 
+  # Every supplied subnet ID, lowercased for comparison since Azure treats
+  # resource IDs case-insensitively. Used to reject the same subnet twice.
+  supplied_subnet_ids = [
+    for id in [var.aks_subnet_id, var.postgres_subnet_id, var.redis_subnet_id] :
+    lower(id) if id != ""
+  ]
+
+  # ── AKS ClusterIP range ─────────────────────────────────────────────────────
+  # The create path gets the default here rather than on the variable, so that
+  # the variable can be required under bring-your-own without breaking it.
+  # dns_service_ip has to sit inside the service CIDR, so derive it from
+  # whichever range is in play instead of letting a stale default outlive it.
+  aks_service_cidr   = var.aks_service_cidr != "" ? var.aks_service_cidr : "10.0.64.0/20"
+  aks_dns_service_ip = var.aks_dns_service_ip != "" ? var.aks_dns_service_ip : cidrhost(local.aks_service_cidr, 10)
+
+  # ── AKS subnet capacity ─────────────────────────────────────────────────────
+  # Azure CNI is a flat network here (network_plugin = "azure", no overlay mode),
+  # so nodes and pods both draw IPs from this subnet. Azure's formula is
+  # (nodes + surge) + ((nodes + surge) * max_pods), which factors to
+  # (nodes + surge) * (max_pods + 1). One surge node per pool covers upgrades.
+  # Additional pools do not set max_pods, so they get the Azure CNI default.
+  aks_default_pool_max_pods = 30
+  aks_required_ips = sum(concat(
+    [(var.default_node_pool_max_count + 1) * (var.default_node_pool_max_pods + 1)],
+    [for pool in var.additional_node_pools : (pool.max_count + 1) * (local.aks_default_pool_max_pods + 1)]
+  ))
+
+  # Whichever prefixes the AKS subnet ends up with: read back from a supplied
+  # subnet, or the ones Terraform is about to carve. Both paths are checked,
+  # since a hand-picked aks_subnet_address_prefix can be just as undersized.
+  # one() returns null at count = 0, so neither branch needs a data source guard.
+  aks_subnet_prefixes = local.byo_aks_subnet ? coalesce(one(data.azurerm_subnet.byo_aks_subnet[*].address_prefixes), []) : var.aks_subnet_address_prefix
+
+  # Azure reserves five addresses per subnet. concat([0], ...) keeps sum() off an
+  # empty list. Prefixes may be disjoint, so capacity is their total.
+  aks_usable_ips = sum(concat([0], [
+    for prefix in local.aks_subnet_prefixes :
+    pow(2, 32 - tonumber(split("/", prefix)[1]))
+  ])) - 5
+
   # ── Common tags ─────────────────────────────────────────────────────────────
   # Applied to every Azure resource in every sub-module.
   # Sub-modules merge their own { module = "..." } tag on top.
@@ -213,6 +253,31 @@ resource "terraform_data" "validate_network" {
       ])
       error_message = "The subnet given as aks_subnet_id must carry both the Microsoft.Storage and Microsoft.KeyVault service endpoints. Without them the storage and Key Vault firewalls cannot allowlist the subnet and LangSmith pods lose access to blobs and secrets. Add both endpoints to the subnet, or clear aks_subnet_id and let Terraform create one."
     }
+
+    # Each service needs its own subnet. Postgres is the reason this is fatal
+    # rather than untidy: its subnet is delegated, and Azure documents that no
+    # other resource type may sit in a delegated subnet. Sharing passes the
+    # delegation check above and then fails partway through a long apply.
+    precondition {
+      condition     = length(local.supplied_subnet_ids) == length(distinct(local.supplied_subnet_ids))
+      error_message = "aks_subnet_id, postgres_subnet_id and redis_subnet_id must be three different subnets. The Postgres subnet is delegated to Microsoft.DBforPostgreSQL/flexibleServers and Azure allows no other resource type inside a delegated subnet, so a shared subnet fails during apply."
+    }
+
+    # Undersizing is the one network mistake that survives apply: the cluster
+    # comes up, and the autoscaler later stalls partway to max_count once the
+    # subnet runs out of addresses. Check it here instead.
+    precondition {
+      condition     = local.aks_usable_ips >= local.aks_required_ips
+      error_message = "The AKS subnet holds ${local.aks_usable_ips} usable addresses, short of the ${local.aks_required_ips} that Azure CNI needs for the configured node pools. Nodes and pods both draw IPs from this subnet, so the autoscaler would stall before reaching max_count. Widen the subnet (a /22 or larger covers the defaults), or lower default_node_pool_max_count and default_node_pool_max_pods."
+    }
+
+    # 10.0.64.0/20 only avoids the VNet that Terraform builds. Inside someone
+    # else's address space AKS can accept an overlapping ClusterIP range and
+    # break later, so make the operator name one.
+    precondition {
+      condition     = var.create_vnet || var.aks_service_cidr != ""
+      error_message = "aks_service_cidr is required when create_vnet = false. The 10.0.64.0/20 default is chosen to sit outside the Terraform-managed 10.0.0.0/17 and can fall inside your VNet. AKS requires a ClusterIP range that nothing on or connected to your VNet uses, so set one outside your VNet's address space."
+    }
   }
 }
 
@@ -226,8 +291,8 @@ module "aks" {
   location            = var.location
   resource_group_name = azurerm_resource_group.resource_group.name
   subnet_id           = local.aks_subnet_id
-  service_cidr        = var.aks_service_cidr   # K8s ClusterIP range (must not overlap VNet)
-  dns_service_ip      = var.aks_dns_service_ip # CoreDNS IP (must be within service_cidr)
+  service_cidr        = local.aks_service_cidr   # K8s ClusterIP range (must not overlap VNet)
+  dns_service_ip      = local.aks_dns_service_ip # CoreDNS IP (derived from service_cidr)
 
   default_node_pool_vm_size   = var.default_node_pool_vm_size
   default_node_pool_min_count = var.default_node_pool_min_count

--- a/modules/azure/infra/main.tf
+++ b/modules/azure/infra/main.tf
@@ -106,6 +106,57 @@ locals {
     pow(2, 32 - tonumber(split("/", prefix)[1]))
   ])) - 5
 
+  # ── Address space of a reused VNet ──────────────────────────────────────────
+  # A VNet ID is one segment shorter than a subnet ID, so the same positional
+  # read applies with the name at 8 instead of 10:
+  #   0:"" 1:subscriptions 2:<sub> 3:resourceGroups 4:<rg>
+  #   5:providers 6:Microsoft.Network 7:virtualNetworks 8:<name>
+  byo_vnet_parts     = split("/", var.vnet_id)
+  vnet_address_space = coalesce(one(data.azurerm_virtual_network.byo_vnet[*].address_space), [])
+
+  # Every prefix Terraform is about to carve, tagged with the variable that set
+  # it so a failure names what to change. A service running in-cluster carves
+  # nothing, so its prefix is left out rather than checked pointlessly.
+  carved_prefixes = flatten([
+    for entry in [
+      { name = "aks_subnet_address_prefix", carve = local.create_aks_subnet, prefixes = var.aks_subnet_address_prefix },
+      { name = "postgres_subnet_address_prefix", carve = local.create_postgres_subnet, prefixes = var.postgres_subnet_address_prefix },
+      { name = "redis_subnet_address_prefix", carve = local.create_redis_subnet, prefixes = var.redis_subnet_address_prefix },
+    ] : [for prefix in entry.prefixes : { name = entry.name, prefix = prefix }] if entry.carve
+  ])
+
+  # Terraform has no CIDR containment or overlap function, so reduce every range
+  # to its numeric bounds and compare those. cidrhost(x, 0) is the network
+  # address, and the last address is that plus the host count.
+  measured_cidrs = distinct(concat(
+    local.vnet_address_space,
+    [for entry in local.carved_prefixes : entry.prefix],
+    [local.aks_service_cidr],
+  ))
+  cidr_first = { for cidr in local.measured_cidrs : cidr => sum([
+    for i, octet in split(".", cidrhost(cidr, 0)) : tonumber(octet) * pow(256, 3 - i)
+  ]) }
+  cidr_last = { for cidr in local.measured_cidrs : cidr => local.cidr_first[cidr] + pow(2, 32 - tonumber(split("/", cidr)[1])) - 1 }
+
+  # A carved subnet has to fall inside one of the VNet's address prefixes. Azure
+  # will not split a subnet across two of them, so containment is per-prefix.
+  uncontained_prefixes = [
+    for entry in local.carved_prefixes : "${entry.prefix} (${entry.name})" if !anytrue([
+      for space in local.vnet_address_space :
+      local.cidr_first[entry.prefix] >= local.cidr_first[space] &&
+      local.cidr_last[entry.prefix] <= local.cidr_last[space]
+    ])
+  ]
+
+  # The ClusterIP range is the opposite case: it is not carved from the VNet and
+  # must stay clear of it. Two ranges overlap unless one ends before the other
+  # starts.
+  service_cidr_overlaps_vnet = anytrue([
+    for space in local.vnet_address_space :
+    local.cidr_first[local.aks_service_cidr] <= local.cidr_last[space] &&
+    local.cidr_last[local.aks_service_cidr] >= local.cidr_first[space]
+  ])
+
   # ── Common tags ─────────────────────────────────────────────────────────────
   # Applied to every Azure resource in every sub-module.
   # Sub-modules merge their own { module = "..." } tag on top.
@@ -180,6 +231,16 @@ data "azapi_resource" "byo_postgres_subnet" {
   type                   = "Microsoft.Network/virtualNetworks/subnets@2023-11-01"
   resource_id            = var.postgres_subnet_id
   response_export_values = ["properties.delegations"]
+}
+
+# Reads a reused VNet for its address space, so the prefixes Terraform is about
+# to carve inside it can be checked before apply. Gated on vnet_id being set as
+# well as create_vnet, so an empty vnet_id reaches its own precondition below
+# rather than failing on the positional read.
+data "azurerm_virtual_network" "byo_vnet" {
+  count               = !var.create_vnet && var.vnet_id != "" ? 1 : 0
+  name                = local.byo_vnet_parts[8]
+  resource_group_name = local.byo_vnet_parts[4]
 }
 
 # Reads an operator-supplied AKS subnet to confirm the service endpoints the
@@ -277,6 +338,24 @@ resource "terraform_data" "validate_network" {
     precondition {
       condition     = var.create_vnet || var.aks_service_cidr != ""
       error_message = "aks_service_cidr is required when create_vnet = false. The 10.0.64.0/20 default is chosen to sit outside the Terraform-managed 10.0.0.0/17 and can fall inside your VNet. AKS requires a ClusterIP range that nothing on or connected to your VNet uses, so set one outside your VNet's address space."
+    }
+
+    # Requiring aks_service_cidr does not make it correct, and a range picked out
+    # of the VNet's own space is the mistake the requirement exists to prevent.
+    # AKS accepts the overlap at cluster creation and the collision surfaces
+    # later, so it is worth the read.
+    precondition {
+      condition     = length(data.azurerm_virtual_network.byo_vnet) == 0 || !local.service_cidr_overlaps_vnet
+      error_message = "aks_service_cidr (${local.aks_service_cidr}) overlaps the address space of vnet_id (${join(", ", local.vnet_address_space)}). Kubernetes ClusterIPs are not carved from the VNet, and AKS requires a range nothing on or connected to it uses. This check only sees the VNet's own address space, so keep clear of peered and on-premises ranges too."
+    }
+
+    # The subnet prefix defaults describe the 10.0.0.0/17 VNet Terraform builds,
+    # so on someone else's network they are wrong more often than right. Azure
+    # rejects an out-of-range prefix partway through apply, once the resource
+    # group and Key Vault already exist.
+    precondition {
+      condition     = length(data.azurerm_virtual_network.byo_vnet) == 0 || length(local.uncontained_prefixes) == 0
+      error_message = "These subnet prefixes fall outside the address space of vnet_id (${join(", ", local.vnet_address_space)}): ${join(", ", local.uncontained_prefixes)}. Point each at a free range inside your VNet, or supply that subnet's ID to reuse a subnet that already exists."
     }
   }
 }

--- a/modules/azure/infra/main.tf
+++ b/modules/azure/infra/main.tf
@@ -35,13 +35,30 @@ locals {
   # Uses the user-supplied keyvault_name or derives from identifier.
   keyvault_name = var.keyvault_name != "" ? var.keyvault_name : "langsmith-kv${local.identifier}"
 
-  # Subnet ID resolution: use newly-created VNet subnets OR bring-your-own
-  # existing ones (set create_vnet = false and supply the IDs via variables).
+  # ── Network resolution ──────────────────────────────────────────────────────
+  # create_vnet = true  → Terraform owns the whole network; BYO IDs are rejected
+  #                       by the preconditions below rather than silently ignored.
+  # create_vnet = false → vnet_id is reused, and each subnet is independently
+  #                       either brought (ID supplied) or carved by Terraform.
+  byo_aks_subnet      = !var.create_vnet && var.aks_subnet_id != ""
+  byo_postgres_subnet = !var.create_vnet && var.postgres_subnet_id != ""
+  byo_redis_subnet    = !var.create_vnet && var.redis_subnet_id != ""
+
+  # A subnet is created only when it is needed by an enabled service and the
+  # operator has not supplied one.
+  create_aks_subnet      = !local.byo_aks_subnet
+  create_postgres_subnet = var.postgres_source == "external" && !local.byo_postgres_subnet
+  create_redis_subnet    = var.redis_source == "external" && !local.byo_redis_subnet
+
   vnet_id            = var.create_vnet ? module.vnet.vnet_id : var.vnet_id
-  aks_subnet_id      = var.create_vnet ? module.vnet.subnet_main_id : var.aks_subnet_id
-  postgres_subnet_id = var.create_vnet ? module.vnet.subnet_postgres_id : var.postgres_subnet_id
-  redis_subnet_id    = var.create_vnet ? module.vnet.subnet_redis_id : var.redis_subnet_id
-  agic_subnet_id     = var.create_vnet ? module.vnet.subnet_agic_id : ""
+  aks_subnet_id      = local.byo_aks_subnet ? var.aks_subnet_id : module.vnet.subnet_main_id
+  postgres_subnet_id = local.byo_postgres_subnet ? var.postgres_subnet_id : module.vnet.subnet_postgres_id
+  redis_subnet_id    = local.byo_redis_subnet ? var.redis_subnet_id : module.vnet.subnet_redis_id
+
+  # Bastion and AGIC have no bring-your-own input, so their subnets exist only
+  # on the create_vnet path. The preconditions below enforce that.
+  agic_subnet_id    = module.vnet.subnet_agic_id
+  bastion_subnet_id = module.vnet.subnet_bastion_id
 
   # ── Common tags ─────────────────────────────────────────────────────────────
   # Applied to every Azure resource in every sub-module.
@@ -67,8 +84,10 @@ resource "azurerm_resource_group" "resource_group" {
 }
 
 # ── Networking ────────────────────────────────────────────────────────────────
-# Creates VNet + three dedicated subnets (AKS, PostgreSQL, Redis).
-# Skip this block (create_vnet = false) to reuse an existing VNet.
+# Creates the VNet plus the dedicated subnets (AKS, PostgreSQL, Redis) that the
+# enabled services need. With create_vnet = false the VNet is reused and only
+# the subnets that were not supplied get created inside it — set every subnet ID
+# and this module creates nothing at all.
 
 module "vnet" {
   source              = "./modules/networking"
@@ -76,11 +95,16 @@ module "vnet" {
   location            = var.location
   resource_group_name = azurerm_resource_group.resource_group.name
 
-  # Controls whether the Postgres/Redis subnets are created.
-  # Set false if using in-cluster Postgres/Redis (no dedicated subnets needed).
-  enable_external_postgres = var.postgres_source == "external"
-  enable_external_redis    = var.redis_source == "external"
+  create_vnet      = var.create_vnet
+  existing_vnet_id = var.vnet_id
 
+  # A subnet is skipped when the operator supplied one, or when the service it
+  # serves runs in-cluster and needs no dedicated subnet.
+  create_main_subnet     = local.create_aks_subnet
+  create_postgres_subnet = local.create_postgres_subnet
+  create_redis_subnet    = local.create_redis_subnet
+
+  main_subnet_address_prefix     = var.aks_subnet_address_prefix
   postgres_subnet_address_prefix = var.postgres_subnet_address_prefix
   redis_subnet_address_prefix    = var.redis_subnet_address_prefix
 
@@ -92,6 +116,69 @@ module "vnet" {
   agic_subnet_address_prefix = var.agic_subnet_address_prefix
 
   tags = local.common_tags
+}
+
+# ── Input validation ──────────────────────────────────────────────────────────
+# Cross-variable network checks that a single variable's validation block cannot
+# express. These fire at plan time with an actionable message rather than
+# surfacing as an opaque Azure API error partway through an apply.
+
+# Reads an operator-supplied Postgres subnet to confirm the flexibleServers
+# delegation is present. The azurerm_subnet data source does not expose
+# delegations, so this goes through azapi.
+data "azapi_resource" "byo_postgres_subnet" {
+  count                  = local.byo_postgres_subnet && var.postgres_source == "external" ? 1 : 0
+  type                   = "Microsoft.Network/virtualNetworks/subnets@2023-11-01"
+  resource_id            = var.postgres_subnet_id
+  response_export_values = ["properties.delegations"]
+}
+
+resource "terraform_data" "validate_network" {
+  lifecycle {
+    precondition {
+      condition     = var.create_vnet || var.vnet_id != ""
+      error_message = "vnet_id is required when create_vnet = false. Supply the VNet that LangSmith should deploy into."
+    }
+
+    # BYO subnet IDs are meaningless on the create path — fail loudly instead of
+    # building a VNet the operator did not expect and ignoring what they set.
+    precondition {
+      condition     = !var.create_vnet || (var.aks_subnet_id == "" && var.postgres_subnet_id == "" && var.redis_subnet_id == "")
+      error_message = "aks_subnet_id, postgres_subnet_id and redis_subnet_id only apply when create_vnet = false. Set create_vnet = false to reuse existing subnets, or clear these to let Terraform create the network."
+    }
+
+    # Every supplied subnet must belong to vnet_id. A subnet in a different VNet
+    # would leave Postgres and Redis unreachable: the private DNS zones are
+    # linked to vnet_id, and AKS could not route to them.
+    precondition {
+      condition = var.create_vnet || alltrue([
+        for id in [var.aks_subnet_id, var.postgres_subnet_id, var.redis_subnet_id] :
+        id == "" || startswith(id, "${var.vnet_id}/subnets/")
+      ])
+      error_message = "Every supplied subnet ID must be a subnet of vnet_id. Private DNS zones and AKS routing are wired to vnet_id, so a subnet in another VNet would be unreachable."
+    }
+
+    # Both subnets are create-path only — neither has a bring-your-own input.
+    precondition {
+      condition     = !var.create_bastion || var.create_vnet
+      error_message = "create_bastion = true requires create_vnet = true. There is no bastion_subnet_id input, so the bastion subnet can only be carved out of a Terraform-managed VNet."
+    }
+
+    precondition {
+      condition     = var.ingress_controller != "agic" || var.create_vnet
+      error_message = "ingress_controller = 'agic' requires create_vnet = true. Application Gateway needs its own /24 subnet and there is no agic_subnet_id input."
+    }
+
+    # A Postgres Flexible Server can only be injected into a subnet delegated to
+    # it. Without this check the failure surfaces as a generic Azure API error.
+    precondition {
+      condition = length(data.azapi_resource.byo_postgres_subnet) == 0 || contains([
+        for d in try(data.azapi_resource.byo_postgres_subnet[0].output.properties.delegations, []) :
+        try(d.properties.serviceName, "")
+      ], "Microsoft.DBforPostgreSQL/flexibleServers")
+      error_message = "The subnet given as postgres_subnet_id is not delegated to Microsoft.DBforPostgreSQL/flexibleServers. Add that delegation (action Microsoft.Network/virtualNetworks/subnets/join/action) to the subnet, or clear postgres_subnet_id and let Terraform create a correctly delegated subnet."
+    }
+  }
 }
 
 # ── Kubernetes Cluster ────────────────────────────────────────────────────────
@@ -385,7 +472,7 @@ module "bastion" {
   name                 = "langsmith-bastion${local.identifier}"
   resource_group_name  = azurerm_resource_group.resource_group.name
   location             = var.location
-  subnet_id            = module.vnet.subnet_bastion_id
+  subnet_id            = local.bastion_subnet_id
   vm_size              = var.bastion_vm_size
   admin_ssh_public_key = var.bastion_admin_ssh_public_key
   allowed_ssh_cidrs    = var.bastion_allowed_ssh_cidrs

--- a/modules/azure/infra/modules/k8s-cluster/variables.tf
+++ b/modules/azure/infra/modules/k8s-cluster/variables.tf
@@ -78,7 +78,7 @@ variable "additional_node_pools" {
 
 variable "ingress_controller" {
   type        = string
-  description = "Ingress controller to install. 'nginx' = NGINX ingress via Helm. 'istio' = Istio via Helm (self-managed). 'istio-addon' = Azure managed Istio (AKS service mesh add-on, recommended on Azure). 'agic' = Application Gateway Ingress Controller (requires agic_subnet_id). 'envoy-gateway' = Envoy Gateway via Helm (Gateway API). 'none' = skip."
+  description = "Ingress controller to install. 'nginx' = NGINX ingress via Helm, the current default and the only option with every TLS path validated. 'istio' = Istio via Helm (self-managed). 'istio-addon' = Azure managed Istio (AKS service mesh add-on); use for mTLS or multi-dataplane. 'agic' = Application Gateway Ingress Controller (requires agic_subnet_id). 'envoy-gateway' = Envoy Gateway via Helm (Gateway API). 'none' = skip."
   default     = "nginx"
 
   validation {

--- a/modules/azure/infra/modules/networking/main.tf
+++ b/modules/azure/infra/modules/networking/main.tf
@@ -13,12 +13,36 @@
 #   • PostgreSQL Flexible Server requires its own delegated subnet (Azure restriction).
 #   • Redis Premium requires its own dedicated subnet.
 #   • Isolation allows independent NSG rules per service tier in Stage 3.
+#
+# Bring-your-own network:
+#   create_vnet = false skips the VNet and creates the subnets inside the VNet
+#   named by existing_vnet_id instead. Each subnet is independently opt-out via
+#   its create_*_subnet flag, so an operator can supply some subnet IDs and let
+#   Terraform carve the rest. With every flag false this module creates nothing.
 # ══════════════════════════════════════════════════════════════════════════════
+
+locals {
+  # An existing VNet lives in its own resource group, which is not necessarily
+  # the LangSmith resource group, so subnets must be placed by parsing the ID.
+  # Azure VNet IDs are fixed-shape, so index positionally rather than matching
+  # on segment names (Azure is inconsistent about "resourceGroups" casing):
+  #   0:"" 1:subscriptions 2:<sub> 3:resourceGroups 4:<rg>
+  #   5:providers 6:Microsoft.Network 7:virtualNetworks 8:<name>
+  # The root module validates the shape before this ever runs; the length guard
+  # keeps the empty-string default (create_vnet = true) from erroring here.
+  existing_vnet_parts = split("/", var.existing_vnet_id)
+  existing_vnet_valid = length(local.existing_vnet_parts) == 9
+
+  # Where every subnet below gets created.
+  subnet_resource_group_name = var.create_vnet ? var.resource_group_name : (local.existing_vnet_valid ? local.existing_vnet_parts[4] : "")
+  subnet_vnet_name           = var.create_vnet ? one(azurerm_virtual_network.vnet[*].name) : (local.existing_vnet_valid ? local.existing_vnet_parts[8] : "")
+}
 
 # The top-level VNet that all LangSmith resources share.
 # Azure CNI places AKS node & pod IPs directly in the subnet address space,
 # so the main subnet must be large enough for max_nodes * max_pods_per_node.
 resource "azurerm_virtual_network" "vnet" {
+  count               = var.create_vnet ? 1 : 0
   name                = var.network_name
   address_space       = var.address_space
   location            = var.location
@@ -37,22 +61,25 @@ resource "azurerm_virtual_network" "vnet" {
 # blocked by the deny rule. Cheap to enable and required for the storage/KV
 # default-deny posture in modules/storage and modules/keyvault.
 resource "azurerm_subnet" "subnet_main" {
+  count                = var.create_main_subnet ? 1 : 0
   name                 = "${var.network_name}-subnet-0"
-  resource_group_name  = var.resource_group_name
-  virtual_network_name = azurerm_virtual_network.vnet.name
+  resource_group_name  = local.subnet_resource_group_name
+  virtual_network_name = local.subnet_vnet_name
   address_prefixes     = var.main_subnet_address_prefix
   service_endpoints    = ["Microsoft.Storage", "Microsoft.KeyVault"]
 }
 
-# PostgreSQL subnet — created only when enable_external_postgres = true.
+# PostgreSQL subnet — created only when create_postgres_subnet = true.
 # MUST be delegated to Microsoft.DBforPostgreSQL/flexibleServers; the
 # delegation grants the service permission to inject NICs into this subnet.
 # No other resources can be placed in a delegated subnet.
+# An operator-supplied Postgres subnet must already carry this delegation —
+# the root module verifies that at plan time before the server is created.
 resource "azurerm_subnet" "subnet_postgres" {
-  count                = var.enable_external_postgres ? 1 : 0
+  count                = var.create_postgres_subnet ? 1 : 0
   name                 = "${var.network_name}-subnet-postgres"
-  resource_group_name  = var.resource_group_name
-  virtual_network_name = azurerm_virtual_network.vnet.name
+  resource_group_name  = local.subnet_resource_group_name
+  virtual_network_name = local.subnet_vnet_name
   address_prefixes     = var.postgres_subnet_address_prefix
 
   delegation {
@@ -68,14 +95,16 @@ resource "azurerm_subnet" "subnet_postgres" {
   }
 }
 
-# Redis subnet — created only when enable_external_redis = true.
-# Azure Redis Cache Premium tier requires an exclusive subnet
-# (no other resources allowed). Must be /28 or larger.
+# Redis subnet — created only when create_redis_subnet = true.
+# Deliberately NOT delegated. Azure Managed Redis is not subnet-injected; the
+# redis module reaches it through a private endpoint placed in this subnet
+# (see modules/redis/main.tf). A delegation here would in fact block that,
+# since a delegated subnet accepts only its delegated service.
 resource "azurerm_subnet" "subnet_redis" {
-  count                = var.enable_external_redis ? 1 : 0
+  count                = var.create_redis_subnet ? 1 : 0
   name                 = "${var.network_name}-subnet-redis"
-  resource_group_name  = var.resource_group_name
-  virtual_network_name = azurerm_virtual_network.vnet.name
+  resource_group_name  = local.subnet_resource_group_name
+  virtual_network_name = local.subnet_vnet_name
   address_prefixes     = var.redis_subnet_address_prefix
 }
 
@@ -84,8 +113,8 @@ resource "azurerm_subnet" "subnet_redis" {
 resource "azurerm_subnet" "subnet_bastion" {
   count                = var.enable_bastion ? 1 : 0
   name                 = "${var.network_name}-subnet-bastion"
-  resource_group_name  = var.resource_group_name
-  virtual_network_name = azurerm_virtual_network.vnet.name
+  resource_group_name  = local.subnet_resource_group_name
+  virtual_network_name = local.subnet_vnet_name
   address_prefixes     = var.bastion_subnet_address_prefix
 }
 
@@ -95,7 +124,7 @@ resource "azurerm_subnet" "subnet_bastion" {
 resource "azurerm_subnet" "subnet_agic" {
   count                = var.enable_agic ? 1 : 0
   name                 = "${var.network_name}-subnet-agic"
-  resource_group_name  = var.resource_group_name
-  virtual_network_name = azurerm_virtual_network.vnet.name
+  resource_group_name  = local.subnet_resource_group_name
+  virtual_network_name = local.subnet_vnet_name
   address_prefixes     = var.agic_subnet_address_prefix
 }

--- a/modules/azure/infra/modules/networking/outputs.tf
+++ b/modules/azure/infra/modules/networking/outputs.tf
@@ -1,7 +1,12 @@
-# Each output is null when the resource was not created — either the operator
-# brought their own, or the service is in-cluster. The root module resolves
-# every one against its bring-your-own variable, so no downstream module ever
-# receives a null subnet ID.
+# The VNet and the three service subnets below are null when the resource was
+# not created — either the operator brought their own, or the service is
+# in-cluster. The root module resolves each against its bring-your-own variable,
+# so no downstream module ever receives a null subnet ID.
+#
+# subnet_bastion_id and subnet_agic_id return an empty string instead, and have
+# to: k8s-cluster gates AGIC on agic_subnet_id != "", which a null passes, and
+# the split that follows would then fail. Do not switch them to one() for
+# consistency with the four above.
 
 output "vnet_id" {
   value       = one(azurerm_virtual_network.vnet[*].id)

--- a/modules/azure/infra/modules/networking/outputs.tf
+++ b/modules/azure/infra/modules/networking/outputs.tf
@@ -1,11 +1,16 @@
+# Each output is null when the resource was not created — either the operator
+# brought their own, or the service is in-cluster. The root module resolves
+# every one against its bring-your-own variable, so no downstream module ever
+# receives a null subnet ID.
+
 output "vnet_id" {
-  value       = azurerm_virtual_network.vnet.id
-  description = "The ID of the VNet."
+  value       = try(azurerm_virtual_network.vnet[0].id, null)
+  description = "The ID of the VNet, if created."
 }
 
 output "subnet_main_id" {
-  value       = azurerm_subnet.subnet_main.id
-  description = "The ID of the main subnet to be used by the AKS cluster."
+  value       = try(azurerm_subnet.subnet_main[0].id, null)
+  description = "The ID of the main subnet to be used by the AKS cluster, if created."
 }
 
 output "subnet_postgres_id" {
@@ -20,10 +25,10 @@ output "subnet_redis_id" {
 
 output "subnet_bastion_id" {
   description = "ID of the bastion subnet (empty string when enable_bastion = false)"
-  value       = var.enable_bastion ? azurerm_subnet.subnet_bastion[0].id : ""
+  value       = try(azurerm_subnet.subnet_bastion[0].id, "")
 }
 
 output "subnet_agic_id" {
   description = "ID of the Application Gateway subnet (empty string when enable_agic = false)"
-  value       = var.enable_agic ? azurerm_subnet.subnet_agic[0].id : ""
+  value       = try(azurerm_subnet.subnet_agic[0].id, "")
 }

--- a/modules/azure/infra/modules/networking/outputs.tf
+++ b/modules/azure/infra/modules/networking/outputs.tf
@@ -4,31 +4,31 @@
 # receives a null subnet ID.
 
 output "vnet_id" {
-  value       = try(azurerm_virtual_network.vnet[0].id, null)
+  value       = one(azurerm_virtual_network.vnet[*].id)
   description = "The ID of the VNet, if created."
 }
 
 output "subnet_main_id" {
-  value       = try(azurerm_subnet.subnet_main[0].id, null)
+  value       = one(azurerm_subnet.subnet_main[*].id)
   description = "The ID of the main subnet to be used by the AKS cluster, if created."
 }
 
 output "subnet_postgres_id" {
-  value       = try(azurerm_subnet.subnet_postgres[0].id, null)
+  value       = one(azurerm_subnet.subnet_postgres[*].id)
   description = "The ID of the Postgres subnet, if created."
 }
 
 output "subnet_redis_id" {
-  value       = try(azurerm_subnet.subnet_redis[0].id, null)
+  value       = one(azurerm_subnet.subnet_redis[*].id)
   description = "The ID of the Redis subnet, if created."
 }
 
 output "subnet_bastion_id" {
   description = "ID of the bastion subnet (empty string when enable_bastion = false)"
-  value       = try(azurerm_subnet.subnet_bastion[0].id, "")
+  value       = var.enable_bastion ? azurerm_subnet.subnet_bastion[0].id : ""
 }
 
 output "subnet_agic_id" {
   description = "ID of the Application Gateway subnet (empty string when enable_agic = false)"
-  value       = try(azurerm_subnet.subnet_agic[0].id, "")
+  value       = var.enable_agic ? azurerm_subnet.subnet_agic[0].id : ""
 }

--- a/modules/azure/infra/modules/networking/variables.tf
+++ b/modules/azure/infra/modules/networking/variables.tf
@@ -3,6 +3,24 @@ variable "network_name" {
   description = "Name of the virtual network"
 }
 
+variable "create_vnet" {
+  type        = bool
+  description = "Create the VNet. When false, subnets are created inside the VNet identified by existing_vnet_id."
+  default     = true
+}
+
+variable "existing_vnet_id" {
+  type        = string
+  description = "Resource ID of an existing VNet to create subnets in. Required when create_vnet = false."
+  default     = ""
+}
+
+variable "create_main_subnet" {
+  type        = bool
+  description = "Create the main (AKS) subnet. False when an existing AKS subnet is supplied."
+  default     = true
+}
+
 variable "location" {
   type        = string
   description = "Location of the virtual network"
@@ -25,15 +43,15 @@ variable "main_subnet_address_prefix" {
   default     = ["10.0.0.0/19"] # 8k IP addresses
 }
 
-variable "enable_external_postgres" {
+variable "create_postgres_subnet" {
   type        = bool
-  description = "Enable external Postgres"
+  description = "Create the delegated Postgres subnet. False when Postgres is in-cluster, or when an existing Postgres subnet is supplied."
   default     = true
 }
 
-variable "enable_external_redis" {
+variable "create_redis_subnet" {
   type        = bool
-  description = "Enable external Redis"
+  description = "Create the Redis subnet. False when Redis is in-cluster, or when an existing Redis subnet is supplied."
   default     = true
 }
 

--- a/modules/azure/infra/outputs.tf
+++ b/modules/azure/infra/outputs.tf
@@ -38,6 +38,30 @@ output "resource_group_name" {
   value       = azurerm_resource_group.resource_group.name
 }
 
+# ── Networking ────────────────────────────────────────────────────────────────
+# Resolved IDs, whether Terraform created the subnet or the operator supplied it.
+# When create_vnet = false these tell you what Terraform carved out of your VNet.
+
+output "vnet_id" {
+  description = "Resource ID of the VNet LangSmith is deployed into"
+  value       = local.vnet_id
+}
+
+output "aks_subnet_id" {
+  description = "Resource ID of the subnet holding the AKS nodes and pods"
+  value       = local.aks_subnet_id
+}
+
+output "postgres_subnet_id" {
+  description = "Resource ID of the delegated Postgres subnet (null when postgres_source = 'in-cluster')"
+  value       = local.postgres_subnet_id
+}
+
+output "redis_subnet_id" {
+  description = "Resource ID of the subnet holding the Redis private endpoint (null when redis_source = 'in-cluster')"
+  value       = local.redis_subnet_id
+}
+
 # ── AKS cluster ───────────────────────────────────────────────────────────────
 
 output "aks_cluster_name" {

--- a/modules/azure/infra/scripts/quickstart.sh
+++ b/modules/azure/infra/scripts/quickstart.sh
@@ -194,6 +194,26 @@ VNET_ID=""
 AKS_SUBNET_ID=""
 POSTGRES_SUBNET_ID=""
 REDIS_SUBNET_ID=""
+AKS_SUBNET_CIDR_LINE=""
+POSTGRES_SUBNET_CIDR_LINE=""
+REDIS_SUBNET_CIDR_LINE=""
+
+# Ask for one subnet in bring-your-own-VNet mode. An empty answer means
+# "Terraform creates it", which then needs a CIDR to carve out of the VNet.
+# Sets _SUBNET_ID and _SUBNET_CIDR_LINE.
+_ask_subnet() {
+  local label="$1" cidr_var="$2" default_cidr="$3" note="$4"
+  _SUBNET_ID=""
+  _SUBNET_CIDR_LINE=""
+  echo ""
+  _hint "$note"
+  _ask "${label} subnet resource ID (Enter = let Terraform create it)" ""
+  _SUBNET_ID="$_REPLY"
+  if [[ -z "$_SUBNET_ID" ]]; then
+    _ask "CIDR for the new ${label} subnet" "$default_cidr"
+    _SUBNET_CIDR_LINE="${cidr_var} = [\"$_REPLY\"]"
+  fi
+}
 
 _run_section_3() {
   _section "3. Networking"
@@ -203,24 +223,63 @@ _run_section_3() {
 
   CREATE_VNET="true"
   VNET_ID=""; AKS_SUBNET_ID=""; POSTGRES_SUBNET_ID=""; REDIS_SUBNET_ID=""
+  AKS_SUBNET_CIDR_LINE=""; POSTGRES_SUBNET_CIDR_LINE=""; REDIS_SUBNET_CIDR_LINE=""
 
   if _ask_yn "Create a new VNet? (recommended)" "y"; then
     CREATE_VNET="true"
-  else
-    CREATE_VNET="false"
+    return
+  fi
+
+  CREATE_VNET="false"
+
+  # This section can be re-run from the review menu, after AGIC or a bastion has
+  # already been chosen. Neither has a bring-your-own subnet input, so leaving
+  # them set would emit a tfvars that terraform plan rejects. Reset and say so.
+  if [[ "$INGRESS_CONTROLLER" == "agic" ]]; then
+    INGRESS_CONTROLLER="nginx"
+    AGW_SKU_TIER_LINE=""
+    _red "  AGIC needs a Terraform-managed VNet — ingress controller reset to nginx."
     echo ""
-    _hint "Bring Your Own VNet — you must provide existing subnet resource IDs."
-    _hint "The PostgreSQL subnet must have Microsoft.DBforPostgreSQL/flexibleServers delegation."
+  fi
+  if [[ "$CREATE_BASTION" == "true" ]]; then
+    CREATE_BASTION="false"
+    _red "  The bastion needs a Terraform-managed VNet — bastion disabled."
     echo ""
+  fi
+
+  echo ""
+  _hint "Bring Your Own VNet — LangSmith deploys into a VNet you already own."
+  _hint "Each subnet below is optional. Paste a subnet resource ID to reuse an"
+  _hint "existing subnet, or press Enter and Terraform creates it inside your VNet"
+  _hint "with the settings that service needs."
+  echo ""
+
+  # Matched against the same shape the vnet_id variable validates, so a typo is
+  # caught here rather than at terraform plan.
+  local vnet_re='^/subscriptions/[^/]+/resourceGroups/[^/]+/providers/Microsoft\.Network/virtualNetworks/[^/]+$'
+  while true; do
     _ask "VNet resource ID (/subscriptions/.../virtualNetworks/...)" ""
     VNET_ID="$_REPLY"
-    _ask "AKS subnet resource ID (/subscriptions/.../subnets/...)" ""
-    AKS_SUBNET_ID="$_REPLY"
-    _ask "PostgreSQL subnet resource ID (must have flexibleServers delegation)" ""
-    POSTGRES_SUBNET_ID="$_REPLY"
-    _ask "Redis subnet resource ID" ""
-    REDIS_SUBNET_ID="$_REPLY"
-  fi
+    [[ "$VNET_ID" =~ $vnet_re ]] && break
+    _red "  ERROR: expected /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Network/virtualNetworks/<name>"
+    echo ""
+  done
+
+  _ask_subnet "AKS" "aks_subnet_address_prefix" "10.0.0.0/19" \
+    "Holds AKS node and pod IPs (Azure CNI). An existing subnet needs the Microsoft.Storage and Microsoft.KeyVault service endpoints."
+  AKS_SUBNET_ID="$_SUBNET_ID"; AKS_SUBNET_CIDR_LINE="$_SUBNET_CIDR_LINE"
+
+  _ask_subnet "PostgreSQL" "postgres_subnet_address_prefix" "10.0.32.0/20" \
+    "An existing subnet must already be delegated to Microsoft.DBforPostgreSQL/flexibleServers and contain nothing else. A new one gets that delegation automatically."
+  POSTGRES_SUBNET_ID="$_SUBNET_ID"; POSTGRES_SUBNET_CIDR_LINE="$_SUBNET_CIDR_LINE"
+
+  _ask_subnet "Redis" "redis_subnet_address_prefix" "10.0.48.0/20" \
+    "Holds the Azure Managed Redis private endpoint. This subnet must NOT be delegated — a delegated subnet would reject the endpoint."
+  REDIS_SUBNET_ID="$_SUBNET_ID"; REDIS_SUBNET_CIDR_LINE="$_SUBNET_CIDR_LINE"
+
+  echo ""
+  _hint "Any CIDR you entered must fit inside your VNet's address space, not overlap"
+  _hint "an existing subnet, and not overlap the Kubernetes service CIDR (10.0.64.0/20)."
 }
 
 # -- 4. AKS ------------------------------------------------------------------
@@ -273,29 +332,44 @@ _run_section_5() {
   _hint "istio-addon — AKS managed Istio mesh; best for multi-dataplane + mTLS use cases."
   _hint "istio       — self-managed Istio via Helm; more control, more operational overhead."
   _hint "agic        — Azure Application Gateway; enterprise WAF built-in, but requires a"
-  _hint "              dedicated subnet at VNet creation time (cannot add to existing VNet)."
+  _hint "              dedicated /24 subnet in a Terraform-managed VNet."
   _hint "envoy-gateway — Gateway API native; useful if you're standardizing on Gateway API."
   _hint "Start with nginx unless you have a specific reason to use another."
 
   ISTIO_ADDON_REVISION_LINE=""
   AGW_SKU_TIER_LINE=""
 
-  _ask_choice "Which ingress controller?" \
-    "nginx         — NGINX via Helm (recommended default)" \
-    "istio-addon   — Azure managed Istio, AKS service mesh add-on" \
-    "istio         — Istio via Helm (self-managed)" \
-    "agic          — Application Gateway Ingress Controller (enterprise, native WAF)" \
-    "envoy-gateway — Envoy Gateway (Gateway API native)" \
-    "none          — skip (bring your own)"
+  while true; do
+    _ask_choice "Which ingress controller?" \
+      "nginx         — NGINX via Helm (recommended default)" \
+      "istio-addon   — Azure managed Istio, AKS service mesh add-on" \
+      "istio         — Istio via Helm (self-managed)" \
+      "agic          — Application Gateway Ingress Controller (enterprise, native WAF)" \
+      "envoy-gateway — Envoy Gateway (Gateway API native)" \
+      "none          — skip (bring your own)"
 
-  case "$_CHOICE" in
-    1) INGRESS_CONTROLLER="nginx" ;;
-    2) INGRESS_CONTROLLER="istio-addon" ;;
-    3) INGRESS_CONTROLLER="istio" ;;
-    4) INGRESS_CONTROLLER="agic" ;;
-    5) INGRESS_CONTROLLER="envoy-gateway" ;;
-    6) INGRESS_CONTROLLER="none" ;;
-  esac
+    case "$_CHOICE" in
+      1) INGRESS_CONTROLLER="nginx" ;;
+      2) INGRESS_CONTROLLER="istio-addon" ;;
+      3) INGRESS_CONTROLLER="istio" ;;
+      4) INGRESS_CONTROLLER="agic" ;;
+      5) INGRESS_CONTROLLER="envoy-gateway" ;;
+      6) INGRESS_CONTROLLER="none" ;;
+    esac
+
+    # There is no agic_subnet_id input, so the Application Gateway subnet can
+    # only be carved out of a VNet Terraform owns. Catch it here rather than
+    # letting terraform plan reject the generated tfvars.
+    if [[ "$INGRESS_CONTROLLER" == "agic" && "$CREATE_VNET" == "false" ]]; then
+      _red "  AGIC is not available with a bring-your-own VNet."
+      echo ""
+      _hint "Application Gateway needs a dedicated /24 subnet that Terraform can only"
+      _hint "create in a VNet it manages. Pick another controller, or re-run section 3"
+      _hint "and let Terraform create the VNet."
+      continue
+    fi
+    break
+  done
 
   echo ""
   printf "  Ingress: $(_cyan "$INGRESS_CONTROLLER")\n"
@@ -611,7 +685,11 @@ _run_section_10() {
     echo ""
     _hint "Bastion host    — jump VM for direct SSH to AKS nodes (private cluster debugging)."
     _hint "                  Not needed for most deployments unless nodes are on a private subnet."
-    if _ask_yn "Create bastion host? (for node-level troubleshooting)" "n"; then
+    if [[ "$CREATE_VNET" == "false" ]]; then
+      # No bastion_subnet_id input exists, so the bastion subnet can only be
+      # created in a Terraform-managed VNet.
+      _hint "                  Unavailable with a bring-your-own VNet — skipped."
+    elif _ask_yn "Create bastion host? (for node-level troubleshooting)" "n"; then
       CREATE_BASTION="true"
     fi
   else
@@ -732,10 +810,15 @@ if [[ "$CREATE_VNET" == "false" ]]; then
   cat >> "$OUTPUT" << TFVARS
 create_vnet        = false
 vnet_id            = "${VNET_ID}"
-aks_subnet_id      = "${AKS_SUBNET_ID}"
-postgres_subnet_id = "${POSTGRES_SUBNET_ID}"
-redis_subnet_id    = "${REDIS_SUBNET_ID}"
 TFVARS
+  # A subnet ID reuses an existing subnet; its absence plus a CIDR tells
+  # Terraform to create that subnet inside the VNet above.
+  [[ -n "$AKS_SUBNET_ID" ]]      && echo "aks_subnet_id      = \"${AKS_SUBNET_ID}\"" >> "$OUTPUT"
+  [[ -n "$POSTGRES_SUBNET_ID" ]] && echo "postgres_subnet_id = \"${POSTGRES_SUBNET_ID}\"" >> "$OUTPUT"
+  [[ -n "$REDIS_SUBNET_ID" ]]    && echo "redis_subnet_id    = \"${REDIS_SUBNET_ID}\"" >> "$OUTPUT"
+  [[ -n "$AKS_SUBNET_CIDR_LINE" ]]      && echo "$AKS_SUBNET_CIDR_LINE" >> "$OUTPUT"
+  [[ -n "$POSTGRES_SUBNET_CIDR_LINE" ]] && echo "$POSTGRES_SUBNET_CIDR_LINE" >> "$OUTPUT"
+  [[ -n "$REDIS_SUBNET_CIDR_LINE" ]]    && echo "$REDIS_SUBNET_CIDR_LINE" >> "$OUTPUT"
 else
   echo "# Using auto-created VNet (default)" >> "$OUTPUT"
 fi

--- a/modules/azure/infra/scripts/quickstart.sh
+++ b/modules/azure/infra/scripts/quickstart.sh
@@ -266,15 +266,23 @@ _run_section_3() {
   _hint "Each subnet below is optional. Paste a subnet resource ID to reuse an"
   _hint "existing subnet, or press Enter and Terraform creates it inside your VNet"
   _hint "with the settings that service needs."
+  _hint "The CIDRs offered as defaults below describe the VNet Terraform builds, not"
+  _hint "yours. Replace each with a free range inside your own address space."
   echo ""
 
   # Matched against the same shape the vnet_id variable validates, so a typo is
-  # caught here rather than at terraform plan.
-  local vnet_re='^/subscriptions/[^/]+/resourceGroups/[^/]+/providers/Microsoft\.Network/virtualNetworks/[^/]+$'
+  # caught here rather than at terraform plan. That validation is
+  # case-insensitive because Azure hands back "resourcegroups" in some contexts
+  # and "resourceGroups" in others, so lowercase a copy before comparing — bash
+  # 3.2 has no ${var,,}. Only the comparison is lowered; Terraform gets what was
+  # pasted.
+  local vnet_re='^/subscriptions/[^/]+/resourcegroups/[^/]+/providers/microsoft\.network/virtualnetworks/[^/]+$'
+  local vnet_lc
   while true; do
     _ask "VNet resource ID (/subscriptions/.../virtualNetworks/...)" ""
     VNET_ID="$_REPLY"
-    [[ "$VNET_ID" =~ $vnet_re ]] && break
+    vnet_lc=$(printf '%s' "$VNET_ID" | tr '[:upper:]' '[:lower:]')
+    [[ "$vnet_lc" =~ $vnet_re ]] && break
     _red "  ERROR: expected /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Network/virtualNetworks/<name>"
     echo ""
   done

--- a/modules/azure/infra/scripts/quickstart.sh
+++ b/modules/azure/infra/scripts/quickstart.sh
@@ -211,7 +211,19 @@ _ask_subnet() {
   _SUBNET_ID="$_REPLY"
   if [[ -z "$_SUBNET_ID" ]]; then
     _ask "CIDR for the new ${label} subnet" "$default_cidr"
-    _SUBNET_CIDR_LINE="${cidr_var} = [\"$_REPLY\"]"
+    # Padded so the three prefix lines line up with each other in the tfvars.
+    _SUBNET_CIDR_LINE="$(printf '%-30s = ["%s"]' "$cidr_var" "$_REPLY")"
+  fi
+}
+
+# One subnet's line on the review screen: the ID being reused, or the CIDR
+# Terraform will carve. Lets an operator catch a pasted ID before anything runs.
+_subnet_review() {
+  local id="$1" cidr_line="$2"
+  if [[ -n "$id" ]]; then
+    echo "reuse   $id"
+  else
+    echo "create  ${cidr_line#*= }"
   fi
 }
 
@@ -728,6 +740,12 @@ while true; do
   printf "  %-24s %s\n" "   Location:"        "$LOCATION"
   printf "  %-24s %s\n" "   Environment:"     "$ENVIRONMENT"
   printf "  %-24s %s\n" "3. VNet:"            "$( [[ "$CREATE_VNET" == "true" ]] && echo "new (auto-created)" || echo "existing" )"
+  if [[ "$CREATE_VNET" == "false" ]]; then
+    printf "  %-24s %s\n" "   VNet ID:"           "$VNET_ID"
+    printf "  %-24s %s\n" "   AKS subnet:"        "$(_subnet_review "$AKS_SUBNET_ID" "$AKS_SUBNET_CIDR_LINE")"
+    printf "  %-24s %s\n" "   PostgreSQL subnet:" "$(_subnet_review "$POSTGRES_SUBNET_ID" "$POSTGRES_SUBNET_CIDR_LINE")"
+    printf "  %-24s %s\n" "   Redis subnet:"      "$(_subnet_review "$REDIS_SUBNET_ID" "$REDIS_SUBNET_CIDR_LINE")"
+  fi
   printf "  %-24s %s\n" "4. Node size:"       "$NODE_VM_SIZE  min=$NODE_MIN  max=$NODE_MAX"
   printf "  %-24s %s\n" "5. Ingress:"         "$INGRESS_CONTROLLER"
   [[ -n "$ISTIO_ADDON_REVISION_LINE" ]] && printf "  %-24s %s\n" "   Istio revision:"  "${ISTIO_ADDON_REVISION_LINE#*= }"

--- a/modules/azure/infra/scripts/quickstart.sh
+++ b/modules/azure/infra/scripts/quickstart.sh
@@ -217,6 +217,34 @@ _ask_subnet() {
   fi
 }
 
+# A subnet that has to already exist. AGIC and the bastion have no carve path
+# inside a VNet Terraform does not own, so an ID is required rather than optional.
+# Lowercased before matching for the same reason as vnet_re below, and the
+# optional third argument enforces a name Azure demands.
+_ask_required_subnet() {
+  local label="$1" note="$2" want_name="$3" id_lc want_lc
+  local subnet_re='^/subscriptions/[^/]+/resourcegroups/[^/]+/providers/microsoft\.network/virtualnetworks/[^/]+/subnets/[^/]+$'
+  want_lc=$(printf '%s' "$want_name" | tr '[:upper:]' '[:lower:]')
+  echo ""
+  _hint "$note"
+  while true; do
+    _ask "${label} subnet resource ID" ""
+    _REQUIRED_SUBNET_ID="$_REPLY"
+    id_lc=$(printf '%s' "$_REQUIRED_SUBNET_ID" | tr '[:upper:]' '[:lower:]')
+    if [[ ! "$id_lc" =~ $subnet_re ]]; then
+      _red "  ERROR: expected /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Network/virtualNetworks/<vnet>/subnets/<name>"
+      echo ""
+      continue
+    fi
+    if [[ -n "$want_lc" && "${id_lc##*/}" != "$want_lc" ]]; then
+      _red "  ERROR: Azure requires this subnet be named ${want_name}."
+      echo ""
+      continue
+    fi
+    break
+  done
+}
+
 # One subnet's line on the review screen: the ID being reused, or the CIDR
 # Terraform will carve. Lets an operator catch a pasted ID before anything runs.
 _subnet_review() {
@@ -238,6 +266,7 @@ _run_section_3() {
   VNET_ID=""; AKS_SUBNET_ID=""; POSTGRES_SUBNET_ID=""; REDIS_SUBNET_ID=""
   AKS_SUBNET_CIDR_LINE=""; POSTGRES_SUBNET_CIDR_LINE=""; REDIS_SUBNET_CIDR_LINE=""
   AKS_SERVICE_CIDR=""
+  AGIC_SUBNET_ID=""; BASTION_SUBNET_ID=""
 
   if _ask_yn "Create a new VNet? (recommended)" "y"; then
     CREATE_VNET="true"
@@ -245,21 +274,6 @@ _run_section_3() {
   fi
 
   CREATE_VNET="false"
-
-  # This section can be re-run from the review menu, after AGIC or a bastion has
-  # already been chosen. Neither has a bring-your-own subnet input, so leaving
-  # them set would emit a tfvars that terraform plan rejects. Reset and say so.
-  if [[ "$INGRESS_CONTROLLER" == "agic" ]]; then
-    INGRESS_CONTROLLER="nginx"
-    AGW_SKU_TIER_LINE=""
-    _red "  AGIC needs a Terraform-managed VNet — ingress controller reset to nginx."
-    echo ""
-  fi
-  if [[ "$CREATE_BASTION" == "true" ]]; then
-    CREATE_BASTION="false"
-    _red "  The bastion needs a Terraform-managed VNet — bastion disabled."
-    echo ""
-  fi
 
   echo ""
   _hint "Bring Your Own VNet — LangSmith deploys into a VNet you already own."
@@ -309,6 +323,21 @@ _run_section_3() {
   _ask "Kubernetes service CIDR" "10.0.64.0/20"
   AKS_SERVICE_CIDR="$_REPLY"
 
+  # This section can be re-run from the review menu, after AGIC or a bastion has
+  # already been chosen. Neither is carved inside a VNet Terraform does not own,
+  # so collect the subnet each one needs. On a first pass through the wizard both
+  # are still at their defaults and the prompts below ask at the point of choice.
+  if [[ "$INGRESS_CONTROLLER" == "agic" ]]; then
+    _ask_required_subnet "Application Gateway" \
+      "AGIC needs an existing subnet to itself, /24 recommended. Terraform will not create one inside a VNet you own." ""
+    AGIC_SUBNET_ID="$_REQUIRED_SUBNET_ID"
+  fi
+  if [[ "$CREATE_BASTION" == "true" ]]; then
+    _ask_required_subnet "Azure Bastion" \
+      "Azure Bastion needs an existing subnet named AzureBastionSubnet, /26 or larger." "AzureBastionSubnet"
+    BASTION_SUBNET_ID="$_REQUIRED_SUBNET_ID"
+  fi
+
   echo ""
   _hint "Any CIDR you entered must fit inside your VNet's address space, not overlap"
   _hint "an existing subnet, and not overlap the Kubernetes service CIDR above."
@@ -318,6 +347,7 @@ _run_section_3() {
 NODE_VM_SIZE="Standard_D4s_v3"
 NODE_MIN=2
 NODE_MAX=5
+NODE_MAX_PODS=60
 AKS_DELETION_PROTECTION="false"
 
 _run_section_4() {
@@ -344,6 +374,16 @@ _run_section_4() {
   NODE_MIN="$_REPLY"
   _ask_int "Node pool max count (autoscaler ceiling)" "$max_default"
   NODE_MAX="$_REPLY"
+
+  # Azure CNI draws pod IPs from the AKS subnet, so this multiplies the subnet
+  # size: the cluster needs (max_count + 1) x (max_pods + 1) addresses. It is one
+  # of the two knobs the capacity check tells operators to lower, so it needs to
+  # be reachable from here.
+  _hint "Max pods per node multiplies the AKS subnet requirement, at"
+  _hint "(max count + 1) x (max pods + 1) addresses. 60 suits most deployments;"
+  _hint "lower it if your subnet is fixed and tight."
+  _ask_int "Max pods per node" "60"
+  NODE_MAX_PODS="$_REPLY"
 
   AKS_DELETION_PROTECTION="false"
   if [[ "$PROFILE" == "prod" ]]; then
@@ -389,16 +429,12 @@ _run_section_5() {
       6) INGRESS_CONTROLLER="none" ;;
     esac
 
-    # There is no agic_subnet_id input, so the Application Gateway subnet can
-    # only be carved out of a VNet Terraform owns. Catch it here rather than
-    # letting terraform plan reject the generated tfvars.
+    # Terraform will not carve an Application Gateway subnet inside a VNet it
+    # does not own, so on that path the operator names one that already exists.
     if [[ "$INGRESS_CONTROLLER" == "agic" && "$CREATE_VNET" == "false" ]]; then
-      _red "  AGIC is not available with a bring-your-own VNet."
-      echo ""
-      _hint "Application Gateway needs a dedicated /24 subnet that Terraform can only"
-      _hint "create in a VNet it manages. Pick another controller, or re-run section 3"
-      _hint "and let Terraform create the VNet."
-      continue
+      _ask_required_subnet "Application Gateway" \
+        "AGIC needs an existing subnet to itself, /24 recommended. Terraform will not create one inside a VNet you own." ""
+      AGIC_SUBNET_ID="$_REQUIRED_SUBNET_ID"
     fi
     break
   done
@@ -419,8 +455,8 @@ _run_section_5() {
     echo ""
     _hint "AGIC provisions an Azure Application Gateway v2 with a dedicated /24 subnet."
     _hint "WAF_v2 adds OWASP 3.2 rules + bot protection — no separate WAF module needed."
-    _hint "Note: AGIC requires a full cluster rebuild to enable (AGW subnet is provisioned"
-    _hint "at VNet creation time and cannot be added to an existing VNet)."
+    _hint "Note: AGIC requires a full cluster rebuild to enable (the add-on is part of the"
+    _hint "cluster resource). With a VNet you own, supply the Application Gateway subnet."
     _ask_choice "Application Gateway SKU tier:" \
       "Standard_v2 — standard routing (no WAF)" \
       "WAF_v2      — with integrated WAF (OWASP 3.2 + bot protection)"
@@ -717,12 +753,15 @@ _run_section_10() {
     echo ""
     _hint "Bastion host    — jump VM for direct SSH to AKS nodes (private cluster debugging)."
     _hint "                  Not needed for most deployments unless nodes are on a private subnet."
-    if [[ "$CREATE_VNET" == "false" ]]; then
-      # No bastion_subnet_id input exists, so the bastion subnet can only be
-      # created in a Terraform-managed VNet.
-      _hint "                  Unavailable with a bring-your-own VNet — skipped."
-    elif _ask_yn "Create bastion host? (for node-level troubleshooting)" "n"; then
+    if _ask_yn "Create bastion host? (for node-level troubleshooting)" "n"; then
       CREATE_BASTION="true"
+      # Terraform carves the bastion subnet only out of a VNet it owns, so on the
+      # bring-your-own path the operator names an existing one.
+      if [[ "$CREATE_VNET" == "false" ]]; then
+        _ask_required_subnet "Azure Bastion" \
+          "Azure Bastion needs an existing subnet named AzureBastionSubnet, /26 or larger." "AzureBastionSubnet"
+        BASTION_SUBNET_ID="$_REQUIRED_SUBNET_ID"
+      fi
     fi
   else
     _hint "Dev profile: security add-ons skipped. Edit terraform.tfvars to enable after deploy."
@@ -766,8 +805,10 @@ while true; do
     printf "  %-24s %s\n" "   PostgreSQL subnet:" "$(_subnet_review "$POSTGRES_SUBNET_ID" "$POSTGRES_SUBNET_CIDR_LINE")"
     printf "  %-24s %s\n" "   Redis subnet:"      "$(_subnet_review "$REDIS_SUBNET_ID" "$REDIS_SUBNET_CIDR_LINE")"
     printf "  %-24s %s\n" "   Service CIDR:"      "$AKS_SERVICE_CIDR"
+    [[ -n "$AGIC_SUBNET_ID" ]]    && printf "  %-24s %s\n" "   AGIC subnet:"    "reuse   $AGIC_SUBNET_ID"
+    [[ -n "$BASTION_SUBNET_ID" ]] && printf "  %-24s %s\n" "   Bastion subnet:" "reuse   $BASTION_SUBNET_ID"
   fi
-  printf "  %-24s %s\n" "4. Node size:"       "$NODE_VM_SIZE  min=$NODE_MIN  max=$NODE_MAX"
+  printf "  %-24s %s\n" "4. Node size:"       "$NODE_VM_SIZE  min=$NODE_MIN  max=$NODE_MAX  max_pods=$NODE_MAX_PODS"
   printf "  %-24s %s\n" "5. Ingress:"         "$INGRESS_CONTROLLER"
   [[ -n "$ISTIO_ADDON_REVISION_LINE" ]] && printf "  %-24s %s\n" "   Istio revision:"  "${ISTIO_ADDON_REVISION_LINE#*= }"
   [[ -n "$AGW_SKU_TIER_LINE" ]]         && printf "  %-24s %s\n" "   AGW SKU:"         "${AGW_SKU_TIER_LINE#*= }"
@@ -861,6 +902,9 @@ TFVARS
   # Required on this path: the variable default is only safe against the VNet
   # Terraform builds, so terraform plan rejects an empty value here.
   printf '%-30s = "%s"\n' "aks_service_cidr" "$AKS_SERVICE_CIDR" >> "$OUTPUT"
+  # Also required on this path, whenever the feature that needs them is on.
+  [[ -n "$AGIC_SUBNET_ID" ]]    && printf '%-30s = "%s"\n' "agic_subnet_id" "$AGIC_SUBNET_ID" >> "$OUTPUT"
+  [[ -n "$BASTION_SUBNET_ID" ]] && printf '%-30s = "%s"\n' "bastion_subnet_id" "$BASTION_SUBNET_ID" >> "$OUTPUT"
 else
   echo "# Using auto-created VNet (default)" >> "$OUTPUT"
 fi
@@ -873,7 +917,7 @@ cat >> "$OUTPUT" << TFVARS
 default_node_pool_vm_size   = "${NODE_VM_SIZE}"
 default_node_pool_min_count = ${NODE_MIN}
 default_node_pool_max_count = ${NODE_MAX}
-default_node_pool_max_pods  = 60
+default_node_pool_max_pods  = ${NODE_MAX_PODS}
 aks_deletion_protection     = ${AKS_DELETION_PROTECTION}
 
 #------------------------------------------------------------------------------

--- a/modules/azure/infra/scripts/quickstart.sh
+++ b/modules/azure/infra/scripts/quickstart.sh
@@ -197,6 +197,7 @@ REDIS_SUBNET_ID=""
 AKS_SUBNET_CIDR_LINE=""
 POSTGRES_SUBNET_CIDR_LINE=""
 REDIS_SUBNET_CIDR_LINE=""
+AKS_SERVICE_CIDR=""
 
 # Ask for one subnet in bring-your-own-VNet mode. An empty answer means
 # "Terraform creates it", which then needs a CIDR to carve out of the VNet.
@@ -236,6 +237,7 @@ _run_section_3() {
   CREATE_VNET="true"
   VNET_ID=""; AKS_SUBNET_ID=""; POSTGRES_SUBNET_ID=""; REDIS_SUBNET_ID=""
   AKS_SUBNET_CIDR_LINE=""; POSTGRES_SUBNET_CIDR_LINE=""; REDIS_SUBNET_CIDR_LINE=""
+  AKS_SERVICE_CIDR=""
 
   if _ask_yn "Create a new VNet? (recommended)" "y"; then
     CREATE_VNET="true"
@@ -289,9 +291,19 @@ _run_section_3() {
     "Holds the Azure Managed Redis private endpoint. This subnet must NOT be delegated — a delegated subnet would reject the endpoint."
   REDIS_SUBNET_ID="$_SUBNET_ID"; REDIS_SUBNET_CIDR_LINE="$_SUBNET_CIDR_LINE"
 
+  # Kubernetes ClusterIPs are internal to the cluster, but AKS still requires the
+  # range to be unused by anything on or connected to the VNet. The default only
+  # dodges the VNet Terraform builds, so on this path the operator must name one.
+  echo ""
+  _hint "Kubernetes assigns ClusterIPs from a range that must not be used by anything"
+  _hint "in your VNet or any network peered to it. It is not carved from your VNet —"
+  _hint "pick a range that sits outside your VNet's address space entirely."
+  _ask "Kubernetes service CIDR" "10.0.64.0/20"
+  AKS_SERVICE_CIDR="$_REPLY"
+
   echo ""
   _hint "Any CIDR you entered must fit inside your VNet's address space, not overlap"
-  _hint "an existing subnet, and not overlap the Kubernetes service CIDR (10.0.64.0/20)."
+  _hint "an existing subnet, and not overlap the Kubernetes service CIDR above."
 }
 
 # -- 4. AKS ------------------------------------------------------------------
@@ -745,6 +757,7 @@ while true; do
     printf "  %-24s %s\n" "   AKS subnet:"        "$(_subnet_review "$AKS_SUBNET_ID" "$AKS_SUBNET_CIDR_LINE")"
     printf "  %-24s %s\n" "   PostgreSQL subnet:" "$(_subnet_review "$POSTGRES_SUBNET_ID" "$POSTGRES_SUBNET_CIDR_LINE")"
     printf "  %-24s %s\n" "   Redis subnet:"      "$(_subnet_review "$REDIS_SUBNET_ID" "$REDIS_SUBNET_CIDR_LINE")"
+    printf "  %-24s %s\n" "   Service CIDR:"      "$AKS_SERVICE_CIDR"
   fi
   printf "  %-24s %s\n" "4. Node size:"       "$NODE_VM_SIZE  min=$NODE_MIN  max=$NODE_MAX"
   printf "  %-24s %s\n" "5. Ingress:"         "$INGRESS_CONTROLLER"
@@ -837,6 +850,9 @@ TFVARS
   [[ -n "$AKS_SUBNET_CIDR_LINE" ]]      && echo "$AKS_SUBNET_CIDR_LINE" >> "$OUTPUT"
   [[ -n "$POSTGRES_SUBNET_CIDR_LINE" ]] && echo "$POSTGRES_SUBNET_CIDR_LINE" >> "$OUTPUT"
   [[ -n "$REDIS_SUBNET_CIDR_LINE" ]]    && echo "$REDIS_SUBNET_CIDR_LINE" >> "$OUTPUT"
+  # Required on this path: the variable default is only safe against the VNet
+  # Terraform builds, so terraform plan rejects an empty value here.
+  printf '%-30s = "%s"\n' "aks_service_cidr" "$AKS_SERVICE_CIDR" >> "$OUTPUT"
 else
   echo "# Using auto-created VNet (default)" >> "$OUTPUT"
 fi

--- a/modules/azure/infra/terraform.tfvars.example
+++ b/modules/azure/infra/terraform.tfvars.example
@@ -205,8 +205,9 @@ sizing_profile = "production"
 #
 # Or omit an ID above and set its prefix here to have Terraform carve it out.
 # These defaults are sized for the 10.0.0.0/17 VNet Terraform builds, so treat
-# them as a starting point. Each must fit inside your VNet address space, not
-# overlap an existing subnet, and not overlap aks_service_cidr.
+# them as a starting point. Plan reads your VNet and rejects a prefix outside its
+# address space, but cannot tell whether one collides with a subnet that already
+# exists there, so pick ranges you know are free.
 # aks_subnet_address_prefix      = ["10.0.0.0/19"]
 # postgres_subnet_address_prefix = ["10.0.32.0/20"]
 # redis_subnet_address_prefix    = ["10.0.48.0/20"]
@@ -215,7 +216,8 @@ sizing_profile = "production"
 # range, and AKS requires one that nothing on or connected to your VNet uses.
 # The 10.0.64.0/20 default only avoids the VNet Terraform builds, and an overlap
 # with your own space can be accepted at cluster creation and break later, so
-# pick a range outside your VNet entirely. aks_dns_service_ip is derived from it.
+# pick a range outside your VNet entirely — plan rejects one that overlaps it,
+# though peered networks are on you. aks_dns_service_ip is derived from it.
 # aks_service_cidr     = "10.100.0.0/20"
 #
 # create_bastion and ingress_controller = "agic" both need subnets that only

--- a/modules/azure/infra/terraform.tfvars.example
+++ b/modules/azure/infra/terraform.tfvars.example
@@ -203,6 +203,16 @@ sizing_profile = "production"
 # postgres_subnet_id   = "/subscriptions/.../virtualNetworks/my-vnet/subnets/postgres"
 # redis_subnet_id      = "/subscriptions/.../virtualNetworks/my-vnet/subnets/redis"
 #
+# Have Terraform add the two service endpoints to the AKS subnet above rather
+# than fail the plan when they are missing. It patches that one property and
+# leaves the rest of the subnet alone, but it needs write access on the subnet,
+# so leave this off if a network team owns it and only granted read, or if their
+# tooling sets the endpoints too. Otherwise add them yourself, repeating any
+# already there since the flag replaces the whole list:
+#   az network vnet subnet update --ids <subnet-id> \
+#     --service-endpoints Microsoft.Storage Microsoft.KeyVault
+# manage_byo_subnet_service_endpoints = true
+#
 # Or omit an ID above and set its prefix here to have Terraform carve it out.
 # These defaults are sized for the 10.0.0.0/17 VNet Terraform builds, so treat
 # them as a starting point. Plan reads your VNet and rejects a prefix outside its

--- a/modules/azure/infra/terraform.tfvars.example
+++ b/modules/azure/infra/terraform.tfvars.example
@@ -190,7 +190,11 @@ sizing_profile = "production"
 #
 # Reuse subnets you already have. Each must be a subnet of vnet_id above.
 # An existing Postgres subnet must already carry the flexibleServers delegation
-# and hold nothing else — Terraform checks this at plan time.
+# and hold nothing else. An existing AKS subnet must carry both the
+# Microsoft.Storage and Microsoft.KeyVault service endpoints, since the storage
+# and Key Vault firewalls allowlist it by ID and Azure rejects a subnet rule
+# without the matching endpoint. Terraform checks both at plan time, which means
+# plan needs read access to whichever subnets you supply here.
 # aks_subnet_id        = "/subscriptions/.../virtualNetworks/my-vnet/subnets/aks"
 # postgres_subnet_id   = "/subscriptions/.../virtualNetworks/my-vnet/subnets/postgres"
 # redis_subnet_id      = "/subscriptions/.../virtualNetworks/my-vnet/subnets/redis"

--- a/modules/azure/infra/terraform.tfvars.example
+++ b/modules/azure/infra/terraform.tfvars.example
@@ -188,23 +188,35 @@ sizing_profile = "production"
 # create_vnet          = false
 # vnet_id              = "/subscriptions/.../resourceGroups/net-rg/providers/Microsoft.Network/virtualNetworks/my-vnet"
 #
-# Reuse subnets you already have. Each must be a subnet of vnet_id above.
+# Reuse subnets you already have. Give three different subnets — sharing one
+# fails during apply, since the Postgres subnet is delegated and Azure allows no
+# other resource type inside a delegated subnet.
 # An existing Postgres subnet must already carry the flexibleServers delegation
 # and hold nothing else. An existing AKS subnet must carry both the
 # Microsoft.Storage and Microsoft.KeyVault service endpoints, since the storage
 # and Key Vault firewalls allowlist it by ID and Azure rejects a subnet rule
-# without the matching endpoint. Terraform checks both at plan time, which means
-# plan needs read access to whichever subnets you supply here.
+# without the matching endpoint. It must also be big enough for the node pools
+# below: Azure CNI draws node and pod IPs from it, 764 addresses at the
+# defaults, so a /22 or larger. Terraform checks all of this at plan time, which
+# means plan needs read access to whichever subnets you supply here.
 # aks_subnet_id        = "/subscriptions/.../virtualNetworks/my-vnet/subnets/aks"
 # postgres_subnet_id   = "/subscriptions/.../virtualNetworks/my-vnet/subnets/postgres"
 # redis_subnet_id      = "/subscriptions/.../virtualNetworks/my-vnet/subnets/redis"
 #
 # Or omit an ID above and set its prefix here to have Terraform carve it out.
-# Each must fit inside the VNet address space, not overlap an existing subnet,
-# and not overlap aks_service_cidr (default 10.0.64.0/20).
+# These defaults are sized for the 10.0.0.0/17 VNet Terraform builds, so treat
+# them as a starting point. Each must fit inside your VNet address space, not
+# overlap an existing subnet, and not overlap aks_service_cidr.
 # aks_subnet_address_prefix      = ["10.0.0.0/19"]
 # postgres_subnet_address_prefix = ["10.0.32.0/20"]
 # redis_subnet_address_prefix    = ["10.0.48.0/20"]
+#
+# Required when create_vnet = false. Kubernetes assigns ClusterIPs from this
+# range, and AKS requires one that nothing on or connected to your VNet uses.
+# The 10.0.64.0/20 default only avoids the VNet Terraform builds, and an overlap
+# with your own space can be accepted at cluster creation and break later, so
+# pick a range outside your VNet entirely. aks_dns_service_ip is derived from it.
+# aks_service_cidr     = "10.100.0.0/20"
 #
 # create_bastion and ingress_controller = "agic" both need subnets that only
 # exist on the create_vnet = true path, so they cannot be combined with the

--- a/modules/azure/infra/terraform.tfvars.example
+++ b/modules/azure/infra/terraform.tfvars.example
@@ -220,9 +220,12 @@ sizing_profile = "production"
 # though peered networks are on you. aks_dns_service_ip is derived from it.
 # aks_service_cidr     = "10.100.0.0/20"
 #
-# create_bastion and ingress_controller = "agic" both need subnets that only
-# exist on the create_vnet = true path, so they cannot be combined with the
-# above. Terraform rejects that combination at plan time.
+# create_bastion and ingress_controller = "agic" each need a subnet to
+# themselves. Terraform carves those only out of a VNet it owns, so on this path
+# you supply them; there is no prefix to carve from. Plan rejects either feature
+# with create_vnet = false and no subnet named here.
+# agic_subnet_id    = "/subscriptions/.../virtualNetworks/my-vnet/subnets/appgw"
+# bastion_subnet_id = "/subscriptions/.../virtualNetworks/my-vnet/subnets/AzureBastionSubnet"
 
 # ── Network hardening (production) ────────────────────────────────────────────
 # Storage / Key Vault / AKS default-deny firewalls. AKS pods are allowlisted

--- a/modules/azure/infra/terraform.tfvars.example
+++ b/modules/azure/infra/terraform.tfvars.example
@@ -176,11 +176,35 @@ sizing_profile = "production"
 # postgres_geo_redundant_backup        = true             # geo-redundant backups
 
 # ── Networking (optional — override only if reusing existing VNet) ─────────────
+# Set create_vnet = false and give the VNet you want LangSmith to deploy into.
+# Each subnet is then independent: supply an ID to reuse a subnet you already
+# have, or leave it out and Terraform creates that subnet inside your VNet from
+# the matching address prefix. Terraform applies the settings each service
+# needs — the Postgres subnet gets the Microsoft.DBforPostgreSQL/flexibleServers
+# delegation, the AKS subnet gets the Storage and Key Vault service endpoints,
+# and the Redis subnet gets no delegation (it holds a private endpoint, and a
+# delegated subnet would reject it).
+#
 # create_vnet          = false
-# vnet_id              = "/subscriptions/.../virtualNetworks/my-vnet"
-# aks_subnet_id        = "/subscriptions/.../subnets/aks"
-# postgres_subnet_id   = "/subscriptions/.../subnets/postgres"
-# redis_subnet_id      = "/subscriptions/.../subnets/redis"
+# vnet_id              = "/subscriptions/.../resourceGroups/net-rg/providers/Microsoft.Network/virtualNetworks/my-vnet"
+#
+# Reuse subnets you already have. Each must be a subnet of vnet_id above.
+# An existing Postgres subnet must already carry the flexibleServers delegation
+# and hold nothing else — Terraform checks this at plan time.
+# aks_subnet_id        = "/subscriptions/.../virtualNetworks/my-vnet/subnets/aks"
+# postgres_subnet_id   = "/subscriptions/.../virtualNetworks/my-vnet/subnets/postgres"
+# redis_subnet_id      = "/subscriptions/.../virtualNetworks/my-vnet/subnets/redis"
+#
+# Or omit an ID above and set its prefix here to have Terraform carve it out.
+# Each must fit inside the VNet address space, not overlap an existing subnet,
+# and not overlap aks_service_cidr (default 10.0.64.0/20).
+# aks_subnet_address_prefix      = ["10.0.0.0/19"]
+# postgres_subnet_address_prefix = ["10.0.32.0/20"]
+# redis_subnet_address_prefix    = ["10.0.48.0/20"]
+#
+# create_bastion and ingress_controller = "agic" both need subnets that only
+# exist on the create_vnet = true path, so they cannot be combined with the
+# above. Terraform rejects that combination at plan time.
 
 # ── Network hardening (production) ────────────────────────────────────────────
 # Storage / Key Vault / AKS default-deny firewalls. AKS pods are allowlisted

--- a/modules/azure/infra/variables.tf
+++ b/modules/azure/infra/variables.tf
@@ -148,7 +148,7 @@ variable "redis_subnet_id" {
 
 variable "aks_subnet_address_prefix" {
   type        = list(string)
-  description = "Prefix for the AKS subnet, used when Terraform creates it. Azure CNI puts node and pod IPs in this range, so it needs (max_count + 1) * (max_pods + 1) addresses per node pool, which is 764 at the default sizing. Terraform checks this at plan time, because an undersized subnet applies cleanly and then stalls the autoscaler. Must also fit inside the VNet address space and not overlap aks_service_cidr."
+  description = "Prefix for the AKS subnet, used when Terraform creates it. Azure CNI puts node and pod IPs in this range, so it needs (max_count + 1) * (max_pods + 1) addresses per node pool, which is 764 at the default sizing. Terraform checks this at plan time, because an undersized subnet applies cleanly and then stalls the autoscaler. The default is sized for the VNet Terraform builds; under create_vnet = false it must fall inside your VNet's address space, which plan also checks."
   default     = ["10.0.0.0/19"] # 8k IP addresses
 }
 
@@ -193,13 +193,13 @@ variable "clickhouse_source" {
 
 variable "redis_subnet_address_prefix" {
   type        = list(string)
-  description = "Prefix for the Redis subnet. Can be disjoint IP ranges."
+  description = "Prefix for the Redis subnet. Can be disjoint IP ranges. Under create_vnet = false it must fall inside your VNet's address space, which plan checks."
   default     = ["10.0.48.0/20"] # 4k IP addresses
 }
 
 variable "postgres_subnet_address_prefix" {
   type        = list(string)
-  description = "Prefix for the Postgres subnet. Can be disjoint IP ranges."
+  description = "Prefix for the Postgres subnet. Can be disjoint IP ranges. Under create_vnet = false it must fall inside your VNet's address space, which plan checks."
   default     = ["10.0.32.0/20"] # 4k IP addresses
 }
 
@@ -279,7 +279,7 @@ variable "default_node_pool_max_pods" {
 # bring-your-own, where the operator's address space is unknown here.
 variable "aks_service_cidr" {
   type        = string
-  description = "Kubernetes ClusterIP range for the AKS cluster. Defaults to 10.0.64.0/20, which is chosen to sit outside the Terraform-managed 10.0.0.0/17 VNet. Required when create_vnet = false: AKS needs a range that nothing on or connected to your VNet uses, and an overlap can be accepted at create time and break later."
+  description = "Kubernetes ClusterIP range for the AKS cluster. Defaults to 10.0.64.0/20, which is chosen to sit outside the Terraform-managed 10.0.0.0/17 VNet. Required when create_vnet = false: AKS needs a range that nothing on or connected to your VNet uses, and an overlap can be accepted at create time and break later. Plan rejects a range that overlaps your VNet's address space, but cannot see peered or on-premises networks."
   default     = ""
 }
 

--- a/modules/azure/infra/variables.tf
+++ b/modules/azure/infra/variables.tf
@@ -146,6 +146,28 @@ variable "redis_subnet_id" {
   }
 }
 
+variable "agic_subnet_id" {
+  type        = string
+  description = "The id of an existing subnet for the Application Gateway, required when ingress_controller = \"agic\" and create_vnet = false. Unlike the three above there is no carve path: Terraform will not create an Application Gateway subnet inside a VNet it does not own. Application Gateway v2 needs the subnet to itself, and Azure recommends a /24."
+  default     = ""
+
+  validation {
+    condition     = var.agic_subnet_id == "" || can(regex("(?i)^/subscriptions/[^/]+/resourceGroups/[^/]+/providers/Microsoft\\.Network/virtualNetworks/[^/]+/subnets/[^/]+$", var.agic_subnet_id))
+    error_message = "agic_subnet_id must be a full subnet resource ID: /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Network/virtualNetworks/<vnet>/subnets/<name>"
+  }
+}
+
+variable "bastion_subnet_id" {
+  type        = string
+  description = "The id of an existing subnet for Azure Bastion, required when create_bastion = true and create_vnet = false. Azure requires the subnet be named exactly AzureBastionSubnet and be /26 or larger; Terraform checks the name at plan time. There is no carve path, for the same reason as agic_subnet_id."
+  default     = ""
+
+  validation {
+    condition     = var.bastion_subnet_id == "" || can(regex("(?i)^/subscriptions/[^/]+/resourceGroups/[^/]+/providers/Microsoft\\.Network/virtualNetworks/[^/]+/subnets/[^/]+$", var.bastion_subnet_id))
+    error_message = "bastion_subnet_id must be a full subnet resource ID: /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Network/virtualNetworks/<vnet>/subnets/<name>"
+  }
+}
+
 variable "aks_subnet_address_prefix" {
   type        = list(string)
   description = "Prefix for the AKS subnet, used when Terraform creates it. Azure CNI puts node and pod IPs in this range, so it needs (max_count + 1) * (max_pods + 1) addresses per node pool, which is 764 at the default sizing. Terraform checks this at plan time, because an undersized subnet applies cleanly and then stalls the autoscaler. The default is sized for the VNet Terraform builds; under create_vnet = false it must fall inside your VNet's address space, which plan also checks."

--- a/modules/azure/infra/variables.tf
+++ b/modules/azure/infra/variables.tf
@@ -89,32 +89,63 @@ variable "subscription_id" {
 
 variable "create_vnet" {
   type        = bool
-  description = "Whether to create a new VNet. If false, you will need to provide a vnet id and subnet ids."
+  description = "Whether to create a new VNet. If false, vnet_id is required and each subnet is either supplied via its *_subnet_id variable or carved out of that VNet by Terraform."
   default     = true
 }
 
 variable "vnet_id" {
   type        = string
-  description = "The id of the existing VNet to use. If create_vnet is false, this is required."
+  description = "The id of the existing VNet to use. Required when create_vnet is false. Any subnet Terraform creates is placed in this VNet's resource group."
   default     = ""
+
+  validation {
+    condition     = var.vnet_id == "" || can(regex("^/subscriptions/[^/]+/resourceGroups/[^/]+/providers/Microsoft\\.Network/virtualNetworks/[^/]+$", var.vnet_id))
+    error_message = "vnet_id must be a full VNet resource ID: /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Network/virtualNetworks/<name>"
+  }
 }
+
+# ── Bring-your-own subnets (optional, only when create_vnet = false) ──────────
+# Each subnet is independent. Supply an ID to reuse an existing subnet; leave it
+# empty and Terraform creates that subnet inside vnet_id using the matching
+# *_subnet_address_prefix, with the correct delegation applied.
 
 variable "aks_subnet_id" {
   type        = string
-  description = "The id of the existing subnet to use for the AKS cluster. If create_vnet is false, this is required."
+  description = "The id of an existing subnet to use for the AKS cluster. Leave empty to have Terraform create one in vnet_id using aks_subnet_address_prefix. Must have the Microsoft.Storage and Microsoft.KeyVault service endpoints if you enable the storage or Key Vault default-deny firewalls."
   default     = ""
+
+  validation {
+    condition     = var.aks_subnet_id == "" || can(regex("/providers/Microsoft\\.Network/virtualNetworks/[^/]+/subnets/[^/]+$", var.aks_subnet_id))
+    error_message = "aks_subnet_id must be a full subnet resource ID ending in /virtualNetworks/<name>/subnets/<name>"
+  }
 }
 
 variable "postgres_subnet_id" {
   type        = string
-  description = "The id of the existing subnet to use for the Postgres server. If create_vnet is false, this is required."
+  description = "The id of an existing subnet to use for the Postgres server. Leave empty to have Terraform create one in vnet_id using postgres_subnet_address_prefix. An existing subnet must already be delegated to Microsoft.DBforPostgreSQL/flexibleServers and hold no other resources."
   default     = ""
+
+  validation {
+    condition     = var.postgres_subnet_id == "" || can(regex("/providers/Microsoft\\.Network/virtualNetworks/[^/]+/subnets/[^/]+$", var.postgres_subnet_id))
+    error_message = "postgres_subnet_id must be a full subnet resource ID ending in /virtualNetworks/<name>/subnets/<name>"
+  }
 }
 
 variable "redis_subnet_id" {
   type        = string
-  description = "The id of the existing subnet to use for the Redis server. If create_vnet is false, this is required."
+  description = "The id of an existing subnet to use for the Redis private endpoint. Leave empty to have Terraform create one in vnet_id using redis_subnet_address_prefix. This subnet must NOT be delegated — Azure Managed Redis is reached through a private endpoint, and a delegated subnet would reject it."
   default     = ""
+
+  validation {
+    condition     = var.redis_subnet_id == "" || can(regex("/providers/Microsoft\\.Network/virtualNetworks/[^/]+/subnets/[^/]+$", var.redis_subnet_id))
+    error_message = "redis_subnet_id must be a full subnet resource ID ending in /virtualNetworks/<name>/subnets/<name>"
+  }
+}
+
+variable "aks_subnet_address_prefix" {
+  type        = list(string)
+  description = "Prefix for the AKS subnet, used when Terraform creates it. Azure CNI puts node and pod IPs in this range, so size it for max_nodes * max_pods_per_node. Must fit inside the VNet address space and not overlap aks_service_cidr."
+  default     = ["10.0.0.0/19"] # 8k IP addresses
 }
 
 variable "postgres_database_name" {
@@ -286,7 +317,7 @@ variable "langsmith_namespace" {
 
 variable "ingress_controller" {
   type        = string
-  description = "Ingress controller to install. 'nginx' = NGINX via Helm. 'istio' = Istio via Helm (self-managed). 'istio-addon' = Azure managed Istio (AKS service mesh add-on, recommended on Azure). 'agic' = Application Gateway Ingress Controller. 'envoy-gateway' = Envoy Gateway via Helm (Gateway API). 'none' = skip."
+  description = "Ingress controller to install. 'nginx' = NGINX via Helm, the current default and the only option with every TLS path validated. 'istio' = Istio via Helm (self-managed). 'istio-addon' = Azure managed Istio (AKS service mesh add-on); use for mTLS or multi-dataplane. 'agic' = Application Gateway Ingress Controller. 'envoy-gateway' = Envoy Gateway via Helm (Gateway API). 'none' = skip. See INGRESS_CONTROLLERS.md for the TLS compatibility matrix."
   default     = "nginx"
 
   validation {

--- a/modules/azure/infra/variables.tf
+++ b/modules/azure/infra/variables.tf
@@ -115,7 +115,7 @@ variable "vnet_id" {
 
 variable "aks_subnet_id" {
   type        = string
-  description = "The id of an existing subnet to use for the AKS cluster. Leave empty to have Terraform create one in vnet_id using aks_subnet_address_prefix. An existing subnet must carry the Microsoft.Storage and Microsoft.KeyVault service endpoints: the blob storage firewall is always default-deny and allowlists this subnet by ID, and Azure rejects a subnet rule when the matching endpoint is absent. Terraform checks this at plan time."
+  description = "The id of an existing subnet to use for the AKS cluster. Leave empty to have Terraform create one in vnet_id using aks_subnet_address_prefix. An existing subnet must carry the Microsoft.Storage and Microsoft.KeyVault service endpoints: the blob storage firewall is always default-deny and allowlists this subnet by ID, and Azure rejects a subnet rule when the matching endpoint is absent. Terraform checks this at plan time, or adds them itself when manage_byo_subnet_service_endpoints is set."
   default     = ""
 
   validation {
@@ -166,6 +166,12 @@ variable "bastion_subnet_id" {
     condition     = var.bastion_subnet_id == "" || can(regex("(?i)^/subscriptions/[^/]+/resourceGroups/[^/]+/providers/Microsoft\\.Network/virtualNetworks/[^/]+/subnets/[^/]+$", var.bastion_subnet_id))
     error_message = "bastion_subnet_id must be a full subnet resource ID: /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Network/virtualNetworks/<vnet>/subnets/<name>"
   }
+}
+
+variable "manage_byo_subnet_service_endpoints" {
+  type        = bool
+  description = "Add the Microsoft.Storage and Microsoft.KeyVault service endpoints to the subnet given as aks_subnet_id, instead of failing the plan when they are missing. Terraform patches only that one property and leaves the rest of the subnet — address prefixes, delegations, NSG and route table associations — to whoever owns it. Needs Microsoft.Network/virtualNetworks/subnets/write on the subnet, so leave this false when it belongs to a network team that only granted read, or when their own tooling manages its endpoints and both would rewrite the property on every run."
+  default     = false
 }
 
 variable "aks_subnet_address_prefix" {

--- a/modules/azure/infra/variables.tf
+++ b/modules/azure/infra/variables.tf
@@ -99,7 +99,7 @@ variable "vnet_id" {
   default     = ""
 
   validation {
-    condition     = var.vnet_id == "" || can(regex("^/subscriptions/[^/]+/resourceGroups/[^/]+/providers/Microsoft\\.Network/virtualNetworks/[^/]+$", var.vnet_id))
+    condition     = var.vnet_id == "" || can(regex("(?i)^/subscriptions/[^/]+/resourceGroups/[^/]+/providers/Microsoft\\.Network/virtualNetworks/[^/]+$", var.vnet_id))
     error_message = "vnet_id must be a full VNet resource ID: /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Network/virtualNetworks/<name>"
   }
 }
@@ -108,26 +108,30 @@ variable "vnet_id" {
 # Each subnet is independent. Supply an ID to reuse an existing subnet; leave it
 # empty and Terraform creates that subnet inside vnet_id using the matching
 # *_subnet_address_prefix, with the correct delegation applied.
+#
+# The IDs are matched against the full 11-segment shape, case-insensitively.
+# Anchoring both ends is what lets main.tf index the segments positionally to
+# locate a supplied subnet, and Azure treats resource IDs as case-insensitive.
 
 variable "aks_subnet_id" {
   type        = string
-  description = "The id of an existing subnet to use for the AKS cluster. Leave empty to have Terraform create one in vnet_id using aks_subnet_address_prefix. Must have the Microsoft.Storage and Microsoft.KeyVault service endpoints if you enable the storage or Key Vault default-deny firewalls."
+  description = "The id of an existing subnet to use for the AKS cluster. Leave empty to have Terraform create one in vnet_id using aks_subnet_address_prefix. An existing subnet must carry the Microsoft.Storage and Microsoft.KeyVault service endpoints: the blob storage firewall is always default-deny and allowlists this subnet by ID, and Azure rejects a subnet rule when the matching endpoint is absent. Terraform checks this at plan time."
   default     = ""
 
   validation {
-    condition     = var.aks_subnet_id == "" || can(regex("/providers/Microsoft\\.Network/virtualNetworks/[^/]+/subnets/[^/]+$", var.aks_subnet_id))
-    error_message = "aks_subnet_id must be a full subnet resource ID ending in /virtualNetworks/<name>/subnets/<name>"
+    condition     = var.aks_subnet_id == "" || can(regex("(?i)^/subscriptions/[^/]+/resourceGroups/[^/]+/providers/Microsoft\\.Network/virtualNetworks/[^/]+/subnets/[^/]+$", var.aks_subnet_id))
+    error_message = "aks_subnet_id must be a full subnet resource ID: /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Network/virtualNetworks/<vnet>/subnets/<name>"
   }
 }
 
 variable "postgres_subnet_id" {
   type        = string
-  description = "The id of an existing subnet to use for the Postgres server. Leave empty to have Terraform create one in vnet_id using postgres_subnet_address_prefix. An existing subnet must already be delegated to Microsoft.DBforPostgreSQL/flexibleServers and hold no other resources."
+  description = "The id of an existing subnet to use for the Postgres server. Leave empty to have Terraform create one in vnet_id using postgres_subnet_address_prefix. An existing subnet must already be delegated to Microsoft.DBforPostgreSQL/flexibleServers and hold no other resources. Terraform checks the delegation at plan time."
   default     = ""
 
   validation {
-    condition     = var.postgres_subnet_id == "" || can(regex("/providers/Microsoft\\.Network/virtualNetworks/[^/]+/subnets/[^/]+$", var.postgres_subnet_id))
-    error_message = "postgres_subnet_id must be a full subnet resource ID ending in /virtualNetworks/<name>/subnets/<name>"
+    condition     = var.postgres_subnet_id == "" || can(regex("(?i)^/subscriptions/[^/]+/resourceGroups/[^/]+/providers/Microsoft\\.Network/virtualNetworks/[^/]+/subnets/[^/]+$", var.postgres_subnet_id))
+    error_message = "postgres_subnet_id must be a full subnet resource ID: /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Network/virtualNetworks/<vnet>/subnets/<name>"
   }
 }
 
@@ -137,8 +141,8 @@ variable "redis_subnet_id" {
   default     = ""
 
   validation {
-    condition     = var.redis_subnet_id == "" || can(regex("/providers/Microsoft\\.Network/virtualNetworks/[^/]+/subnets/[^/]+$", var.redis_subnet_id))
-    error_message = "redis_subnet_id must be a full subnet resource ID ending in /virtualNetworks/<name>/subnets/<name>"
+    condition     = var.redis_subnet_id == "" || can(regex("(?i)^/subscriptions/[^/]+/resourceGroups/[^/]+/providers/Microsoft\\.Network/virtualNetworks/[^/]+/subnets/[^/]+$", var.redis_subnet_id))
+    error_message = "redis_subnet_id must be a full subnet resource ID: /subscriptions/<sub>/resourceGroups/<rg>/providers/Microsoft.Network/virtualNetworks/<vnet>/subnets/<name>"
   }
 }
 

--- a/modules/azure/infra/variables.tf
+++ b/modules/azure/infra/variables.tf
@@ -148,7 +148,7 @@ variable "redis_subnet_id" {
 
 variable "aks_subnet_address_prefix" {
   type        = list(string)
-  description = "Prefix for the AKS subnet, used when Terraform creates it. Azure CNI puts node and pod IPs in this range, so size it for max_nodes * max_pods_per_node. Must fit inside the VNet address space and not overlap aks_service_cidr."
+  description = "Prefix for the AKS subnet, used when Terraform creates it. Azure CNI puts node and pod IPs in this range, so it needs (max_count + 1) * (max_pods + 1) addresses per node pool, which is 764 at the default sizing. Terraform checks this at plan time, because an undersized subnet applies cleanly and then stalls the autoscaler. Must also fit inside the VNet address space and not overlap aks_service_cidr."
   default     = ["10.0.0.0/19"] # 8k IP addresses
 }
 
@@ -273,16 +273,20 @@ variable "default_node_pool_max_pods" {
   default     = 60
 }
 
+# Both of these are empty by default rather than carrying the create-path value,
+# because 10.0.64.0/20 is only safe against the VNet Terraform builds. main.tf
+# fills them in for create_vnet = true and requires aks_service_cidr under
+# bring-your-own, where the operator's address space is unknown here.
 variable "aks_service_cidr" {
   type        = string
-  description = "The service CIDR of the AKS cluster"
-  default     = "10.0.64.0/20"
+  description = "Kubernetes ClusterIP range for the AKS cluster. Defaults to 10.0.64.0/20, which is chosen to sit outside the Terraform-managed 10.0.0.0/17 VNet. Required when create_vnet = false: AKS needs a range that nothing on or connected to your VNet uses, and an overlap can be accepted at create time and break later."
+  default     = ""
 }
 
 variable "aks_dns_service_ip" {
   type        = string
-  description = "The DNS service IP of the AKS cluster"
-  default     = "10.0.64.10"
+  description = "CoreDNS ClusterIP. Must sit inside aks_service_cidr. Defaults to the eleventh address of aks_service_cidr, which is the Azure convention (10.0.64.10 for the default range)."
+  default     = ""
 }
 
 variable "additional_node_pools" {


### PR DESCRIPTION
`create_vnet = false` used to force the operator to supply all of `vnet_id`, `aks_subnet_id`, `postgres_subnet_id`, and `redis_subnet_id`. A network team that owns the VNet but not every subnet inside it had no way in.

Each subnet is now independent. Supply an ID to reuse a subnet you already have, or leave it blank and Terraform creates that subnet inside `vnet_id` from the matching address prefix. Created subnets land in the existing VNet's resource group, parsed out of `vnet_id`, and carry the same configuration as the create path:

| Subnet | What Terraform applies |
| --- | --- |
| AKS | `Microsoft.Storage` and `Microsoft.KeyVault` service endpoints |
| Postgres | `Microsoft.DBforPostgreSQL/flexibleServers` delegation |
| Redis | No delegation. It holds the Azure Managed Redis private endpoint, and a delegated subnet rejects one. |

## Pre-existing bug this fixes

`module "vnet"` had no `count`, so `create_vnet = false` still built and billed an orphan `10.0.0.0/17` VNet whose address space could collide with the operator's. The bastion read `module.vnet.subnet_bastion_id` directly, so it landed in that orphan VNet, disconnected from the cluster it exists to reach. Every resource in the networking module is now individually conditional, and with all flags false the module creates nothing.

## Plan-time checks

Thirteen preconditions replace opaque Azure API errors:

1. `vnet_id` is required when `create_vnet = false`, and must match the VNet ID shape
2. Subnet IDs are rejected when `create_vnet = true`, where Terraform owns the subnets
3. Every supplied subnet must belong to `vnet_id`, compared case-insensitively
4. The supplied subnet IDs must be three different subnets
5. A supplied Postgres subnet must carry the `flexibleServers` delegation, read through `azapi` because the `azurerm_subnet` data source does not expose delegations
6. A supplied AKS subnet must carry both service endpoints
7. The AKS subnet must hold enough addresses for the configured node pools
8. Every prefix Terraform is about to carve must sit inside the VNet's address space
9. `aks_service_cidr` must be set when `create_vnet = false`
10. `aks_service_cidr` must not overlap the VNet's address space
11. `create_bastion` under BYO requires `bastion_subnet_id`
12. A supplied bastion subnet must be named `AzureBastionSubnet`
13. `ingress_controller = "agic"` under BYO requires `agic_subnet_id`

Checks 5, 6, and 7 read a supplied subnet during plan, and 8 and 10 read the VNet, so whoever runs `terraform plan` needs read access to both. Carving a subnet needs `Microsoft.Network/virtualNetworks/subnets/write` on the VNet as well, which is the larger ask and fails at apply rather than at plan. All of it usually sits in the network team's resource group rather than the LangSmith one, so the README says so next to the checks.

## Three requirements that were silent

**Subnet capacity.** `network_plugin = "azure"` with no overlay mode is a flat network, so nodes and pods both draw IPs from the AKS subnet. Azure's formula is `(nodes + surge) + ((nodes + surge) * max_pods)`, which is 764 addresses at the default pool sizing and needs a `/22` or larger. Undersizing is the one network mistake that survives apply: the cluster starts, and the autoscaler stalls short of `max_count` later, once the subnet runs dry. Check 7 measures whichever prefixes the subnet ends up with, so it covers a subnet you supplied and one Terraform carves from `aks_subnet_address_prefix` equally.

**Service CIDR.** `10.0.64.0/20` was chosen to sit outside the Terraform-managed `10.0.0.0/17`. In someone else's VNet it can land inside their address space, and AKS requires a ClusterIP range that nothing on or connected to the VNet uses, so an overlap can be accepted at cluster creation and break later. `aks_service_cidr` is now required under BYO. The create-path default moved from the variable into a local, so that path is unchanged, and `aks_dns_service_ip` is derived as the eleventh address of whichever range is in play rather than sitting at a fixed `10.0.64.10` outside a supplied range.

**Address space.** The prefixes Terraform carves inside a reused VNet were never checked against that VNet. The defaults describe the `10.0.0.0/17` network Terraform builds, so an operator on a different address space who leaves a subnet ID out gets prefixes Azure rejects partway through apply, once the resource group and Key Vault already exist. Plan now reads the VNet and names both the offending range and the variable that set it. Terraform has no CIDR containment function, so every range reduces to numeric bounds and compares.

That read is also what makes check 10 possible: requiring `aks_service_cidr` does not make it right, and a range picked out of the VNet's own space is the mistake the requirement exists to prevent. Neither check sees peered or on-premises ranges, and neither can tell whether a prefix collides with a subnet that already exists, because a VNet read returns subnet names rather than their ranges. Both limits are in the README.

Azure's `/28` floor on a delegated subnet stays documented rather than checked, since Azure enforces it when the delegation is added, so any subnet passing check 5 already clears it.

## AGIC and the bastion get subnet inputs

Both were rejected outright under BYO, and the error messages said why: neither had a subnet input. That was a plumbing gap rather than an Azure limitation. `agic_subnet_id` and `bastion_subnet_id` now exist, matching the shape and `(?i)` validation of the other three, and both preconditions accept either a Terraform-managed VNet or a supplied ID.

They are supply-only: there is no carve path inside a VNet Terraform does not own, so `enable_agic` and `enable_bastion` on the networking module are gated on `create_vnet`. Both new IDs run through the same belongs-to-`vnet_id`, distinctness, and rejected-on-the-create-path checks as the other three, through one shared list — two inputs that skipped every check would be worse than no inputs. A supplied bastion subnet is checked for the name `AzureBastionSubnet`, which Azure requires and a well-formed resource ID does not imply. Azure's `/26` floor stays documented rather than checked, since reading it costs another data source.

## The capacity error now shows its arithmetic

It used to state a total and name two variables to lower, with neither the working behind it nor a subnet size that would do. It now carries a row per node pool summing to the total, the smallest prefix that holds the requirement plus Azure's five reserved addresses, and what each knob is worth:

```
The AKS subnet holds 251 usable addresses, short of the 764 that Azure CNI needs
for the configured node pools. Nodes and pods both draw IPs from this subnet, at
(max_count + 1) nodes x (max_pods + 1) addresses per pool:

  default:         11 x  61 =   671
  large:            3 x  31 =    93

Undersized, the cluster still starts and the autoscaler stalls short of max_count
later, once the subnet runs dry. Widen the subnet to a /22 or larger, the smallest
prefix that holds 764 plus the 5 addresses Azure reserves. Or lower the default
pool: one off default_node_pool_max_count frees 61 addresses, and one off
default_node_pool_max_pods frees 11.
```

The prefix is computed, so a smaller cluster is told `/25` rather than the `/22` the old message hardcoded. The total is unchanged and now comes from a per-pool map, so the number and the explanation are built in one place. Terraform's diagnostic renderer preserves explicit newlines and indentation and reflows only long prose lines, which is what lets the breakdown render as a table; checked against a failing plan rather than assumed.

The wizard prompts for max pods per node, which was pinned at 60 with nothing behind it despite being one of the two knobs the message tells operators to lower.

## Fixes from a stacked review

Reviewing this branch alongside the other open Azure PRs turned up two mistakes in its own code:

- The quickstart wizard matched a pasted VNet ID case-sensitively while the matching variable validation is `(?i)`, so it rejected the `resourcegroups` spelling Azure hands back in some contexts before Terraform ever saw it. bash 3.2 has no `${var,,}`, so the comparison lowercases a copy.
- The networking outputs header claimed every output is null when the resource was not created. `subnet_bastion_id` and `subnet_agic_id` return an empty string, and have to: `k8s-cluster` gates AGIC on `agic_subnet_id != ""`, which a null passes, and the `split` that follows would then fail. The comment was what was wrong, and now says not to switch them for consistency.

## Why the AKS service endpoints are required unconditionally

The storage module hardcodes `default_action = "Deny"`, and both the storage and Key Vault modules receive `[local.aks_subnet_id]` in `virtual_network_subnet_ids` with no flag to turn it off. ARM carries `ignoreMissingVnetServiceEndpoint` on the Key Vault virtual network rule, but `azurerm`'s `network_acls` block does not expose it, so a subnet missing an endpoint breaks pod access to blobs and secrets no matter what `keyvault_default_action` is set to.

## Other changes

- The quickstart wizard asks per subnet and for the service CIDR, validates the VNet ID against the same shape the variable does, warns that the subnet CIDRs it offers as defaults describe the VNet Terraform builds rather than the operator's, blocks the AGIC and bastion combinations plan would reject, and prints reuse-versus-create per subnet on the review screen so a mistyped ID shows up before anything runs.
- The networking submodule renames `enable_external_postgres` and `enable_external_redis` to `create_postgres_subnet` and `create_redis_subnet`, where the meaning changed from "is this service external" to "should I create this subnet". Both are internal to the module; no root variable changed name.
- Drops the stale "recommended on Azure" claim from `istio-addon`, which contradicted the rest of the docs, all of which say nginx.

## Verification

`terraform validate` passes and `terraform fmt -recursive -check` is clean. The wizard passes `bash -n` under bash 3.2 and `shellcheck -S warning -x`, and a full bring-your-own run with mixed subnets exits 0 and writes the expected tfvars.

A throwaway `terraform test` suite over the new locals, precondition conditions, and variable validations passes 63 cases. Among them: mixed-case IDs, an ID with junk ahead of `/subscriptions`, the positional split that locates a supplied subnet, a casing-only collision between two supplied IDs, the derived DNS service IP, a `/24` rejected against a `/22` accepted, disjoint prefixes summing to a passing total, a smaller cluster fitting a smaller subnet, and a supplied subnet being measured rather than the unused prefix variable.

The containment cases pin the dotted-quad conversion to hand-computed integers, then cover a prefix equal to the whole address space, one a bit too wide, one in a VNet's second address prefix, one straddling two adjacent prefixes (which Azure will not carve), a supplied subnet's unused prefix variable staying out of the check, an in-cluster service carving nothing, adjacency in both directions for the overlap comparison, and the `10.0.64.0/20` service CIDR default caught inside a corporate `10.0.0.0/8`. The create-path case asserts that all three prefixes *are* uncontained against an empty address space and the precondition still passes, so it cannot pass for the wrong reason.

The AGIC and bastion cases cover each feature rejected under BYO without its subnet and accepted with it, both still passing on the create path, the networking module carving neither under BYO, a bastion subnet named `jumpbox` rejected, `AZUREBASTIONSUBNET` accepted, and a casing-only collision between the AKS and AGIC subnets caught. The message cases assert the rows sum to 764, that a smaller cluster is told `/25`, and that `ceil()` interpolates as `22` rather than `22.0`, which would read as a malformed prefix.

Two harnesses cover the wizard directly. The VNet ID matcher takes 8 cases: three casings accepted, and a subnet ID, leading junk, a wrong provider namespace, an empty name, and an empty string rejected. The new required-subnet prompt rejects garbage, a VNet ID missing `/subnets/`, and a wrongly-named bastion subnet, and accepts an all-lowercase resource ID with an uppercase subnet name. The real tfvars emission block was run against a mixed reuse/carve config with both new IDs.

That split indexes element 10 of `split("/", var.aks_subnet_id)`, which has one element on the default `create_vnet = true` path. A separate test confirmed Terraform does not evaluate a resource body at `count = 0`, with a control at `count = 1` that fails on `Invalid index`, so the default path is not at risk. The both-ends-anchored regex is what guarantees 11 segments whenever the count is 1.

**Not verified:** no `terraform plan` or `apply` has run against live Azure, so none of the three plan-time reads has executed against the API — the `azapi` Postgres delegation traversal, `azurerm_subnet.service_endpoints`, or `azurerm_virtual_network.address_space`.
