### PR TITLE
feat(aws,gcp,azure): pass ARGS through to terraform, expand make help

### DIFF
--- a/modules/aws/COMMANDS.md
+++ b/modules/aws/COMMANDS.md
@@ -1,6 +1,8 @@
 # LangSmith on AWS — Make Target Glossary
 
-All commands run from `terraform/aws/`. Run `make help` for a quick inline summary.
+All commands run from `modules/aws/`. Run `make help` for a quick inline summary.
+
+Every terraform-backed target accepts an `ARGS` variable that is appended to the terraform command — see [Terraform flags](#terraform-flags).
 
 ---
 
@@ -33,6 +35,35 @@ All commands run from `terraform/aws/`. Run `make help` for a quick inline summa
 | `make plan` | `terraform plan` — previews changes; review before every apply |
 | `make apply` | `terraform apply` — provisions VPC, EKS, RDS, ElastiCache, S3, ALB, IRSA (~20–25 min) |
 | `make destroy` | `terraform destroy` — tears down all infrastructure; run `make uninstall` first |
+| `make tf` | Run any other terraform subcommand against `infra/` — `make tf ARGS="state list"` |
+
+---
+
+## Terraform flags
+
+`ARGS` is appended verbatim to the terraform command, so you never have to leave `make` or remember `-chdir=infra`:
+
+```bash
+make init    ARGS="-upgrade"               # re-resolve provider versions
+make plan    ARGS="-target=module.eks"     # plan one module
+make plan    ARGS="-out=tfplan"            # save a plan file
+make apply   ARGS="tfplan"                 # apply that saved plan
+make apply   ARGS="-auto-approve"          # skip the approval prompt
+make destroy ARGS="-target=module.redis"   # destroy one module
+```
+
+`make tf` takes a full terraform command line, for anything the named targets don't cover:
+
+```bash
+make tf ARGS="output"
+make tf ARGS="output -raw cluster_name"
+make tf ARGS="state list"
+make tf ARGS="state list module.eks"       # filter state to one module
+make tf ARGS="validate"
+make tf ARGS="providers"
+```
+
+`ARGS` set on the command line reaches every target in that invocation, including prerequisites — `make deploy-all ARGS="-auto-approve"` auto-approves the `apply` step. Combining it with `-target` on a combo target is not meaningful.
 
 ---
 

--- a/modules/aws/Makefile
+++ b/modules/aws/Makefile
@@ -10,8 +10,9 @@
 # Full deploy:       make deploy-all
 # Teardown:          make uninstall → make destroy → make purge-secrets → make clean
 # Where am I?        make status
+# Terraform flags:   make plan ARGS="-target=module.eks"   (see make help)
 
-.PHONY: help quickstart status status-quick setup-env init plan apply destroy purge-secrets \
+.PHONY: help quickstart status status-quick setup-env init plan apply destroy purge-secrets tf \
         preflight preflight-post preflight-ssm kubeconfig ssm secrets secrets-list tls \
         init-values deploy apply-eso uninstall clean deploy-all \
         test-e2e test-permutations test-parallel \
@@ -21,8 +22,25 @@ INFRA_DIR := infra
 HELM_DIR  := helm
 
 help: ## Show available targets
+	@echo ""
+	@echo "  \033[1mUsage:\033[0m make <target> [ARGS=\"<extra terraform flags>\"]"
+	@echo ""
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
 		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}'
+	@echo ""
+	@echo "  \033[1mARGS is appended to the terraform command:\033[0m"
+	@echo "    make init    ARGS=\"-upgrade\"                 # re-resolve provider versions"
+	@echo "    make plan    ARGS=\"-target=module.eks\"       # plan one module"
+	@echo "    make plan    ARGS=\"-out=tfplan\"              # save a plan file"
+	@echo "    make apply   ARGS=\"tfplan\"                   # apply that saved plan"
+	@echo "    make apply   ARGS=\"-auto-approve\"            # skip the approval prompt"
+	@echo "    make destroy ARGS=\"-target=module.redis\"     # destroy one module"
+	@echo ""
+	@echo "  \033[1mAny other terraform command — no need to remember -chdir:\033[0m"
+	@echo "    make tf      ARGS=\"output\"                   # all infra outputs"
+	@echo "    make tf      ARGS=\"output -raw cluster_name\""
+	@echo "    make tf      ARGS=\"state list\"               # inspect infra state"
+	@echo ""
 
 status: ## Check deployment state and show what to run next
 	$(INFRA_DIR)/scripts/status.sh
