### PR TITLE
fix(app): make enable_* flags authoritative + pin chart_version line (#90)

### DIFF
--- a/modules/aws/app/main.tf
+++ b/modules/aws/app/main.tf
@@ -318,6 +318,16 @@ locals {
         annotations = local.irsa_annotations
       }
     } },
+    # Chart defaults insights/polly/operator ON. Make the enable_* flags
+    # authoritative so a flag left off doesn't deploy a component that then
+    # references encryption keys absent from langsmith-config-secret. insights
+    # and polly aren't in irsa_components, so toggle them directly. operator is
+    # (when agent deploys are on), so only inject a disable when off — adding an
+    # operator key while on would clobber its IRSA annotations via merge()'s
+    # shallow merge.
+    { insights = { enabled = var.enable_insights } },
+    { polly = { enabled = var.enable_polly } },
+    var.enable_agent_deploys ? {} : { operator = { enabled = false } },
   )
 
   # Agent deploys override — only the dynamic tlsEnabled field.

--- a/modules/aws/app/variables.tf
+++ b/modules/aws/app/variables.tf
@@ -107,9 +107,9 @@ variable "release_name" {
 }
 
 variable "chart_version" {
-  description = "LangSmith Helm chart version. Empty string = latest."
+  description = "LangSmith Helm chart version constraint. Defaults to the pinned ~0.15.1 line (latest 0.15.x, never 0.16), matching the deploy scripts. Empty string = newest published chart."
   type        = string
-  default     = ""
+  default     = "~0.15.1"
 }
 
 variable "helm_timeout" {

--- a/modules/azure/app/locals.tf
+++ b/modules/azure/app/locals.tf
@@ -186,5 +186,14 @@ locals {
     # overlay files set enabled = true when the flags are on, keeping this consistent.
     { insights = { enabled = var.enable_insights } },
     { polly = { enabled = var.enable_polly } },
+    # operator and the fleet servers live in wi_components when their flag is on,
+    # so the map above already owns those keys. Only inject a disable when the
+    # flag is off — adding the key while on would clobber the WI config via
+    # merge()'s shallow merge.
+    var.enable_agent_deploys ? {} : { operator = { enabled = false } },
+    var.enable_fleet ? {} : {
+      fleetToolServer    = { enabled = false }
+      fleetTriggerServer = { enabled = false }
+    },
   )
 }

--- a/modules/azure/app/variables.tf
+++ b/modules/azure/app/variables.tf
@@ -96,9 +96,9 @@ variable "release_name" {
 }
 
 variable "chart_version" {
-  description = "LangSmith Helm chart version. Empty string = latest."
+  description = "LangSmith Helm chart version constraint. Defaults to the pinned ~0.15.1 line (latest 0.15.x, never 0.16), matching the deploy scripts. Empty string = newest published chart."
   type        = string
-  default     = ""
+  default     = "~0.15.1"
 }
 
 variable "helm_timeout" {

--- a/modules/gcp/app/locals.tf
+++ b/modules/gcp/app/locals.tf
@@ -72,6 +72,16 @@ locals {
         annotations = local.wi_annotations
       }
     } } : {},
+    # Chart defaults insights/polly/operator ON. Make the enable_* flags
+    # authoritative so a flag left off doesn't deploy a component that then
+    # references encryption keys absent from langsmith-config-secret. insights
+    # and polly aren't in wi_components, so toggle them directly. operator is
+    # (when agent deploys are on), so only inject a disable when off — adding an
+    # operator key while on would clobber its WI annotations via merge()'s
+    # shallow merge.
+    { insights = { enabled = var.enable_insights } },
+    { polly = { enabled = var.enable_polly } },
+    var.enable_agent_deploys ? {} : { operator = { enabled = false } },
   )
 
   # Agent deploys override — TLS flag only (dynamic per environment).

--- a/modules/gcp/app/variables.tf
+++ b/modules/gcp/app/variables.tf
@@ -111,9 +111,9 @@ variable "release_name" {
 }
 
 variable "chart_version" {
-  description = "LangSmith Helm chart version. Empty string = latest."
+  description = "LangSmith Helm chart version constraint. Defaults to the pinned ~0.15.1 line (latest 0.15.x, never 0.16), matching the deploy scripts. Empty string = newest published chart."
   type        = string
-  default     = ""
+  default     = "~0.15.1"
 }
 
 variable "helm_timeout" {


### PR DESCRIPTION
## What

Two root-cause fixes for the deploy failures reported in #90.

**Gap 1 — authoritative feature flags.** The LangSmith chart defaults `insights`, `polly`, and `operator` to `enabled: true`. Each cloud's `app` module builds Helm values **additively** — the overlays only ever set `enabled: true` — so a feature flag left off falls through to the chart default. The component deploys anyway and then fails referencing encryption keys absent from `langsmith-config-secret` (the `CreateContainerConfigError` in #90). This makes the `enable_*` flags authoritative in each cloud's `overrides_values`, so a component whose flag is off is explicitly `enabled = false`.

**Gap 2 — pin the chart line.** The `app` modules defaulted `chart_version = ""`, which tells the Helm provider to pull the newest published chart. A chart-default flip (exactly what surfaced Gap 1) could then break a deploy with no change on our side. The default is now `~0.15.1` — the same line the deploy scripts, `chart-line-check` CI, and release tags already pin — so the Terraform path is reproducible by default. Set `chart_version = ""` to opt back into the newest chart.

## Changes

| Cloud | insights / polly | operator | fleet servers | chart_version |
|-------|------------------|----------|---------------|---------------|
| AWS   | direct toggle (added) | disable-when-off (added) | n/a | `~0.15.1` (was `""`) |
| GCP   | direct toggle (added) | disable-when-off (added) | n/a | `~0.15.1` (was `""`) |
| Azure | already authoritative (#80) | disable-when-off (added) | disable-when-off (added) | `~0.15.1` (was `""`) |

## The shallow-merge trap (Gap 1)

The naive fix `{ operator = { enabled = var.enable_agent_deploys } }` is unsafe: `operator` (and Azure's `fleetToolServer`/`fleetTriggerServer`) are already keys in the IRSA/WI component map whenever their flag is **on**. Terraform's `merge()` is **shallow**, so re-keying `operator` would replace the whole object and drop its `serviceAccount` annotations, breaking IRSA/Workload Identity.

So those components use a disable-only-when-off form (`var.enable_agent_deploys ? {} : { operator = { enabled = false } }`). Only `insights`/`polly`, which are never in the component map, use the direct toggle.

## Note on the version constraint

`~0.15.1` is a semver constraint (latest 0.15.x, never 0.16), not an exact version. The Helm provider resolves it via the repo index the same way the shell path already does (`helm --version "~0.15.1"` against the identical chart repo), so the Terraform and script paths pin to the same line.

## #90 disposition

- **Gap 1** — fixed above.
- **Gap 2** — fixed above.
- **Gap 3a** (GCP dead `enable_fleet` var) — left as-is by decision; no fleet toggle wired here.
- **Gap 3b** (Azure BYO multi-node Redis Cluster) — dropped from scope; it's a feature request, not a fix.

Closes #90.

## Verification

`terraform validate` and `terraform fmt` clean on all three modules.