### PR TITLE
fix(aws,gcp): make setup-env.sh non-interactive failure visible and bound cloud calls

### DIFF
--- a/modules/aws/infra/scripts/setup-env.sh
+++ b/modules/aws/infra/scripts/setup-env.sh
@@ -58,6 +58,12 @@ export TF_VAR_name_prefix="${_name_prefix}"
 
 _ssm_prefix="/langsmith/${_name_prefix}-${_environment}"
 
+# Variables that could not be resolved from the environment or SSM, collected by
+# _ssm_secret and reported together at the end. _ssm_secret runs in this shell
+# (its values come back via export, not command substitution), so the append
+# inside it is visible here.
+_missing_vars=""
+
 # ── Warn on pre-exported secrets ──────────────────────────────────────────────
 # _ssm_secret short-circuits (step 0) when a variable is already exported.
 # If LANGSMITH_LICENSE_KEY or LANGSMITH_ADMIN_PASSWORD are set from a prior
@@ -71,6 +77,22 @@ for _precheck_var in LANGSMITH_LICENSE_KEY LANGSMITH_ADMIN_PASSWORD; do
     echo ""
   fi
 done
+
+# ── Bounded AWS CLI calls ─────────────────────────────────────────────────────
+# Bounded by timeout(1) when available so a sandbox with blocked egress fails
+# fast instead of stalling on a full TCP timeout. timeout is not in the macOS
+# base install, and gtimeout is the Homebrew coreutils name; run bare if neither.
+_timeout_bin=""
+for _t in timeout gtimeout; do
+  if command -v "$_t" >/dev/null 2>&1; then _timeout_bin="$_t"; break; fi
+done
+_aws() {
+  if [[ -n "$_timeout_bin" ]]; then
+    "$_timeout_bin" 30 aws "$@"
+  else
+    aws "$@"
+  fi
+}
 
 # ── Safe SSM write ────────────────────────────────────────────────────────────
 # Writes a value to SSM via a JSON file to avoid shell expansion issues with