@@ -51,16 +69,19 @@ setup-env: ## Set up secrets in SSM (prints the source command you need to run)
 	@echo ""
 
 init: ## terraform init (infra)
-	terraform -chdir=$(INFRA_DIR) init
+	terraform -chdir=$(INFRA_DIR) init $(ARGS)
 
 plan: ## terraform plan (infra)
-	terraform -chdir=$(INFRA_DIR) plan
+	terraform -chdir=$(INFRA_DIR) plan $(ARGS)
 
 apply: ## terraform apply (infra)
-	terraform -chdir=$(INFRA_DIR) apply
+	terraform -chdir=$(INFRA_DIR) apply $(ARGS)
 
 destroy: ## terraform destroy (infra) — run make uninstall first
-	terraform -chdir=$(INFRA_DIR) destroy
+	terraform -chdir=$(INFRA_DIR) destroy $(ARGS)
+
+tf: ## Any terraform command in infra/ (make tf ARGS="state list")
+	terraform -chdir=$(INFRA_DIR) $(ARGS)
 
 purge-secrets: ## Delete SSM secrets after Terraform has no managed resources
 	$(INFRA_DIR)/scripts/purge-secrets.sh

--- a/modules/aws/Makefile
+++ b/modules/aws/Makefile
@@ -23,7 +23,7 @@ HELM_DIR  := helm
 
 help: ## Show available targets
 	@echo ""
-	@echo "  \033[1mUsage:\033[0m make <target> [ARGS=\"<extra terraform flags>\"]"
+	@echo "  \033[1mUsage:\033[0m make <target> [ARGS=\"<extra flags>\"]"
 	@echo ""
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
 		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}'
@@ -40,6 +40,9 @@ help: ## Show available targets
 	@echo "    make tf      ARGS=\"output\"                   # all infra outputs"
 	@echo "    make tf      ARGS=\"output -raw cluster_name\""
 	@echo "    make tf      ARGS=\"state list\"               # inspect infra state"
+	@echo ""
+	@echo "  \033[1mThe test targets take ARGS too, as a test subset — not terraform flags:\033[0m"
+	@echo "    make test-permutations ARGS=\"1 2 5\"          # run permutations 1, 2 and 5"
 	@echo ""
 
 status: ## Check deployment state and show what to run next

--- a/modules/aws/QUICK_REFERENCE.md
+++ b/modules/aws/QUICK_REFERENCE.md
@@ -213,20 +213,32 @@ aws iam get-role --role-name <irsa-role-name>
 
 ## Terraform Commands
 
