### PR TITLE
Add Karpenter instance termination delete permission

### DIFF
--- a/modules/byoc/aws/langsmith-byoc-role/policies/delete.json
+++ b/modules/byoc/aws/langsmith-byoc-role/policies/delete.json
@@ -1,6 +1,20 @@
 {
   "vpc": [
     {
+      "Sid": "EC2TerminateKarpenterInstances",
+      "Effect": "Allow",
+      "Action": ["ec2:TerminateInstances"],
+      "Resource": "arn:aws:ec2:*:${account_id}:instance/*",
+      "Condition": {
+        "Null": {
+          "aws:ResourceTag/karpenter.sh/nodepool": "false"
+        },
+        "StringLike": {
+          "aws:ResourceTag/aws:eks:cluster-name": "*-smith-eks"
+        }
+      }
+    },
+    {
       "Sid": "EC2DeleteManagedResources",
       "Effect": "Allow",
       "Action": [


### PR DESCRIPTION
## Summary
- add `ec2:TerminateInstances` permission to the BYOC role delete permissions, to allow force termination of nodes in the data plane teardown
- restrict termination to tagged Karpenter instances in `*-smith-eks` clusters
- keep gated by `allow_delete_permissions`