@@ -95,7 +117,7 @@ _ssm_put_safe() {
   fi
 
   local _rc=0
-  aws ssm put-parameter \
+  _aws ssm put-parameter \
     --region "$AWS_REGION" \
     --cli-input-json "file://${_tmpjson}" \
     --output text >/dev/null 2>&1 || _rc=$?
@@ -131,7 +153,7 @@ _ssm_secret() {
   #    Without this backfill, pre-exported vars silently skip the SSM write, leaving
   #    ESO unable to sync the secret into the K8s langsmith-config secret.
   if [[ -n "$(printenv "$varname")" ]]; then
-    if ! aws ssm get-parameter --region "$AWS_REGION" --name "$_path" \
+    if ! _aws ssm get-parameter --region "$AWS_REGION" --name "$_path" \
         --query Parameter.Name --output text &>/dev/null; then
       echo "  $varname is set in env but missing from SSM — backfilling → $_path"
       if ! _ssm_put_safe "$_path" "$(printenv "$varname")"; then
@@ -143,7 +165,7 @@ _ssm_secret() {
   fi
 
   # 1. Try SSM Parameter Store
-  val=$(aws ssm get-parameter \
+  val=$(_aws ssm get-parameter \
     --region "$AWS_REGION" \
     --name "$_path" \
     --with-decryption \
@@ -187,12 +209,16 @@ _ssm_secret() {
         return 1
       fi
     else
-      # Non-interactive (CI, piped stdin, redirected) — cannot prompt
-      echo "  ERROR: $varname is required but not set and no interactive terminal available." >&2
-      echo "         Pre-export it before sourcing this script:" >&2
-      echo "           export $varname='<value>'" >&2
-      echo "         Or populate SSM directly:" >&2
-      echo "           ./infra/scripts/manage-ssm.sh set $ssm_name '<value>'" >&2
+      # Non-interactive (CI, piped stdin, redirected) — cannot prompt.
+      # Reported on stdout, not stderr: a sandboxed shell that surfaces only
+      # stdout (Cursor's agent shell) shows nothing at all otherwise, so the
+      # script looks like it exited without a reason.
+      echo "  ERROR: $varname is required but not set and no interactive terminal available."
+      echo "         Pre-export it before sourcing this script:"
+      echo "           export $varname='<value>'"
+      echo "         Or populate SSM directly:"
+      echo "           ./infra/scripts/manage-ssm.sh set $ssm_name '<value>'"
+      _missing_vars="$_missing_vars $varname"
       return 1
     fi
 
@@ -283,6 +309,24 @@ _ssm_secret "insights-encryption-key" "" "TF_VAR_langsmith_insights_encryption_k
 
 _ssm_secret "polly-encryption-key" "" "TF_VAR_langsmith_polly_encryption_key" \
   "$_fernet_gen" "" "true"
+
+# ── Non-interactive failure ───────────────────────────────────────────────────
+# Only populated when stdin is not a tty and a secret was in neither the
+# environment nor SSM. Reported here, once, on stdout — and before the summary,
+# which would otherwise claim the environment was set up successfully.
+if [[ -n "$_missing_vars" ]]; then
+  echo ""
+  echo "ERROR: stdin is not a tty, so setup-env.sh cannot prompt for secrets."
+  echo "       Missing:$_missing_vars"
+  echo ""
+  echo "       Run it from a real terminal, or pre-set the values:"
+  for _v in $_missing_vars; do
+    echo "         export $_v='<value>'"
+  done
+  echo ""
+  echo "       Then re-run: source infra/scripts/setup-env.sh"
+  return 1
+fi
 
 # ── Summary ───────────────────────────────────────────────────────────────────
 echo ""

--- a/modules/aws/infra/scripts/setup-env.sh
+++ b/modules/aws/infra/scripts/setup-env.sh
@@ -86,7 +86,10 @@ _timeout_bin=""
 for _t in timeout gtimeout; do
   if command -v "$_t" >/dev/null 2>&1; then _timeout_bin="$_t"; break; fi
 done
-_aws() {
+# Named _aws_bounded, not _aws: this script is sourced, and _aws is the zsh
+# completion function for the aws command — defining it here would replace the
+# completion for the rest of the caller's shell session.
+_aws_bounded() {
   if [[ -n "$_timeout_bin" ]]; then
     "$_timeout_bin" 30 aws "$@"
   else
@@ -117,7 +120,7 @@ _ssm_put_safe() {
   fi
 
   local _rc=0
-  _aws ssm put-parameter \
+  _aws_bounded ssm put-parameter \
     --region "$AWS_REGION" \
     --cli-input-json "file://${_tmpjson}" \
     --output text >/dev/null 2>&1 || _rc=$?
@@ -153,7 +156,7 @@ _ssm_secret() {
   #    Without this backfill, pre-exported vars silently skip the SSM write, leaving
   #    ESO unable to sync the secret into the K8s langsmith-config secret.
   if [[ -n "$(printenv "$varname")" ]]; then
-    if ! _aws ssm get-parameter --region "$AWS_REGION" --name "$_path" \
+    if ! _aws_bounded ssm get-parameter --region "$AWS_REGION" --name "$_path" \
         --query Parameter.Name --output text &>/dev/null; then
       echo "  $varname is set in env but missing from SSM — backfilling → $_path"
       if ! _ssm_put_safe "$_path" "$(printenv "$varname")"; then
@@ -165,7 +168,7 @@ _ssm_secret() {
   fi
 
   # 1. Try SSM Parameter Store
-  val=$(_aws ssm get-parameter \
+  val=$(_aws_bounded ssm get-parameter \
     --region "$AWS_REGION" \
     --name "$_path" \
     --with-decryption \
@@ -320,8 +323,11 @@ if [[ -n "$_missing_vars" ]]; then
   echo "       Missing:$_missing_vars"
   echo ""
   echo "       Run it from a real terminal, or pre-set the values:"
-  for _v in $_missing_vars; do
-    echo "         export $_v='<value>'"
+  # Split on spaces with tr rather than an unquoted expansion: this script is
+  # sourced, and zsh does not word-split, so `for _v in $_missing_vars` would
+  # print every name on a single bogus export line.
+  echo "$_missing_vars" | tr ' ' '\n' | while read -r _v; do
+    if [[ -n "$_v" ]]; then echo "         export $_v='<value>'"; fi
   done
   echo ""
   echo "       Then re-run: source infra/scripts/setup-env.sh"

--- a/modules/gcp/infra/scripts/setup-env.sh
+++ b/modules/gcp/infra/scripts/setup-env.sh
@@ -86,7 +86,10 @@ _timeout_bin=""
 for _t in timeout gtimeout; do
   if command -v "$_t" >/dev/null 2>&1; then _timeout_bin="$_t"; break; fi
 done
-_gcloud() {
+# Named _gcloud_bounded, not _gcloud: this script is sourced, and _gcloud is the
+# zsh completion function name for the gcloud command — defining it here would
+# replace the completion for the rest of the caller's shell session.
+_gcloud_bounded() {
   if [[ -n "$_timeout_bin" ]]; then
     "$_timeout_bin" 30 gcloud "$@"
   else
@@ -102,8 +105,8 @@ _sm_put() {
   local _secret_id="${_sm_prefix}-${_name}"
 
   # Create the secret resource if it doesn't exist
-  if ! _gcloud secrets describe "$_secret_id" --project="$_project_id" &>/dev/null; then
-    _gcloud secrets create "$_secret_id" \
+  if ! _gcloud_bounded secrets describe "$_secret_id" --project="$_project_id" &>/dev/null; then
+    _gcloud_bounded secrets create "$_secret_id" \
       --project="$_project_id" \
       --replication-policy="automatic" \
       --labels="managed-by=setup-env,langsmith-env=${_environment}" \
@@ -111,7 +114,7 @@ _sm_put() {
   fi
 
   # Add a new version with the value
-  printf '%s' "$_val" | _gcloud secrets versions add "$_secret_id" \
+  printf '%s' "$_val" | _gcloud_bounded secrets versions add "$_secret_id" \
     --project="$_project_id" \
     --data-file=- \
     --quiet &>/dev/null
@@ -121,7 +124,7 @@ _sm_put() {
 _sm_get() {
   local _name="$1"
   local _secret_id="${_sm_prefix}-${_name}"
-  _gcloud secrets versions access latest \
+  _gcloud_bounded secrets versions access latest \
     --secret="$_secret_id" \
     --project="$_project_id" \
     --quiet 2>/dev/null || true
@@ -149,7 +152,7 @@ _sm_secret() {
 
   # 0. Already exported in the environment — use as-is, backfill SM if missing.
   if [[ -n "$(printenv "$varname")" ]]; then
-    if ! _gcloud secrets describe "$_secret_id" --project="$_project_id" &>/dev/null; then
+    if ! _gcloud_bounded secrets describe "$_secret_id" --project="$_project_id" &>/dev/null; then
       echo "  $varname is set in env but missing from Secret Manager — backfilling → ${_secret_id}"
       if ! _sm_put "$sm_name" "$(printenv "$varname")"; then
         echo "  WARNING: Secret Manager write failed for ${_secret_id}"
@@ -265,8 +268,11 @@ if [[ -n "$_missing_vars" ]]; then
   echo "       Missing:$_missing_vars"
   echo ""
   echo "       Run it from a real terminal, or pre-set the values:"
-  for _v in $_missing_vars; do
-    echo "         export $_v='<value>'"
+  # Split on spaces with tr rather than an unquoted expansion: this script is
+  # sourced, and zsh does not word-split, so `for _v in $_missing_vars` would
+  # print every name on a single bogus export line.
+  echo "$_missing_vars" | tr ' ' '\n' | while read -r _v; do
+    if [[ -n "$_v" ]]; then echo "         export $_v='<value>'"; fi
   done
   echo ""
   echo "       Then re-run: source infra/scripts/setup-env.sh"

--- a/modules/gcp/infra/scripts/setup-env.sh
+++ b/modules/gcp/infra/scripts/setup-env.sh
@@ -62,6 +62,12 @@ export TF_VAR_cost_center="${LANGSMITH_COST_CENTER:-}"
 #   projects/{project_id}/secrets/langsmith-{name_prefix}-{environment}-{key}
 _sm_prefix="langsmith-${_name_prefix}-${_environment}"
 
+# Variables that could not be resolved from the environment or Secret Manager,
+# collected by _sm_secret and reported together at the end. _sm_secret runs in
+# this shell (its values come back via export, not command substitution), so the
+# append inside it is visible here.
+_missing_vars=""
+
 # ── Warn on pre-exported secrets ──────────────────────────────────────────────
 for _precheck_var in TF_VAR_langsmith_license_key; do
   if [[ -n "$(printenv "$_precheck_var")" ]]; then
@@ -72,6 +78,22 @@ for _precheck_var in TF_VAR_langsmith_license_key; do
   fi
 done
 
+# ── Bounded gcloud calls ──────────────────────────────────────────────────────
+# Bounded by timeout(1) when available so a sandbox with blocked egress fails
+# fast instead of stalling on a full TCP timeout. timeout is not in the macOS
+# base install, and gtimeout is the Homebrew coreutils name; run bare if neither.
+_timeout_bin=""
+for _t in timeout gtimeout; do
+  if command -v "$_t" >/dev/null 2>&1; then _timeout_bin="$_t"; break; fi
+done
+_gcloud() {
+  if [[ -n "$_timeout_bin" ]]; then
+    "$_timeout_bin" 30 gcloud "$@"
+  else
+    gcloud "$@"
+  fi
+}
+
 # ── Safe Secret Manager write ─────────────────────────────────────────────────
 # Creates a new secret version (or the secret itself if it doesn't exist yet).
 # Accepts value via stdin to avoid exposing it in the process list.
@@ -80,8 +102,8 @@ _sm_put() {
   local _secret_id="${_sm_prefix}-${_name}"
 
   # Create the secret resource if it doesn't exist
-  if ! gcloud secrets describe "$_secret_id" --project="$_project_id" &>/dev/null; then
-    gcloud secrets create "$_secret_id" \
+  if ! _gcloud secrets describe "$_secret_id" --project="$_project_id" &>/dev/null; then
+    _gcloud secrets create "$_secret_id" \
       --project="$_project_id" \
       --replication-policy="automatic" \
       --labels="managed-by=setup-env,langsmith-env=${_environment}" \
@@ -89,7 +111,7 @@ _sm_put() {
   fi
 
   # Add a new version with the value
-  printf '%s' "$_val" | gcloud secrets versions add "$_secret_id" \
+  printf '%s' "$_val" | _gcloud secrets versions add "$_secret_id" \
     --project="$_project_id" \
     --data-file=- \
     --quiet &>/dev/null
@@ -99,7 +121,7 @@ _sm_put() {
 _sm_get() {
   local _name="$1"
   local _secret_id="${_sm_prefix}-${_name}"
-  gcloud secrets versions access latest \
+  _gcloud secrets versions access latest \
     --secret="$_secret_id" \
     --project="$_project_id" \
     --quiet 2>/dev/null || true
@@ -127,7 +149,7 @@ _sm_secret() {
 
   # 0. Already exported in the environment — use as-is, backfill SM if missing.
   if [[ -n "$(printenv "$varname")" ]]; then
-    if ! gcloud secrets describe "$_secret_id" --project="$_project_id" &>/dev/null; then
+    if ! _gcloud secrets describe "$_secret_id" --project="$_project_id" &>/dev/null; then
       echo "  $varname is set in env but missing from Secret Manager — backfilling → ${_secret_id}"
       if ! _sm_put "$sm_name" "$(printenv "$varname")"; then
         echo "  WARNING: Secret Manager write failed for ${_secret_id}"
@@ -168,13 +190,17 @@ _sm_secret() {
         return 1
       fi
     else
-      # Non-interactive (CI, piped stdin, redirected) — cannot prompt
-      echo "  ERROR: $varname is required but not set and no interactive terminal available." >&2
-      echo "         Pre-export it before sourcing this script:" >&2
-      echo "           export $varname='<value>'" >&2
-      echo "         Or populate Secret Manager directly:" >&2
-      echo "           printf '%s' '<value>' | gcloud secrets versions add ${_secret_id} \\" >&2
-      echo "             --project=${_project_id} --data-file=-" >&2
+      # Non-interactive (CI, piped stdin, redirected) — cannot prompt.
+      # Reported on stdout, not stderr: a sandboxed shell that surfaces only
+      # stdout (Cursor's agent shell) shows nothing at all otherwise, so the
+      # script looks like it exited without a reason.
+      echo "  ERROR: $varname is required but not set and no interactive terminal available."
+      echo "         Pre-export it before sourcing this script:"
+      echo "           export $varname='<value>'"
+      echo "         Or populate Secret Manager directly:"
+      echo "           printf '%s' '<value>' | gcloud secrets versions add ${_secret_id} \\"
+      echo "             --project=${_project_id} --data-file=-"
+      _missing_vars="$_missing_vars $varname"
       return 1
     fi
 
@@ -228,6 +254,24 @@ _sm_secret "insights-encryption-key" "TF_VAR_langsmith_insights_encryption_key" 
 
 _sm_secret "polly-encryption-key" "TF_VAR_langsmith_polly_encryption_key" \
   "$_fernet_gen" "" "true"
+
+# ── Non-interactive failure ───────────────────────────────────────────────────
+# Only populated when stdin is not a tty and a secret was in neither the
+# environment nor Secret Manager. Reported here, once, on stdout — and before the
+# summary, which would otherwise claim the environment was set up successfully.
+if [[ -n "$_missing_vars" ]]; then
+  echo ""
+  echo "ERROR: stdin is not a tty, so setup-env.sh cannot prompt for secrets."
+  echo "       Missing:$_missing_vars"
+  echo ""
+  echo "       Run it from a real terminal, or pre-set the values:"
+  for _v in $_missing_vars; do
+    echo "         export $_v='<value>'"
+  done
+  echo ""
+  echo "       Then re-run: source infra/scripts/setup-env.sh"
+  return 1
+fi
 
 # ── Summary ───────────────────────────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
Backports two hardening fixes from the Azure `setup-env.sh` work in #97 to the AWS and GCP modules.

Related: #97 (Azure, still open). This PR is independent of it: it is based on `main` and touches no Azure files.

## 1. The non-interactive failure was invisible

Both scripts detected a missing tty and reported it on stderr, then returned 1. A sandboxed shell that surfaces only stdout (Cursor's agent shell is the reported case) showed nothing, so the script appeared to exit without a reason.

Worse, the script did not stop. Each failing secret returned 1 from inside the helper, execution continued, and the run finished by printing `Terraform environment variables set.` on stdout. The sandboxed case did not just hide the reason, it reported success.

Now: the "cannot prompt" message goes to stdout, and a single block before the summary names every missing variable, its export line, and the re-run command, matching the shape of Azure's non-interactive guard.

```
ERROR: stdin is not a tty, so setup-env.sh cannot prompt for secrets.
       Missing: TF_VAR_postgres_password LANGSMITH_LICENSE_KEY LANGSMITH_ADMIN_PASSWORD LANGSMITH_ADMIN_EMAIL

       Run it from a real terminal, or pre-set the values:
         export TF_VAR_postgres_password='<value>'
         export LANGSMITH_LICENSE_KEY='<value>'
         export LANGSMITH_ADMIN_PASSWORD='<value>'
         export LANGSMITH_ADMIN_EMAIL='<value>'

       Then re-run: source infra/scripts/setup-env.sh
```

### Why the report is at the end, not the top

Azure checks a required-variables list at the top of the script and exits before doing anything. Ported literally, that breaks a working path here.

Both modules ship a `tf-run.sh` that runs `set -euo pipefail` and then `source setup-env.sh > /dev/null 2>&1`, documented for CI. A top-of-script guard keyed on the environment alone cannot know that SSM or Secret Manager already holds the secrets, so a CI run with a populated store and nothing pre-exported would newly fail, and with both streams suppressed it would exit 1 printing nothing. The fix for an invisible failure would have introduced a new invisible failure.

Reporting after the store lookups means the failure fires on exactly the old condition: the value was in neither the environment nor the store. `tf-run.sh` behaves as it did before, and the store-backed path keeps working.

Tradeoff: with egress blocked you wait out the (now bounded) store calls before the message appears, instead of getting it immediately.

## 2. No timeout bound on cloud CLI calls

`aws ssm get-parameter` and `gcloud secrets versions access` stall on a full TCP timeout when egress is blocked, which is what made the Azure script look hung.

Every cloud CLI call now goes through an `_aws_bounded` / `_gcloud_bounded` wrapper that probes for `timeout`, then `gtimeout` (not in the macOS base install; `gtimeout` is the Homebrew coreutils name), and runs bare if neither is present. 30s bound, same as Azure's `_timeout_bin` / `_az` block. AWS: 3 call sites. GCP: 5.

The `_bounded` suffix is deliberate. `_aws` and `_gcloud` are zsh completion function names, and because these scripts are sourced, defining `_aws` would replace the aws completion for the rest of the caller's shell session.

## zsh

These scripts are sourced, so the caller's shell runs them, and zsh is a working path: both source cleanly under `zsh -c` and the code already accommodates it at line 27 (`${BASH_SOURCE[0]:-$0}`). Two things in this change are zsh-sensitive, both caught in review and fixed in the second commit:

- The missing-variable list is split with `tr` rather than an unquoted expansion. zsh does not word-split, so `for _v in $_missing_vars` printed every name on one uncopyable export line.
- The wrapper names, per above.

Azure's version has neither constraint because it is executed rather than sourced, which is why the shapes differ slightly.

## Out of scope

The sourced-and-export architecture is unchanged: no `set -euo pipefail` (it would leak into an interactive shell), values still returned via `export "$varname"="$val"`, and every new failure path uses `return`, never `exit`. Converging the three modules onto Azure's `secrets.auto.tfvars` model is a separate, larger decision.

Also left alone: GCP has no admin email prompt, and neither module offers "press Enter to generate" on the Postgres password. Both are real gaps, but they are feature additions.

Noted while testing, not fixed here: `tf-run.sh` suppresses stdout and stderr, so these messages do not reach a CI log through that wrapper. And the repo's `.gitignore` files cover the secret fallback files these scripts write (`.pg_password`, `.api_key_salt`, `.jwt_secret`, `.license_key`, `.admin_password`) but not `.env` or `*.key`.

## Verification

- `bash -n` passes on both files.
- `shellcheck` 0.11.0: AWS 0 findings, GCP 1 finding, both identical to the pre-change baseline. The GCP finding is a pre-existing SC2043 (single-item loop), line 66 before this change and line 72 on the branch.
- Non-tty paths exercised with a stub `aws`/`gcloud` on PATH that always fails, standing in for a machine without secret-store access. No live cloud calls.
  - Nothing preset, stderr discarded (`source ... 2>/dev/null </dev/null`): AWS lists all 4 missing variables, GCP all 3, return 1.
  - Required variables preset: both complete and print the summary, return 0.
  - Every case run twice, sourced from bash and from zsh. Byte-identical output, same exit status.
- zsh completion: `whence -w _aws` reports the completion function before and after sourcing, and its body contains no wrapper code.
- Timeout wrapper: with a stub `timeout` on PATH, every call is invoked as `timeout 30 <cmd>`. Neither `timeout` nor `gtimeout` exists on the test machine, so the runs above also covered the bare fallback.