-```bash
-cd modules/aws/infra
+Every terraform target accepts `ARGS`, which is appended to the terraform command:
 
-terraform init
-terraform plan
-terraform apply
-terraform apply -target=module.eks
-terraform output
-terraform output -raw cluster_name
-terraform output -raw alb_dns_name
-terraform output -raw langsmith_irsa_role_arn
-terraform output -raw bucket_name
-terraform state list
+```bash
+cd modules/aws
+
+make init    ARGS="-upgrade"               # re-resolve provider versions
+make plan    ARGS="-target=module.eks"     # plan one module
+make plan    ARGS="-out=tfplan"            # save a plan file
+make apply   ARGS="tfplan"                 # apply that saved plan
+make apply   ARGS="-auto-approve"          # skip the approval prompt
+make destroy ARGS="-target=module.redis"   # destroy one module
 ```
+
+For any other subcommand, `make tf` runs against `infra/`:
+
+```bash
+make tf ARGS="output"
+make tf ARGS="output -raw cluster_name"
+make tf ARGS="output -raw alb_dns_name"
+make tf ARGS="output -raw langsmith_irsa_role_arn"
+make tf ARGS="output -raw bucket_name"
+make tf ARGS="state list"
+make tf ARGS="validate"
+```
+
+`make tf ARGS="..."` is exactly `terraform -chdir=infra ...`, so you can also run terraform directly from `modules/aws/infra` if you prefer.
 
 ---
 

--- a/modules/aws/infra/scripts/status.sh
+++ b/modules/aws/infra/scripts/status.sh
@@ -181,8 +181,8 @@ if [[ -d "$INFRA_DIR/.terraform" ]]; then
   pass "terraform init — done"
 else
   fail "terraform init — not run"
-  action "terraform -chdir=infra init"
-  set_next "terraform -chdir=infra init"
+  action "make init"
+  set_next "make init"
 fi
 
 # Use terraform output (fast, no state lock) instead of state list (slow, locks)
@@ -221,9 +221,9 @@ if [[ -n "$_tf_output" ]] && echo "$_tf_output" | grep -q '"cluster_name"'; then
 else
   fail "terraform output — empty (no state file or state is elsewhere)"
   info "If infra was applied from another machine, you need to configure the backend"
-  info "or run 'terraform -chdir=infra init' to reconnect to remote state."
-  action "terraform -chdir=infra init  (if using a remote backend)"
-  action "terraform -chdir=infra apply  (if starting fresh)"
+  info "or run 'make init' to reconnect to remote state."
+  action "make init  (if using a remote backend)"
+  action "make apply  (if starting fresh)"
   set_next "Resolve terraform state — see section 5"
 fi
 
@@ -372,20 +372,20 @@ else
       action "helm rollback langsmith -n ${_NAMESPACE}"
     elif [[ "$_helm_status" == "pending-install" ]]; then
       fail "Helm release: langsmith — stuck in pending-install (interrupted install)"
-      action "helm uninstall langsmith -n ${_NAMESPACE}  then re-run ./helm/scripts/deploy.sh"
+      action "helm uninstall langsmith -n ${_NAMESPACE}  then re-run make deploy"
     elif [[ "$_helm_status" == "failed" ]]; then
       warn "Helm release: langsmith — status 'failed' (likely a prior --wait timeout)"
       info "Pods may still be running — Helm marks the release failed if --wait times out"
       [[ -n "$_helm_version" ]] && info "Chart: ${_helm_version}"
-      action "Re-run ./helm/scripts/deploy.sh  (upgrades over the failed release)"
+      action "Re-run make deploy  (upgrades over the failed release)"
     else
       warn "Helm release: langsmith — status: ${_helm_status}"
-      action "./helm/scripts/deploy.sh"
+      action "make deploy"
     fi
   else
     skip "Helm release: langsmith — not installed"
-    action "./helm/scripts/deploy.sh"
-    set_next "./helm/scripts/deploy.sh"
+    action "make deploy"
+    set_next "make deploy"
   fi
 
   # Pod health
@@ -418,7 +418,7 @@ else
     _ingress_exists=$(kubectl get ingress -n "$_NAMESPACE" langsmith-ingress &>/dev/null && echo "yes" || echo "no")
     if [[ "$_ingress_exists" == "yes" ]]; then
       warn "Ingress exists but ALB hostname not yet assigned (~2 min to provision)"
-      action "Wait 2 min, then re-run ./helm/scripts/deploy.sh to pick up the hostname"
+      action "Wait 2 min, then re-run make deploy to pick up the hostname"
     else
       skip "No ingress found"
     fi

--- a/modules/azure/Makefile
+++ b/modules/azure/Makefile
@@ -7,19 +7,39 @@
 # Full deploy (helm):      make deploy-all
 # Manage secrets:          make keyvault
 # Where am I?              make status
+# Terraform flags:         make plan ARGS="-target=module.aks"   (see make help)
 
 .PHONY: help quickstart test-quickstart setup-env preflight keyvault status status-quick \
-        init plan apply destroy \
+        init plan apply destroy destroy-force tf \
         kubeconfig k8s-secrets \
         init-values deploy uninstall deploy-all \
-        clean
+        clean clean-force
 
 INFRA_DIR := infra
 HELM_DIR  := helm
 
 help: ## Show available targets
+	@echo ""
+	@echo "  \033[1mUsage:\033[0m make <target> [ARGS=\"<extra terraform flags>\"]"
+	@echo ""
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
 		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}'
+	@echo ""
+	@echo "  \033[1mARGS is appended to the terraform command:\033[0m"
+	@echo "    make init    ARGS=\"-upgrade\"                 # re-resolve provider versions"
+	@echo "    make plan    ARGS=\"-target=module.aks\"       # plan one module"
+	@echo "    make plan    ARGS=\"-out=tfplan\"              # save a plan file"
+	@echo "    make destroy ARGS=\"-target=module.redis\"     # destroy one module"
+	@echo ""
+	@echo "    Note: make apply runs three targeted stages. ARGS is passed to each"
+	@echo "    stage, so it suits flags like -var / -parallelism / -refresh=false."
+	@echo "    To apply a saved plan or one module, use: make tf ARGS=\"apply tfplan\""
+	@echo ""
+	@echo "  \033[1mAny other terraform command — no need to remember -chdir:\033[0m"
+	@echo "    make tf      ARGS=\"output\"                   # all infra outputs"
+	@echo "    make tf      ARGS=\"output keyvault_name\""
+	@echo "    make tf      ARGS=\"state list\"               # inspect infra state"
+	@echo ""
 
 quickstart: ## Interactive setup wizard — generates terraform.tfvars
 	$(INFRA_DIR)/scripts/quickstart.sh
@@ -48,16 +68,16 @@ test-preflight: ## Run the pre-flight RBAC tests (stubbed az, no Azure account n
 	python3 $(INFRA_DIR)/scripts/test-preflight-rbac.py
 
 init: ## terraform init (infra)
-	terraform -chdir=$(INFRA_DIR) init
+	terraform -chdir=$(INFRA_DIR) init $(ARGS)
 
 plan: ## terraform plan (infra) — runs setup-env.sh first to ensure secrets.auto.tfvars exists
 	@if [ ! -f $(INFRA_DIR)/secrets.auto.tfvars ]; then cd $(INFRA_DIR) && bash scripts/setup-env.sh; fi
-	terraform -chdir=$(INFRA_DIR) plan
+	terraform -chdir=$(INFRA_DIR) plan $(ARGS)
 
-apply: ## terraform apply (infra) — two-stage: Azure infra first, then k8s bootstrap + ClusterIssuer
+apply: ## terraform apply (infra) — 3 stages: Azure infra → k8s bootstrap → ClusterIssuer (ARGS passed to each)
 	@if [ ! -f $(INFRA_DIR)/secrets.auto.tfvars ]; then cd $(INFRA_DIR) && bash scripts/setup-env.sh; fi
 	@echo "→ Stage 1: Azure infrastructure (RG, VNet, AKS, Postgres, Redis, Blob, KeyVault)..."
-	terraform -chdir=$(INFRA_DIR) apply -auto-approve \
+	terraform -chdir=$(INFRA_DIR) apply -auto-approve $(ARGS) \
 		-target=azurerm_resource_group.resource_group \
 		-target=module.vnet \
 		-target=module.aks \
@@ -66,7 +86,7 @@ apply: ## terraform apply (infra) — two-stage: Azure infra first, then k8s boo
 		-target=module.blob \
 		-target=module.keyvault
 	@echo "→ Stage 2: Kubernetes bootstrap (namespace, secrets, cert-manager, KEDA)..."
-	terraform -chdir=$(INFRA_DIR) apply -auto-approve \
+	terraform -chdir=$(INFRA_DIR) apply -auto-approve $(ARGS) \
 		-target=module.k8s_bootstrap.kubernetes_namespace_v1.langsmith \
 		-target=module.k8s_bootstrap.kubernetes_service_account_v1.langsmith \
 		-target=module.k8s_bootstrap.kubernetes_resource_quota_v1.langsmith \
@@ -78,13 +98,16 @@ apply: ## terraform apply (infra) — two-stage: Azure infra first, then k8s boo
 		-target=module.k8s_bootstrap.helm_release.cert_manager \
 		-target=module.k8s_bootstrap.helm_release.keda
 	@echo "→ Stage 3: ClusterIssuer + remaining resources (cert-manager CRDs now ready)..."
-	terraform -chdir=$(INFRA_DIR) apply -auto-approve
+	terraform -chdir=$(INFRA_DIR) apply -auto-approve $(ARGS)
 
 destroy: ## terraform destroy (infra) — prompts for confirmation
-	terraform -chdir=$(INFRA_DIR) destroy
+	terraform -chdir=$(INFRA_DIR) destroy $(ARGS)
 
 destroy-force: ## terraform destroy without confirmation prompt (use after make uninstall)
-	terraform -chdir=$(INFRA_DIR) destroy -auto-approve
+	terraform -chdir=$(INFRA_DIR) destroy -auto-approve $(ARGS)
+
+tf: ## Any terraform command in infra/ (make tf ARGS="state list")
+	terraform -chdir=$(INFRA_DIR) $(ARGS)
 
 clean: ## Remove all local secrets and generated files (run after destroy)
 	$(INFRA_DIR)/scripts/clean.sh

--- a/modules/azure/QUICK_REFERENCE.md
+++ b/modules/azure/QUICK_REFERENCE.md
@@ -372,6 +372,36 @@ langsmith-standalone-polly-queue-xxxxx             1/1     Running     0        
 
 ---
 
+## Terraform Commands
+
+Every terraform target accepts `ARGS`, which is appended to the terraform command:
+
+```bash
+cd modules/azure
+
+make init    ARGS="-upgrade"                 # re-resolve provider versions
+make plan    ARGS="-target=module.aks"       # plan one module
+make plan    ARGS="-out=tfplan"              # save a plan file
+make destroy ARGS="-target=module.redis"     # destroy one module
+```
+
+> `make apply` runs three targeted stages, and `ARGS` is passed to each of them. That suits flags like `-var`, `-parallelism`, and `-refresh=false`. To apply a saved plan or a single module, bypass the staging with `make tf ARGS="apply tfplan"`.
+
+For any other subcommand, `make tf` runs against `infra/`:
+
+```bash
+make tf ARGS="output"
+make tf ARGS="output keyvault_name"
+make tf ARGS="output aks_cluster_name"
+make tf ARGS="output dns_nameservers"
+make tf ARGS="state list"
+make tf ARGS="validate"
+```
+
+`make tf ARGS="..."` is exactly `terraform -chdir=infra ...`, so you can also run terraform directly from `modules/azure/infra` if you prefer.
+
+---
+
 ## Teardown
 
 ```bash

--- a/modules/azure/infra/scripts/status.sh
+++ b/modules/azure/infra/scripts/status.sh
@@ -75,8 +75,8 @@ if [[ -f "$_secrets_file" ]]; then
   [[ -n "$_pg_pw" ]] && pass "postgres_admin_password is set" || fail "postgres_admin_password is empty"
 else
   fail "secrets.auto.tfvars not found"
-  action "bash infra/setup-env.sh"
-  set_next "bash infra/setup-env.sh"
+  action "make setup-env"
+  set_next "make setup-env"
 fi
 
 # ── 3. Azure Credentials ──────────────────────────────────────────────────────
@@ -113,8 +113,8 @@ elif [[ -z "${_kv_name:-}" || "$_kv_name" == "langsmith-kv" ]]; then
   skip "Cannot check — name_prefix not set in terraform.tfvars"
 elif ! az keyvault show --name "$_kv_name" --output none 2>/dev/null; then
   skip "Key Vault '${_kv_name}' not found (created by terraform apply)"
-  action "terraform -chdir=infra apply"
-  set_next "terraform -chdir=infra apply"
+  action "make apply"
+  set_next "make apply"
 else
   _required_kv_secrets=(
     langsmith-license-key
@@ -150,7 +150,7 @@ else
   done
 
   if [[ "$_kv_ok" == "false" ]]; then
-    action "bash infra/setup-env.sh  (re-run after terraform apply)"
+    action "make setup-env  (re-run after terraform apply)"
     set_next "Resolve missing Key Vault secrets"
   fi
 fi

--- a/modules/gcp/Makefile
+++ b/modules/gcp/Makefile
@@ -5,8 +5,9 @@
 # Pass 2 (helm):        make init-values → make deploy
 # Full deploy:          make deploy-all
 # Where am I?           make status
+# Terraform flags:      make plan ARGS="-target=module.gke_cluster"   (see make help)
 
-.PHONY: help quickstart status status-quick setup-env secrets init plan apply destroy \
+.PHONY: help quickstart status status-quick setup-env secrets init plan apply destroy tf \
         preflight kubeconfig \
         init-values deploy uninstall deploy-all \
         patch-lgp
@@ -15,8 +16,25 @@ INFRA_DIR := infra
 HELM_DIR  := helm
 
 help: ## Show available targets
+	@echo ""
+	@echo "  \033[1mUsage:\033[0m make <target> [ARGS=\"<extra terraform flags>\"]"
+	@echo ""
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | \
 		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2}'
+	@echo ""
+	@echo "  \033[1mARGS is appended to the terraform command:\033[0m"
+	@echo "    make init    ARGS=\"-upgrade\"                     # re-resolve provider versions"
+	@echo "    make plan    ARGS=\"-target=module.gke_cluster\"   # plan one module"
+	@echo "    make plan    ARGS=\"-out=tfplan\"                  # save a plan file"
+	@echo "    make apply   ARGS=\"tfplan\"                       # apply that saved plan"
+	@echo "    make apply   ARGS=\"-auto-approve\"                # skip the approval prompt"
+	@echo "    make destroy ARGS=\"-target=module.redis\"         # destroy one module"
+	@echo ""
+	@echo "  \033[1mAny other terraform command — no need to remember -chdir:\033[0m"
+	@echo "    make tf      ARGS=\"output\"                       # all infra outputs"
+	@echo "    make tf      ARGS=\"output -raw storage_bucket_name\""
+	@echo "    make tf      ARGS=\"state list\"                   # inspect infra state"
+	@echo ""
 
 status: ## Check deployment state and show what to run next
 	$(INFRA_DIR)/scripts/status.sh
@@ -48,16 +66,19 @@ secrets: ## Interactive Secret Manager tool (list/get/set/validate/delete)
 	$(INFRA_DIR)/scripts/manage-secrets.sh
 
 init: ## terraform init (infra)
-	terraform -chdir=$(INFRA_DIR) init
+	terraform -chdir=$(INFRA_DIR) init $(ARGS)
 
 plan: ## terraform plan (infra)
-	terraform -chdir=$(INFRA_DIR) plan
+	terraform -chdir=$(INFRA_DIR) plan $(ARGS)
 
 apply: ## terraform apply (infra)
-	terraform -chdir=$(INFRA_DIR) apply
+	terraform -chdir=$(INFRA_DIR) apply $(ARGS)
 
 destroy: ## terraform destroy (infra)
-	terraform -chdir=$(INFRA_DIR) destroy
+	terraform -chdir=$(INFRA_DIR) destroy $(ARGS)
+
+tf: ## Any terraform command in infra/ (make tf ARGS="state list")
+	terraform -chdir=$(INFRA_DIR) $(ARGS)
 
 preflight: ## Run GCP infra preflight checks
 	$(INFRA_DIR)/scripts/preflight.sh

--- a/modules/gcp/QUICK_REFERENCE.md
+++ b/modules/gcp/QUICK_REFERENCE.md
@@ -444,33 +444,32 @@ gcloud secrets versions access latest --secret=<secret-id> --project <project-id
 
 ## Terraform Commands
 
+Every terraform target accepts `ARGS`, which is appended to the terraform command:
+
 ```bash
-# Initialize
-terraform init
+cd modules/gcp
 
-# Plan
-terraform plan -var-file=terraform.tfvars
-
-# Apply
-terraform apply -var-file=terraform.tfvars
-
-# Target a specific module
-terraform apply -var-file=terraform.tfvars -target=module.networking
-
-# Show all outputs
-terraform output
-
-# Show a specific output
-terraform output -raw cluster_name
-terraform output -raw storage_bucket_name
-
-# Show resource state
-terraform state list
-terraform state show module.gke_cluster
-
-# Refresh state
-terraform refresh -var-file=terraform.tfvars
+make init    ARGS="-upgrade"                     # re-resolve provider versions
+make plan    ARGS="-target=module.gke_cluster"   # plan one module
+make plan    ARGS="-out=tfplan"                  # save a plan file
+make apply   ARGS="tfplan"                       # apply that saved plan
+make apply   ARGS="-auto-approve"                # skip the approval prompt
+make destroy ARGS="-target=module.redis"         # destroy one module
 ```
+
+For any other subcommand, `make tf` runs against `infra/`:
+
+```bash
+make tf ARGS="output"
+make tf ARGS="output -raw cluster_name"
+make tf ARGS="output -raw storage_bucket_name"
+make tf ARGS="state list"
+make tf ARGS="state list module.gke_cluster"   # filter state to one module
+make tf ARGS="validate"
+make tf ARGS="refresh"
+```
+
+`make tf ARGS="..."` is exactly `terraform -chdir=infra ...`, so you can also run terraform directly from `modules/gcp/infra` if you prefer.
 
 ---
 

--- a/modules/gcp/infra/scripts/status.sh
+++ b/modules/gcp/infra/scripts/status.sh
@@ -185,8 +185,8 @@ if [[ -d "$INFRA_DIR/.terraform" ]]; then
   pass "terraform init — done"
 else
   fail "terraform init — not run"
-  action "terraform -chdir=infra init"
-  set_next "terraform -chdir=infra init"
+  action "make init"
+  set_next "make init"
 fi
 
 _tf_output=""
@@ -214,8 +214,8 @@ if [[ -n "$_tf_output" ]] && echo "$_tf_output" | grep -q '"cluster_name"'; then
 else
   fail "terraform output — empty (no state file or infra not yet applied)"
   info "If infra was applied from another machine, configure a GCS remote backend."
-  action "terraform -chdir=infra init  (if using a remote backend)"
-  action "terraform -chdir=infra apply  (if starting fresh)"
+  action "make init  (if using a remote backend)"
+  action "make apply  (if starting fresh)"
   set_next "Resolve terraform state — see section 5"
 fi
 
@@ -354,20 +354,20 @@ else
       action "helm rollback langsmith -n ${_NAMESPACE}"
     elif [[ "$_helm_status" == "pending-install" ]]; then
       fail "Helm release: langsmith — stuck in pending-install (interrupted install)"
-      action "helm uninstall langsmith -n ${_NAMESPACE}  then re-run ./helm/scripts/deploy.sh"
+      action "helm uninstall langsmith -n ${_NAMESPACE}  then re-run make deploy"
     elif [[ "$_helm_status" == "failed" ]]; then
       warn "Helm release: langsmith — status 'failed' (likely a prior --wait timeout)"
       info "Pods may still be running — Helm marks failed if --wait times out"
       [[ -n "$_helm_version" ]] && info "Chart: ${_helm_version}"
-      action "Re-run ./helm/scripts/deploy.sh  (upgrades over the failed release)"
+      action "Re-run make deploy  (upgrades over the failed release)"
     else
       warn "Helm release: langsmith — status: ${_helm_status}"
-      action "./helm/scripts/deploy.sh"
+      action "make deploy"
     fi
   else
     skip "Helm release: langsmith — not installed"
-    action "./helm/scripts/deploy.sh"
-    set_next "./helm/scripts/deploy.sh"
+    action "make deploy"
+    set_next "make deploy"
   fi
 
   # Pod health


### PR DESCRIPTION
Make targets across the AWS, GCP, and Azure modules now pass extra flags down to terraform, and `make help` explains how. Previously any flag terraform accepts meant dropping out of `make` and running `terraform -chdir=infra ...` by hand. `make status` now recommends the make targets too, instead of the raw commands it had been printing.

## Terraform flag passthrough

Every terraform invocation appends `$(ARGS)`, reusing the `ARGS` convention already established by the AWS `test-permutations` target:

```bash
make init    ARGS="-upgrade"               # re-resolve provider versions
make plan    ARGS="-target=module.eks"     # plan one module
make plan    ARGS="-out=tfplan"            # save a plan file
make apply   ARGS="tfplan"                 # apply that saved plan
make apply   ARGS="-auto-approve"          # skip the approval prompt
make destroy ARGS="-target=module.redis"   # destroy one module
```

A new `tf` target covers the subcommands the named targets do not, so `terraform output`, `state list`, and `validate` no longer require remembering `-chdir`:

```bash
make tf ARGS="output -raw cluster_name"
make tf ARGS="state list"
make tf ARGS="validate"
```

The docs pointed at raw `terraform -chdir=infra ...` in roughly 20 places. The AWS and GCP "Terraform Commands" sections now lead with the make forms, Azure gained the section it lacked, and `modules/aws/COMMANDS.md` documents `ARGS` plus the new target.

## Azure apply is the one exception

Azure `apply` runs three targeted stages and passes `ARGS` to each, which suits `-var`, `-parallelism`, and `-refresh=false`. Two forms do not work there:

- A saved plan file, because terraform rejects a plan-file positional combined with the stages' hardcoded `-target` flags.
- `-target`, because it is additive with those hardcoded targets rather than narrowing them.

For both, bypass the staging with `make tf ARGS="apply tfplan"`. The Azure `make help` output and `modules/azure/QUICK_REFERENCE.md` both carry this caveat and omit `make apply ARGS="tfplan"` from their examples. AWS and GCP `apply` are single-shot, so both forms work as documented there.

## make status recommends make targets

`make status` exists to tell users what to run next, but it printed raw terraform and script paths that the make targets already wrap. Two of those were wrong rather than merely inconsistent.

| Module | Was | Now | Why |
|---|---|---|---|
| azure ×3 | `bash infra/setup-env.sh` | `make setup-env` | That path does not exist. The script is at `infra/scripts/setup-env.sh`, so copy-pasting the printed command failed. |
| azure ×2 | `terraform -chdir=infra apply` | `make apply` | Single-shot apply bypasses the three staged, targeted applies the Azure module requires. The same file already said `make apply` elsewhere. |
| aws, gcp ×7 | `terraform -chdir=infra init` | `make init` | Includes the remote-backend reconnect branch |
| aws, gcp ×2 | `terraform -chdir=infra apply` | `make apply` | The "if starting fresh" branch |
| aws, gcp ×11 | `./helm/scripts/deploy.sh` | `make deploy` | Both Makefiles define `deploy` as exactly `$(HELM_DIR)/scripts/deploy.sh` |

Each `set_next` is paired with an `action` line printing the same string, so both change together. Changing only `set_next` would leave the section body teaching the raw form while the Next Step block teaches make.

Three cases stay raw on purpose:

- `source infra/scripts/setup-env.sh` (aws, gcp), because Make cannot export into the calling shell
- `aws eks update-kubeconfig` and `gcloud container clusters get-credentials`, which interpolate the live cluster name and region. AWS `make kubeconfig` only prints the command anyway.
- The `helm rollback` and `helm uninstall` hints, which have no make target

## Additional fixes

| File | Fix |
|---|---|
| `modules/gcp/QUICK_REFERENCE.md` | `state show module.<name>` errors on multi-resource addresses, now `state list module.<name>` |
| `modules/aws/COMMANDS.md` | header said `terraform/aws/`, actual path is `modules/aws/` |
| `modules/azure/Makefile` | `.PHONY` was missing `destroy-force` and `clean-force` |
| `modules/aws/Makefile` | `make help` usage banner said `ARGS="<extra terraform flags>"`, but `test-permutations` and `test-parallel` take a test subset (`ARGS="1 2 5"`). The banner is now flag-neutral and the test form has its own example. |

## Verification

`make -n` on every changed target across all three modules confirms `ARGS` expands into the right position. `make help` renders and exits 0 in all three.

`bash -n` and `shellcheck -S warning` are clean on all three `status.sh` scripts.

Every terraform output name referenced in the docs (`cluster_name`, `alb_dns_name`, `langsmith_irsa_role_arn`, `bucket_name`, `storage_bucket_name`, `keyvault_name`, `aks_cluster_name`, `dns_nameservers`) was checked against the real `outputs.tf`.

No `.tf` files changed, so the `terraform fmt` and `validate` CI job is unaffected. `byoc` and `ocp` have no Makefile and are unaffected.

Merged `main` after #133 landed. That PR rewrote the Azure `apply` docstring and Stage 3 echo when it dropped the dns01 ClusterIssuer, conflicting with this branch's `ARGS` edit on the same lines. Resolution keeps #133's wording and adds `$(ARGS)` to all three staged applies.
