### PR TITLE
feat(azure): catch permission and offer-type blockers in preflight

### DIFF
--- a/modules/azure/Makefile
+++ b/modules/azure/Makefile
@@ -45,6 +45,9 @@ setup-env: ## Bootstrap secrets → secrets.auto.tfvars (prompts on first run, r
 preflight: ## Run Azure pre-flight checks (login, providers, RBAC, terraform.tfvars)
 	cd $(INFRA_DIR) && bash scripts/preflight.sh
 
+test-preflight: ## Run the pre-flight RBAC tests (stubbed az, no Azure account needed)
+	python3 $(INFRA_DIR)/scripts/test-preflight-rbac.py
+
 init: ## terraform init (infra)
 	terraform -chdir=$(INFRA_DIR) init
 

--- a/modules/azure/PERMISSIONS.md
+++ b/modules/azure/PERMISSIONS.md
@@ -1,0 +1,93 @@
+# Azure permissions
+
+The identity that runs `terraform apply` needs two kinds of access: permission to create resources, and permission to create role assignments. Contributor grants the first and not the second, so a Contributor-only identity builds most of the deployment and then fails partway through with a 403.
+
+## Required roles
+
+Grant one of these combinations to the deploying identity at subscription scope:
+
+| Roles | Role definition ID | Covers |
+|-------|-------------------|--------|
+| `Owner` | `8e3af657-a8ff-443c-a75c-2fe8c4bcb635` | Everything, including role assignments |
+| `Contributor` + `Role Based Access Control Administrator` | `b24988ac-6180-42a0-ab88-20f7382dd24c`, `f58310d9-a9f6-439a-9e8d-f62e7b41a168` | Preferred least-privilege pairing |
+| `Contributor` + `User Access Administrator` | `b24988ac-6180-42a0-ab88-20f7382dd24c`, `18d7d88d-d35e-4fb5-a5c3-7773c20a72d9` | Equivalent, broader than the pairing above |
+
+Resource group scope is enough only if the resource group already exists and you set it in `terraform.tfvars`. The deployment creates its own resource group by default, which requires subscription scope.
+
+`Role Based Access Control Administrator` is the narrower of the two role-assignment roles. It grants `Microsoft.Authorization/roleAssignments/write` without the broader access-management rights that `User Access Administrator` carries.
+
+## Verify access before the first apply
+
+Run `make preflight` for the automated version of this check. It resolves the identity Terraform will authenticate as, confirms that identity can write role assignments, and reports PIM-eligible roles, ABAC conditions, and deny assignments. Use the manual probe below to inspect a specific action or a principal other than your own.
+
+Checking for a role by name misses three cases: assignments inherited from a management group, ABAC conditions that restrict which roles you may grant, and deny assignments. The `checkAccess` API evaluates all three and returns the effective decision.
+
+```bash
+SUB=$(az account show --query id -o tsv)
+OID=$(az ad signed-in-user show --query id -o tsv)
+
+cat > /tmp/checkaccess.json <<JSON
+{
+  "subject": { "attributes": { "ObjectId": "$OID" } },
+  "actions": [
+    { "id": "Microsoft.Authorization/roleAssignments/write", "isDataAction": false },
+    { "id": "Microsoft.KeyVault/vaults/write", "isDataAction": false },
+    { "id": "Microsoft.ContainerService/managedClusters/write", "isDataAction": false },
+    { "id": "Microsoft.DBforPostgreSQL/flexibleServers/write", "isDataAction": false },
+    { "id": "Microsoft.ManagedIdentity/userAssignedIdentities/write", "isDataAction": false }
+  ]
+}
+JSON
+
+az rest --method post \
+  --url "https://management.azure.com/subscriptions/${SUB}/providers/Microsoft.Authorization/checkAccess?api-version=2018-09-01-preview" \
+  --headers "Content-Type=application/json" \
+  --body @/tmp/checkaccess.json \
+  --query "[].{action:actionId, decision:accessDecision, condition:roleAssignment.condition, deny:denyAssignment}" \
+  -o table
+```
+
+Every row must read `Allowed`. A populated `condition` or `deny` column means the grant is restricted even when the decision is `Allowed`, so read those columns rather than the decision alone.
+
+For a service principal, replace the `az ad signed-in-user show` call with the principal's object ID. Note that `2018-09-01-preview` is the only api-version this endpoint supports.
+
+## Role assignments created during deployment
+
+The deployment creates the following assignments. Each one requires `Microsoft.Authorization/roleAssignments/write` at the listed scope.
+
+| Role granted | Role definition ID | Scope | Grantee | Created when |
+|--------------|-------------------|-------|---------|--------------|
+| `Key Vault Secrets Officer` | `b86a8fe4-44ce-4948-aee5-eccb2c155cd7` | Key Vault | The deploying identity | Always |
+| `Key Vault Secrets User` | `4633458b-17de-408a-b874-0445c86b69e6` | Key Vault | Pod managed identity | Always |
+| `Storage Blob Data Contributor` | `ba92f5b4-2d11-453d-a403-e96b0029c9fe` | Storage account | Pod managed identity | Always |
+| `DNS Zone Contributor` | `befefa01-2a29-4197-83a8-272ff33ce314` | DNS zone | cert-manager identity | `cert_manager_principal_id` is set |
+| `Reader` | `acdd72a7-3385-48ef-bd42-f606fba81ae7` | Resource group | AGIC identity | `ingress_controller = "agic"` |
+| `Contributor` | `b24988ac-6180-42a0-ab88-20f7382dd24c` | Application Gateway | AGIC identity | `ingress_controller = "agic"` |
+| `Network Contributor` | `4d97b98b-1d4f-4787-a291-c67834d212e7` | Virtual network | AGIC identity | `ingress_controller = "agic"` |
+| `Virtual Machine Administrator Login` | `1c0163c0-47e6-4577-8991-ea5c82e286e4` | Bastion VM | Operators | Bastion module is enabled |
+
+The Key Vault assignment to the deploying identity is self-granting: Terraform gives itself `Key Vault Secrets Officer` so that it can then write the application secrets through the Key Vault data plane. The vault runs in RBAC mode, so no access policy path exists as a fallback.
+
+## Restrict which roles the deployer can assign
+
+Security teams that will not grant unconditional role-assignment rights can attach an ABAC condition to `Role Based Access Control Administrator` that allows only the role definition IDs in the preceding table. Include every ID that applies to your configuration. A condition that omits one produces a partial deployment: assignments for the allowed roles succeed, and the first disallowed role returns 403 while earlier resources remain created.
+
+## Resolve AuthorizationFailed on a role assignment
+
+A failure that names `Microsoft.Authorization/roleAssignments/write` means the deploying identity cannot create role assignments at that scope:
+
+```text
+Error: unexpected status 403 (403 Forbidden) with error: AuthorizationFailed:
+The client '<user>' with object id '<oid>' does not have authorization to
+perform action 'Microsoft.Authorization/roleAssignments/write' over scope
+'<scope>' or the scope is invalid.
+```
+
+Work through these causes in order:
+
+1. **The identity holds Contributor only.** Add `Role Based Access Control Administrator` at subscription scope. This is the common case.
+2. **A condition restricts which roles the identity may assign.** Suspect this when one assignment succeeds and another on the same scope fails, because the two differ only by role definition. Run the `checkAccess` probe and read the `condition` field.
+3. **A deny assignment blocks the write.** Deny assignments override role assignments and appear in the `denyAssignment` field of the probe output. Azure Blueprints and managed application lock-downs both create them.
+4. **The grant has not propagated.** Role assignments take one to three minutes to take effect. If access was granted in the last few minutes, run `az account get-access-token --query expiresOn` to confirm the token predates the grant, then re-authenticate with `az login`.
+
+After granting the missing role, re-run `terraform apply`. The run is resumable, and resources created before the failure stay in state.

--- a/modules/azure/README.md
+++ b/modules/azure/README.md
@@ -302,13 +302,15 @@ Catches the most common problems before you spend 20 minutes on a failing `terra
 - Prints the active subscription — prompts you to verify it is correct
 - Validates 11 required Azure resource providers are registered (`Microsoft.ContainerService`, `Microsoft.DBforPostgreSQL`, `Microsoft.Cache`, `Microsoft.KeyVault`, `Microsoft.Storage`, and others)
 - Reports which identity Terraform will authenticate as, since `ARM_CLIENT_ID`, `ARM_USE_MSI`, and `ARM_USE_OIDC` take precedence over your `az login`, and fails if `ARM_SUBSCRIPTION_ID` or `ARM_TENANT_ID` disagrees with the active `az` account
-- Checks RBAC by permission rather than by role name: resolves every role that identity holds (including grants inherited from a management group or held through a group) and confirms one of them grants `Microsoft.Authorization/roleAssignments/write`, which the eight role assignments in the storage, Key Vault, DNS, bastion, and AKS modules need. Also reports PIM-eligible-but-inactive roles, ABAC conditions that narrow which roles you may assign, and deny assignments that override every grant
+- Checks RBAC by asking ARM for the decision rather than by matching role names. For that identity, at the subscription, at the resource group the deployment creates, and at a bring-your-own VNet if one is configured, it asks whether `Microsoft.Authorization/roleAssignments/write` and eight resource-creation actions are permitted. `roleAssignments/write` is what the eight role assignments in the storage, Key Vault, DNS, bastion, and AKS modules need. Deny assignments and ABAC conditions are already applied in the answer, so a refusal names the deny assignment when there is one, and a grant that carries a condition is flagged because the condition can still reject the specific roles the modules assign. A refusal is cross-checked against PIM, so a role held but not activated reads as "activate it" rather than "you do not have it"
 - Checks the subscription offer type and warns when it is one Azure blocks from provisioning PostgreSQL Flexible Server in high-demand regions, which surfaces as `LocationIsOfferRestricted` well into a long apply
 - Verifies `terraform.tfvars` exists with `location` and `subscription_id` set
 - Verifies `secrets.auto.tfvars` exists and has a non-empty `langsmith_license_key`
 - Checks that `terraform`, `kubectl`, and `helm` binaries are on PATH
 
 > Safe to run at any time with no side effects.
+
+The RBAC verdict comes from `Microsoft.Authorization/checkAccess`, the call the portal's Access control blade makes. It is a preview API with no published specification, so if it stops answering, preflight says so and drops back to checking for Owner or User Access Administrator by name. That fallback cannot see deny assignments, ABAC conditions, or custom roles, so a clean result on it is weaker than a clean result on the primary path. The script tells you which one you got.
 
 ---
 

--- a/modules/azure/README.md
+++ b/modules/azure/README.md
@@ -75,6 +75,8 @@ The identity running Terraform needs the following roles on the subscription:
 
 Owner includes both. Contributor alone is insufficient (role assignments require UAA).
 
+Holding the role is not the same as being able to use it. A PIM-eligible role grants nothing until it is activated, an ABAC condition on the grant can restrict which roles you may assign, and a deny assignment from a landing zone or managed application overrides every grant including Owner. `make preflight` reports all three, so run it rather than reasoning from the role list in the portal.
+
 ### Authenticate
 
 ```bash
@@ -297,7 +299,8 @@ Catches the most common problems before you spend 20 minutes on a failing `terra
 - Checks `az` CLI version and confirms you are logged in
 - Prints the active subscription — prompts you to verify it is correct
 - Validates 11 required Azure resource providers are registered (`Microsoft.ContainerService`, `Microsoft.DBforPostgreSQL`, `Microsoft.Cache`, `Microsoft.KeyVault`, `Microsoft.Storage`, and others)
-- Checks RBAC: requires **Contributor** + **User Access Administrator** (or **Owner**) at subscription scope — needed for role assignments in the Key Vault, storage, and WAF modules
+- Reports which identity Terraform will authenticate as, since `ARM_CLIENT_ID`, `ARM_USE_MSI`, and `ARM_USE_OIDC` take precedence over your `az login`, and fails if `ARM_SUBSCRIPTION_ID` or `ARM_TENANT_ID` disagrees with the active `az` account
+- Checks RBAC by permission rather than by role name: resolves every role that identity holds (including grants inherited from a management group or held through a group) and confirms one of them grants `Microsoft.Authorization/roleAssignments/write`, which the eight role assignments in the storage, Key Vault, DNS, bastion, and AKS modules need. Also reports PIM-eligible-but-inactive roles, ABAC conditions that narrow which roles you may assign, and deny assignments that override every grant
 - Verifies `terraform.tfvars` exists with `location` and `subscription_id` set
 - Verifies `secrets.auto.tfvars` exists and has a non-empty `langsmith_license_key`
 - Checks that `terraform`, `kubectl`, and `helm` binaries are on PATH

--- a/modules/azure/README.md
+++ b/modules/azure/README.md
@@ -71,11 +71,13 @@ The identity running Terraform needs the following roles on the subscription:
 | Role | Purpose |
 |------|---------|
 | `Contributor` | Create and manage all Azure resources |
-| `User Access Administrator` | Create role assignments for Key Vault, Blob, cert-manager managed identities |
+| `Role Based Access Control Administrator` | Create role assignments for Key Vault, Blob, and cert-manager managed identities |
 
-Owner includes both. Contributor alone is insufficient (role assignments require UAA).
+`Owner` covers both. `User Access Administrator` works in place of `Role Based Access Control Administrator` but grants more than the deployment needs. Contributor alone is insufficient: the deployment creates eight role assignments and fails partway through without one of the role-assignment roles.
 
 Holding the role is not the same as being able to use it. A PIM-eligible role grants nothing until it is activated, an ABAC condition on the grant can restrict which roles you may assign, and a deny assignment from a landing zone or managed application overrides every grant including Owner. `make preflight` reports all three, so run it rather than reasoning from the role list in the portal.
+
+For the full permission inventory, the role assignments the deployment creates, and how to restrict which roles the deployer may assign, refer to [PERMISSIONS.md](PERMISSIONS.md).
 
 ### Authenticate
 
@@ -301,6 +303,7 @@ Catches the most common problems before you spend 20 minutes on a failing `terra
 - Validates 11 required Azure resource providers are registered (`Microsoft.ContainerService`, `Microsoft.DBforPostgreSQL`, `Microsoft.Cache`, `Microsoft.KeyVault`, `Microsoft.Storage`, and others)
 - Reports which identity Terraform will authenticate as, since `ARM_CLIENT_ID`, `ARM_USE_MSI`, and `ARM_USE_OIDC` take precedence over your `az login`, and fails if `ARM_SUBSCRIPTION_ID` or `ARM_TENANT_ID` disagrees with the active `az` account
 - Checks RBAC by permission rather than by role name: resolves every role that identity holds (including grants inherited from a management group or held through a group) and confirms one of them grants `Microsoft.Authorization/roleAssignments/write`, which the eight role assignments in the storage, Key Vault, DNS, bastion, and AKS modules need. Also reports PIM-eligible-but-inactive roles, ABAC conditions that narrow which roles you may assign, and deny assignments that override every grant
+- Checks the subscription offer type and warns when it is one Azure blocks from provisioning PostgreSQL Flexible Server in high-demand regions, which surfaces as `LocationIsOfferRestricted` well into a long apply
 - Verifies `terraform.tfvars` exists with `location` and `subscription_id` set
 - Verifies `secrets.auto.tfvars` exists and has a non-empty `langsmith_license_key`
 - Checks that `terraform`, `kubectl`, and `helm` binaries are on PATH

--- a/modules/azure/TROUBLESHOOTING.md
+++ b/modules/azure/TROUBLESHOOTING.md
@@ -124,6 +124,56 @@ Validated: full pass 2–5 deploy (production sizing, all addons) ran successful
 
 ---
 
+### LocationIsOfferRestricted — Postgres Flexible Server blocked in the region
+
+**Symptom:** AKS and the ingress controller create successfully, then Postgres fails several minutes into the apply:
+
+```text
+Error: creating Flexible Server ...: polling after CreateOrUpdate: polling failed:
+Status: "LocationIsOfferRestricted"
+Message: "Subscriptions are restricted from provisioning in location 'eastus'.
+Try again in a different location."
+```
+
+**Cause:** This is a subscription offer-type restriction, not regional capacity and not a configuration error. Azure blocks certain offer types (Free Trial, Azure Pass, Visual Studio and MSDN credit, some sponsored and CSP subscriptions) from provisioning PostgreSQL Flexible Server in high-demand regions. The error text points at the region, which sends most people hunting for a new one, but the subscription is what determines the outcome.
+
+Check the offer type:
+
+```bash
+SUB=$(az account show --query id -o tsv)
+az rest --method get \
+  --url "https://management.azure.com/subscriptions/${SUB}?api-version=2022-12-01" \
+  --query "subscriptionPolicies.quotaId" -o tsv
+```
+
+`PayAsYouGo_*` and `EnterpriseAgreement_*` are unrestricted. `FreeTrial_*`, `MSDN_*`, `MSDNDevTest_*`, `VisualStudio_*`, `AzurePass_*`, `MPN_*`, and `SponsoredMS_*` are the restricted families. `make preflight` reports this before the apply starts.
+
+**Fixes, in order of preference:**
+
+1. **Convert the subscription to Pay-As-You-Go.** For a trial or credit-based subscription this removes the restriction outright, with no ticket and no configuration change.
+2. **Request an exemption** at [aka.ms/postgres-request-quota-increase](https://aka.ms/postgres-request-quota-increase), quota type "Azure Database for PostgreSQL Flexible Server". Requests for offer restrictions are frequently approved the same day, and the region and SKU stay as configured.
+3. **Try a different tier.** Restrictions are sometimes scoped to a SKU family. Set `postgres_sku_name = "GP_Standard_D2ds_v5"` in `terraform.tfvars` and re-apply. This is worth one attempt rather than an expectation.
+4. **Use in-cluster Postgres** for a dev or demo deployment. Set `postgres_source = "in-cluster"` and the Helm chart runs its own Postgres pod, so nothing is provisioned through the PostgreSQL resource provider. Not suitable for production.
+5. **Change the region.** Set `location` in `terraform.tfvars`. Because Postgres uses a delegated subnet it must sit in the same region as the VNet, so the whole deployment moves. Any resources already created are destroyed and recreated.
+
+---
+
+### AuthorizationFailed on roleAssignments/write
+
+**Symptom:** Resources create normally, then a role assignment fails with 403:
+
+```text
+Error: unexpected status 403 (403 Forbidden) with error: AuthorizationFailed:
+The client '<user>' with object id '<oid>' does not have authorization to
+perform action 'Microsoft.Authorization/roleAssignments/write' over scope '<scope>'
+```
+
+**Cause:** The deploying identity holds Contributor but no role-assignment role. Contributor cannot create role assignments, and the deployment creates eight of them.
+
+**Fix:** Grant `Role Based Access Control Administrator` at subscription scope, or `Owner` in place of both roles. When one role assignment succeeds and another on the same scope fails, an ABAC condition is restricting which role definitions the identity may grant. For the full permission inventory, the `checkAccess` probe, and how to read the condition, refer to [PERMISSIONS.md](PERMISSIONS.md).
+
+---
+
 ### Istio addon revision not supported
 
 **Symptom:**

--- a/modules/azure/infra/main.tf
+++ b/modules/azure/infra/main.tf
@@ -163,6 +163,7 @@ module "postgres" {
   admin_username = var.postgres_admin_username
   admin_password = var.postgres_admin_password
   database_name  = var.postgres_database_name
+  sku_name       = var.postgres_sku_name
 
   availability_zone            = var.availability_zones[0]
   standby_availability_zone    = var.postgres_standby_availability_zone

--- a/modules/azure/infra/scripts/preflight.sh
+++ b/modules/azure/infra/scripts/preflight.sh
@@ -463,7 +463,7 @@ if [ -z "$QUOTA_ID" ]; then
   warn "Could not read the subscription offer type — skipping offer restriction check"
 else
   case "$QUOTA_ID" in
-    FreeTrial_*|MSDN_*|MSDNDevTest_*|VisualStudio_*|AzurePass_*|MPN_*|SponsoredMS_*)
+    FreeTrial_*|MSDN_*|MSDNDevTest_*|VisualStudio_*|AzurePass_*|MPN_*|Sponsored_*)
       warn "Subscription offer type is ${QUOTA_ID}."
       warn "Offer types like this are commonly blocked from provisioning PostgreSQL"
       warn "Flexible Server in high-demand regions (LocationIsOfferRestricted)."

--- a/modules/azure/infra/scripts/preflight.sh
+++ b/modules/azure/infra/scripts/preflight.sh
@@ -12,7 +12,8 @@
 #   2. Correct subscription is selected
 #   3. Required resource providers are registered
 #   4. The identity Terraform will use can write role assignments
-#   5. terraform.tfvars exists with required fields populated
+#   5. Subscription offer type is not blocked from provisioning Postgres
+#   6. terraform.tfvars exists with required fields populated
 #
 # Run before: terraform init / terraform apply
 # Usage: bash infra/scripts/preflight.sh
@@ -469,7 +470,37 @@ $RBAC_VERDICT
 EOF
 fi
 
-# ── 5. terraform.tfvars ───────────────────────────────────────────────────────
+# ── 5. Subscription offer type ────────────────────────────────────────────────
+# Azure blocks some subscription offer types from provisioning PostgreSQL
+# Flexible Server in high-demand regions, surfacing as LocationIsOfferRestricted
+# well into the apply, after AKS has already been built. The restriction is a
+# property of how the subscription was bought, not of regional capacity, so no
+# amount of retrying or resizing clears it. quotaId is the only field that
+# reports the offer type, and it is a prefix match: the suffix is a signup date.
+echo ""
+echo "── Subscription Offer Type ───────────────────────────"
+QUOTA_ID=$(az rest --method get \
+  --url "https://management.azure.com/subscriptions/${SUB_ID_CHECK}?api-version=2022-12-01" \
+  --query "subscriptionPolicies.quotaId" -o tsv 2>/dev/null || echo "")
+
+if [ -z "$QUOTA_ID" ]; then
+  warn "Could not read the subscription offer type — skipping offer restriction check"
+else
+  case "$QUOTA_ID" in
+    FreeTrial_*|MSDN_*|MSDNDevTest_*|VisualStudio_*|AzurePass_*|MPN_*|SponsoredMS_*)
+      warn "Subscription offer type is ${QUOTA_ID}."
+      warn "Offer types like this are commonly blocked from provisioning PostgreSQL"
+      warn "Flexible Server in high-demand regions (LocationIsOfferRestricted)."
+      warn "Request an exemption at https://aka.ms/postgres-request-quota-increase,"
+      warn "or set postgres_source = \"in-cluster\" for a dev deployment."
+      ;;
+    *)
+      pass "Subscription offer type: ${QUOTA_ID}"
+      ;;
+  esac
+fi
+
+# ── 6. terraform.tfvars ───────────────────────────────────────────────────────
 echo ""
 echo "── Terraform Config ──────────────────────────────────"
 TFVARS="${INFRA_DIR}/terraform.tfvars"
@@ -505,7 +536,7 @@ else
   fi
 fi
 
-# ── 6. Other tooling ──────────────────────────────────────────────────────────
+# ── 7. Other tooling ──────────────────────────────────────────────────────────
 echo ""
 echo "── Tooling ───────────────────────────────────────────"
 for TOOL in terraform kubectl helm; do

--- a/modules/azure/infra/scripts/preflight.sh
+++ b/modules/azure/infra/scripts/preflight.sh
@@ -111,13 +111,20 @@ fi
 # directory read, which plenty of deployers are not granted. Without an object
 # ID there is no assignee to query, so the RBAC block below degrades to a
 # warning rather than reporting a verdict it cannot support.
+# PRINCIPAL_IS_CALLER records whether the resolved principal is the identity
+# running this script. Only that identity's PIM eligibilities are readable, so
+# without the flag an eligible-but-inactive role held by the operator would be
+# reported as if it belonged to the service principal Terraform will use.
 PRINCIPAL_ID=""
+PRINCIPAL_IS_CALLER=1
 if [ -n "${ARM_CLIENT_ID:-}" ]; then
   PRINCIPAL_KIND="service principal from ARM_CLIENT_ID"
   PRINCIPAL_ID=$(az ad sp show --id "$ARM_CLIENT_ID" --query id -o tsv 2>/dev/null || echo "")
+  PRINCIPAL_IS_CALLER=0
   warn "ARM_CLIENT_ID is set — Terraform authenticates as that service principal, not as your az login"
 elif [ "${ARM_USE_MSI:-}" = "true" ] || [ "${ARM_USE_OIDC:-}" = "true" ]; then
   PRINCIPAL_KIND="managed identity or OIDC federation"
+  PRINCIPAL_IS_CALLER=0
   warn "ARM_USE_MSI or ARM_USE_OIDC is set — Terraform authenticates as a workload identity this script cannot resolve"
 elif [ "$(az account show --query user.type -o tsv 2>/dev/null || echo "")" = "servicePrincipal" ]; then
   PRINCIPAL_KIND="service principal from az login"
@@ -138,13 +145,19 @@ fi
 # Eight resources across the Azure modules create role assignments (storage,
 # keyvault ×2, dns, bastion, k8s-cluster ×3), so
 # Microsoft.Authorization/roleAssignments/write decides whether apply finishes.
-# Looking for the role names "Owner" and "User Access Administrator" does not
-# decide it, in either direction: a custom role can carry the action, an ABAC
+# Reconstructing that answer from role definitions cannot get it right: an ABAC
 # condition can restrict which roles a delegate may assign, a deny assignment
-# overrides every grant including Owner, PIM-eligible roles grant nothing until
-# activated, and a grant inherited from a management group or held through a
-# group carries the same weight as a direct one. So read the role definitions
-# behind the assignments and the deny assignments that override them.
+# overrides every grant including Owner, a PIM-eligible role grants nothing until
+# activated, and a custom role can carry the action under any name. So ask ARM
+# for the decision it will actually make, per action and per scope.
+#
+# checkAccess is the call the portal makes to decide which buttons to grey out.
+# It is also undocumented: nothing in azure-rest-api-specs, no az command, and
+# 2018-09-01-preview is the only api-version ever registered. What it does that
+# nothing documented can: evaluate a named principal (not just the caller) at a
+# scope that does not exist yet, with deny assignments and conditions already
+# applied. A missing or reshaped response is therefore treated as unavailable and
+# degrades to a role-name check, never as a verdict.
 echo ""
 echo "── RBAC Roles ────────────────────────────────────────"
 
@@ -154,157 +167,126 @@ trap 'rm -rf "$RBAC_TMP"' EXIT
 if [ -z "$PRINCIPAL_ID" ] || [ -z "$SUB_ID_CHECK" ]; then
   warn "Skipping RBAC check — no principal object ID to query"
 else
-  # Two queries, because neither direction is a superset of the other. ARM's
-  # atScope() filter returns assignments at and above a scope, so the first call
-  # is the only one that reports a grant inherited from a management group; --all
-  # drops the scope filter entirely, so it is the only one that reports a grant
-  # made below the subscription on a resource group. --include-inherited is what
-  # keeps the above-subscription results in the first call, and has no effect on
-  # the second (--all sends no scope for anything to be inherited from).
-  # --include-groups makes the server filter transitive through group membership,
-  # and --assignee-object-id skips the Graph lookup --assignee would need.
-  ASSIGNMENTS_READ=1
-  az role assignment list \
-    --scope "/subscriptions/${SUB_ID_CHECK}" \
-    --include-inherited \
-    --assignee-object-id "$PRINCIPAL_ID" \
-    --include-groups \
-    -o json > "${RBAC_TMP}/at-and-above.json" 2>/dev/null || ASSIGNMENTS_READ=0
-  az role assignment list \
-    --all \
-    --assignee-object-id "$PRINCIPAL_ID" \
-    --include-groups \
-    -o json > "${RBAC_TMP}/at-and-below.json" 2>/dev/null || ASSIGNMENTS_READ=0
+  # Every scope the deployment writes a role assignment at is knowable before
+  # apply. The subscription covers everything created beneath it by inheritance.
+  # The resource group is where every LangSmith resource lands, and one of the
+  # AGIC assignments names it literally. A bring-your-own VNet can sit in a
+  # platform-managed resource group, which is where a landing zone puts its deny
+  # assignments, so it gets checked on its own when one is configured.
+  #
+  # Both values come out of terraform.tfvars and end up in a request URL, so each
+  # is held to the pattern its Terraform variable already validates and dropped
+  # if it does not fit. An unchecked value here could aim the request elsewhere.
+  TFVARS_FILE="${INFRA_DIR}/terraform.tfvars"
 
-  # Merged into one list so the evaluation below reads a single file. The
-  # subscription scope itself answers both queries, hence the dedupe.
-  python3 - "${RBAC_TMP}/at-and-above.json" "${RBAC_TMP}/at-and-below.json" \
-    > "${RBAC_TMP}/assignments.json" <<'PY' || ASSIGNMENTS_READ=0
-import json, sys
+  # An absent key is a valid answer (every variable read here has a default), so
+  # the trailing || true keeps a no-match grep from tripping set -e.
+  tfvar() {
+    [ -f "$TFVARS_FILE" ] || return 0
+    grep -E "^[[:space:]]*$1[[:space:]]*=" "$TFVARS_FILE" 2>/dev/null | head -1 | cut -d'"' -f2 || true
+  }
 
-seen, merged = set(), []
-for path in sys.argv[1:]:
-    try:
-        with open(path) as fh:
-            entries = json.load(fh) or []
-    except (OSError, ValueError):
-        continue
-    for entry in entries:
-        key = entry.get("id") or json.dumps(entry, sort_keys=True)
-        if key in seen:
-            continue
-        seen.add(key)
-        merged.append(entry)
-print(json.dumps(merged))
-PY
+  SCOPES=("/subscriptions/${SUB_ID_CHECK}")
 
-  # Eligible-but-inactive PIM roles are absent from the list above, which is why
-  # a deployer who "has Owner" can still be denied. Fetching them here turns the
-  # failure message from "you lack the role" into "activate the role you hold".
-  # asTarget() reports eligibilities for the calling identity only, so this is
-  # empty (harmlessly) when Terraform runs as a service principal.
-  az rest --method get \
-    --url "https://management.azure.com/subscriptions/${SUB_ID_CHECK}/providers/Microsoft.Authorization/roleEligibilityScheduleInstances?api-version=2020-10-01&\$filter=asTarget()" \
-    -o json > "${RBAC_TMP}/eligibilities.json" 2>/dev/null || echo "{}" > "${RBAC_TMP}/eligibilities.json"
-
-  # atScope() returns deny assignments at or above the subscription, which is
-  # where landing-zone blueprints and managed applications put them. Two kinds
-  # stay invisible and surface as a 403 at apply: one created directly on a
-  # resource group that does not exist yet, and one that names a group this
-  # principal belongs to rather than the principal itself (the matching below
-  # reads principal IDs, and resolving group membership needs a directory read
-  # this account may not have).
-  az rest --method get \
-    --url "https://management.azure.com/subscriptions/${SUB_ID_CHECK}/providers/Microsoft.Authorization/denyAssignments?api-version=2022-04-01&\$filter=atScope()" \
-    -o json > "${RBAC_TMP}/deny.json" 2>/dev/null || DENY_READ=0
-
-  # A failed read is not an empty result. Reporting "no roles found" when the
-  # query itself was refused would send the operator to their tenant admin for
-  # a grant they may already hold, so say which read failed and stop instead.
-  if [ "$ASSIGNMENTS_READ" -eq 0 ]; then
-    warn "Could not list role assignments for this principal — skipping the RBAC verdict rather than reading a failed query as \"no access\""
-  fi
-  if [ "${DENY_READ:-1}" -eq 0 ]; then
-    echo "{}" > "${RBAC_TMP}/deny.json"
-    warn "Could not read deny assignments (needs Microsoft.Authorization/denyAssignments/read). One that blocks roleAssignments/write would be invisible here and would override every role grant below."
+  # printf adds the newline grep needs to see an empty identifier as a line to
+  # match rather than as no input at all. Empty is valid: it means no suffix.
+  IDENTIFIER=$(tfvar identifier)
+  if printf '%s\n' "$IDENTIFIER" | grep -qE '^(-[a-z0-9][a-z0-9-]*)?$'; then
+    SCOPES+=("/subscriptions/${SUB_ID_CHECK}/resourceGroups/langsmith-rg${IDENTIFIER}")
+  else
+    warn "terraform.tfvars: identifier is not a valid resource-name suffix, so the deployment resource group was not checked"
   fi
 
-  # Resolve every role behind those assignments and eligibilities to its actual
-  # permission set. One JSON object per line so each az call can append without
-  # the shell having to assemble an array.
-  ROLE_NAMES=$(python3 - "${RBAC_TMP}/assignments.json" "${RBAC_TMP}/eligibilities.json" <<'PY' || echo ""
+  EXISTING_VNET=$(tfvar vnet_id)
+  if [ -n "$EXISTING_VNET" ]; then
+    if printf '%s\n' "$EXISTING_VNET" \
+      | grep -qE '^/subscriptions/[0-9a-fA-F-]+/resourceGroups/[A-Za-z0-9._()-]+/providers/Microsoft\.Network/virtualNetworks/[A-Za-z0-9._-]+$'; then
+      SCOPES+=("$EXISTING_VNET")
+    else
+      warn "terraform.tfvars: vnet_id is not a VNet resource ID, so that scope was not checked"
+    fi
+  fi
+
+  # roleAssignments/write is the action that decides; the rest are what a
+  # principal without broad resource access trips over first. checkAccess batches,
+  # so all of them cost one request per scope. The object ID goes through
+  # json.dumps into a file rather than onto a command line.
+  python3 - "$PRINCIPAL_ID" > "${RBAC_TMP}/body.json" <<'PY'
 import json, sys
 
-names = set()
-try:
-    with open(sys.argv[1]) as fh:
-        for a in json.load(fh) or []:
-            if a.get("roleDefinitionName"):
-                names.add(a["roleDefinitionName"])
-except (OSError, ValueError, AttributeError):
-    pass
-try:
-    with open(sys.argv[2]) as fh:
-        for e in (json.load(fh) or {}).get("value") or []:
-            expanded = (e.get("properties") or {}).get("expandedProperties") or {}
-            name = (expanded.get("roleDefinition") or {}).get("displayName")
-            if name:
-                names.add(name)
-except (OSError, ValueError, AttributeError):
-    pass
-print("\n".join(sorted(names)))
+ACTIONS = [
+    "Microsoft.Authorization/roleAssignments/write",
+    "Microsoft.Authorization/roleAssignments/delete",
+    "Microsoft.Resources/subscriptions/resourceGroups/write",
+    "Microsoft.ContainerService/managedClusters/write",
+    "Microsoft.KeyVault/vaults/write",
+    "Microsoft.Storage/storageAccounts/write",
+    "Microsoft.Network/virtualNetworks/write",
+    "Microsoft.DBforPostgreSQL/flexibleServers/write",
+    "Microsoft.Cache/redis/write",
+]
+
+print(json.dumps({
+    "Subject": {"Attributes": {"ObjectId": sys.argv[1]}},
+    "Actions": [{"Id": action, "IsDataAction": False} for action in ACTIONS],
+}))
 PY
-  )
 
-  : > "${RBAC_TMP}/roledefs.jsonl"
-  while IFS= read -r ROLE_NAME; do
-    [ -n "$ROLE_NAME" ] || continue
-    { az role definition list --name "$ROLE_NAME" \
-        --query "[0].{roleName:roleName,permissions:permissions}" -o json 2>/dev/null | tr -d '\n'; } \
-      >> "${RBAC_TMP}/roledefs.jsonl" || true
-    echo "" >> "${RBAC_TMP}/roledefs.jsonl"
-  done <<EOF
-$ROLE_NAMES
-EOF
+  : > "${RBAC_TMP}/scopes.txt"
+  SCOPE_COUNT=0
+  for SCOPE in "${SCOPES[@]}"; do
+    SCOPE_COUNT=$((SCOPE_COUNT + 1))
+    printf '%s\n' "$SCOPE" >> "${RBAC_TMP}/scopes.txt"
+    az rest --method post \
+      --url "https://management.azure.com${SCOPE}/providers/Microsoft.Authorization/checkAccess?api-version=2018-09-01-preview" \
+      --headers "Content-Type=application/json" \
+      --body "@${RBAC_TMP}/body.json" \
+      -o json > "${RBAC_TMP}/response-${SCOPE_COUNT}.json" 2>/dev/null || true
+  done
 
-  # The evaluation is one pass over four files so that the shell only renders
-  # verdicts. Each line it prints is "<severity> <message>".
+  # Eligible-but-inactive PIM roles are why a deployer who "has Owner" is still
+  # denied: checkAccess reports what is active now. asTarget() only reports the
+  # calling identity's eligibilities, so this is skipped when Terraform will
+  # authenticate as somebody else rather than mislabelled as that principal's.
+  echo "{}" > "${RBAC_TMP}/eligibilities.json"
+  if [ "$PRINCIPAL_IS_CALLER" -eq 1 ]; then
+    az rest --method get \
+      --url "https://management.azure.com/subscriptions/${SUB_ID_CHECK}/providers/Microsoft.Authorization/roleEligibilityScheduleInstances?api-version=2020-10-01&\$filter=asTarget()" \
+      -o json > "${RBAC_TMP}/eligibilities.json" 2>/dev/null || echo "{}" > "${RBAC_TMP}/eligibilities.json"
+  fi
+
+  # One pass over the responses so the shell only renders verdicts. Each line it
+  # prints is "<severity> <message>"; the single word "unavailable" means no scope
+  # answered and the fallback below should run instead.
   RBAC_VERDICT=$(python3 - \
-    "${RBAC_TMP}/assignments.json" \
+    "$RBAC_TMP" \
     "${RBAC_TMP}/eligibilities.json" \
-    "${RBAC_TMP}/deny.json" \
-    "${RBAC_TMP}/roledefs.jsonl" \
-    "$PRINCIPAL_ID" \
-    "$SUB_ID_CHECK" \
-    "$ASSIGNMENTS_READ" <<'PY' || echo "warn RBAC evaluation failed to run — falling back to no verdict"
-import fnmatch, json, sys
+    "$PRINCIPAL_IS_CALLER" <<'PY' || echo "unavailable"
+import json, os, sys
 
-assign_path, elig_path, deny_path, defs_path, principal_id, sub_id, read_ok = sys.argv[1:8]
+tmp, elig_path, is_caller = sys.argv[1:4]
 
-# The assignment list could not be read, so there is nothing to render. The
-# shell has already warned; anything printed here would be a verdict built on
-# an empty file.
-if read_ok != "1":
-    sys.exit(0)
-
-# Microsoft.Authorization/roleAssignments/write is the action the modules need
-# and the one the 403 names. The storage write is a proxy for ordinary resource
-# creation: every deployment path builds a storage account.
 ROLE_WRITE = "microsoft.authorization/roleassignments/write"
-RES_WRITE = "microsoft.storage/storageaccounts/write"
+ROLE_DELETE = "microsoft.authorization/roleassignments/delete"
+
+# checkAccess names the granting role by bare GUID. These four are the built-ins
+# that carry roleAssignments/write, verified against az role definition list;
+# anything else prints its GUID rather than a guess.
+ROLE_NAMES = {
+    "8e3af657a8ff443ca75c2fe8c4bcb635": "Owner",
+    "b24988ac618042a0ab8820f7382dd24c": "Contributor",
+    "18d7d88dd35e4fb5a5c37773c20a72d9": "User Access Administrator",
+    "f58310d9a9f6439a9e8df62e7b41a168": "Role Based Access Control Administrator",
+}
 
 # Assigned to the modules by name, so an ABAC condition that omits any of them
-# breaks apply even though roleAssignments/write is granted.
+# breaks apply even where roleAssignments/write is permitted.
 ASSIGNED_ROLES = (
     "Storage Blob Data Contributor, Key Vault Secrets Officer, "
     "Key Vault Secrets User, DNS Zone Contributor, "
     "Virtual Machine Administrator Login, Reader, Contributor, "
     "Network Contributor"
 )
-
-ALL_PRINCIPALS = "00000000-0000-0000-0000-000000000000"
-MG_PREFIX = "/providers/microsoft.management/managementgroups/"
-principal_id = principal_id.lower()
 
 
 def load(path, default):
@@ -321,153 +303,146 @@ def load(path, default):
         return default
 
 
-role_perms = {}
+def role_label(assignment):
+    guid = (assignment.get("roleDefinitionId") or "").replace("-", "").lower()
+    name = ROLE_NAMES.get(guid)
+    if name:
+        return name
+    if assignment.get("assignedToCustomRole"):
+        return "custom role %s" % (guid or "?")
+    return "role %s" % (guid or "?")
+
+
 try:
-    with open(defs_path) as fh:
-        for line in fh:
-            line = line.strip()
-            if not line or line == "null":
-                continue
-            try:
-                definition = json.loads(line)
-            except ValueError:
-                continue
-            if definition and definition.get("roleName"):
-                role_perms[definition["roleName"]] = definition.get("permissions") or []
+    with open(os.path.join(tmp, "scopes.txt")) as fh:
+        scopes = [line.strip() for line in fh if line.strip()]
 except OSError:
-    pass
+    scopes = []
 
-assignments = load(assign_path, []) or []
-eligibilities = (load(elig_path, {}) or {}).get("value") or []
-deny_assignments = (load(deny_path, {}) or {}).get("value") or []
+# A 200 carrying anything but the non-empty array this API is observed to return
+# means the preview contract moved. Refuse the scope rather than guess at it.
+answered, unanswered = [], []
+for index, scope in enumerate(scopes, start=1):
+    data = load(os.path.join(tmp, "response-%d.json" % index), None)
+    if isinstance(data, list) and data:
+        answered.append((scope, data))
+    else:
+        unanswered.append(scope)
 
-
-def matches(action, patterns):
-    # Azure action patterns wildcard with *, which fnmatch spans across / — the
-    # same way ARM reads Microsoft.Authorization/* as covering a nested action.
-    return any(fnmatch.fnmatch(action, (p or "").lower()) for p in patterns or [])
-
-
-def grants(role_name, action):
-    for perm in role_perms.get(role_name, []):
-        if matches(action, perm.get("actions")) and not matches(action, perm.get("notActions")):
-            return True
-    return False
-
-
-def covers_deployment(scope):
-    scope = (scope or "").lower()
-    # --include-inherited only returns management groups above this
-    # subscription, so a management group scope here is always an ancestor.
-    return scope in ("/", "/subscriptions/%s" % sub_id.lower()) or scope.startswith(MG_PREFIX)
-
+if not answered:
+    print("unavailable")
+    raise SystemExit(0)
 
 out = []
-qualifying = [a for a in assignments if grants(a.get("roleDefinitionName"), ROLE_WRITE)]
-broad = [a for a in qualifying if covers_deployment(a.get("scope"))]
-narrow = [a for a in qualifying if not covers_deployment(a.get("scope"))]
+if unanswered:
+    out.append("warn checkAccess did not answer at %s, so nothing here speaks to what the "
+               "deployment can do there." % ", ".join(unanswered))
 
-if broad:
-    winner = broad[0]
-    out.append("pass roleAssignments/write granted by %s at %s"
-               % (winner.get("roleDefinitionName"), winner.get("scope")))
-elif narrow:
-    scopes = ", ".join(sorted({a.get("scope") or "?" for a in narrow}))
-    out.append("warn roleAssignments/write is granted only below the subscription (%s). "
-               "Anything the deployment creates outside that scope will 403 — confirm every "
-               "resource lands inside it." % scopes)
-else:
-    eligible = []
-    for instance in eligibilities:
-        props = instance.get("properties") or {}
-        expanded = (props.get("expandedProperties") or {}).get("roleDefinition") or {}
-        name = expanded.get("displayName")
-        if name and grants(name, ROLE_WRITE):
-            eligible.append("%s at %s" % (name, props.get("scope") or "?"))
-    if eligible:
-        out.append("fail roleAssignments/write is not active, but PIM holds it as eligible: %s. "
-                   "Activate it (portal: PIM -> My roles -> Activate), then re-run this script. "
-                   "Activation is time-bound, so activate for longer than the apply will take."
-                   % "; ".join(sorted(set(eligible))))
-    elif not assignments:
-        out.append("fail No role assignments found for this principal at any scope in the "
-                   "subscription. Either it holds nothing here, or the grant is PIM-eligible and "
-                   "this account cannot read its own eligibilities.")
+denied_write = False
+for scope, decisions in answered:
+    for decision in decisions:
+        if (decision.get("actionId") or "").lower() != ROLE_WRITE:
+            continue
+        assignment = decision.get("roleAssignment") or {}
+        deny = decision.get("denyAssignment") or {}
+        if decision.get("accessDecision") == "Allowed":
+            out.append("pass roleAssignments/write permitted at %s, granted by %s held at %s"
+                       % (scope, role_label(assignment), assignment.get("scope") or "?"))
+            if assignment.get("condition"):
+                out.append("warn That grant carries an ABAC condition, so it permits only the roles "
+                           "the condition allows. The modules assign: %s. Condition: %s"
+                           % (ASSIGNED_ROLES, " ".join(assignment["condition"].split())[:240]))
+        else:
+            denied_write = True
+            if deny:
+                # The roleAssignment shape here was read off live responses; a
+                # populated denyAssignment was never one of them, because you
+                # cannot create a deny assignment to test with. Try the key names
+                # the RBAC APIs use elsewhere and stay useful if it is none of
+                # them: that a deny assignment exists at all is the finding.
+                name = (deny.get("displayName") or deny.get("denyAssignmentName")
+                        or deny.get("name") or deny.get("id") or "unnamed")
+                out.append("fail roleAssignments/write is denied at %s by deny assignment \"%s\". "
+                           "Deny assignments override every role assignment including Owner, so no "
+                           "role grant will fix this: it has to be removed, or this principal added "
+                           "to its exclusion list." % (scope, name))
+            else:
+                out.append("fail roleAssignments/write is not permitted at %s. All eight role "
+                           "assignments in the Azure modules need it." % scope)
+
+for scope, decisions in answered:
+    refused = sorted({decision.get("actionId") or "?" for decision in decisions
+                      if (decision.get("actionId") or "").lower() not in (ROLE_WRITE, ROLE_DELETE)
+                      and decision.get("accessDecision") != "Allowed"})
+    if refused:
+        out.append("fail Not permitted at %s: %s. The deployment creates all of these."
+                   % (scope, ", ".join(refused)))
     else:
-        held = ", ".join(sorted({a.get("roleDefinitionName") or "?" for a in assignments}))
-        out.append("fail No role held by this principal grants "
-                   "Microsoft.Authorization/roleAssignments/write, which all eight role "
-                   "assignments in the Azure modules need. Roles found: %s." % held)
+        out.append("pass Every resource type the deployment creates is writable at %s" % scope)
 
-# A role whose definition could not be read carries no permissions here, which
-# reads exactly like a role that grants nothing. Say which ones, so a verdict
-# resting on an unreadable custom role is not mistaken for a settled one.
-if not broad:
-    unresolved = sorted({a.get("roleDefinitionName") or "(unnamed role)"
-                         for a in assignments
-                         if (a.get("roleDefinitionName") or "") not in role_perms})
-    if unresolved:
-        out.append("warn Could not read the permissions behind these roles held by this "
-                   "principal: %s. They count as granting nothing above, so if one of them is a "
-                   "custom role carrying roleAssignments/write, the verdict is wrong."
-                   % ", ".join(unresolved))
+    for decision in decisions:
+        if ((decision.get("actionId") or "").lower() == ROLE_DELETE
+                and decision.get("accessDecision") != "Allowed"):
+            out.append("warn roleAssignments/delete is not permitted at %s. Apply can create the "
+                       "eight assignments, but terraform destroy and any change that replaces one "
+                       "will fail." % scope)
 
-for assignment in broad + narrow:
-    if assignment.get("condition"):
-        out.append("warn %s at %s carries an ABAC condition, so roleAssignments/write is "
-                   "restricted to the roles that condition allows. The modules assign: %s. "
-                   "Condition: %s"
-                   % (assignment.get("roleDefinitionName"), assignment.get("scope"),
-                      ASSIGNED_ROLES, " ".join(assignment["condition"].split())[:240]))
-
-for entry in deny_assignments:
-    props = entry.get("properties") or {}
-    principals = [(p.get("id") or "").lower() for p in props.get("principals") or []]
-    excluded = [(p.get("id") or "").lower() for p in props.get("excludePrincipals") or []]
-    if principal_id not in principals and ALL_PRINCIPALS not in principals:
-        continue
-    if principal_id in excluded:
-        continue
-    blocked = any(
-        matches(ROLE_WRITE, perm.get("actions")) and not matches(ROLE_WRITE, perm.get("notActions"))
-        for perm in props.get("permissions") or []
-    )
-    if not blocked:
-        continue
-    name = props.get("denyAssignmentName") or entry.get("name") or "?"
-    if excluded:
-        out.append("warn Deny assignment \"%s\" at %s denies roleAssignments/write. Its exclusion "
-                   "list may exempt this principal through a group this script cannot read — if "
-                   "not, apply will 403 no matter which roles are held."
-                   % (name, props.get("scope") or "?"))
+# Only reached when the decisive action was refused, which is the one case where
+# an inactive PIM role is the likely explanation and the fix is a click, not a
+# ticket. Whether an eligible role carries the action is not knowable here, so
+# they are all listed rather than filtered on a guess.
+if denied_write:
+    if is_caller == "1":
+        eligible = []
+        for instance in (load(elig_path, {}) or {}).get("value") or []:
+            props = instance.get("properties") or {}
+            expanded = (props.get("expandedProperties") or {}).get("roleDefinition") or {}
+            if expanded.get("displayName"):
+                eligible.append("%s at %s" % (expanded["displayName"], props.get("scope") or "?"))
+        if eligible:
+            out.append("fail PIM holds these roles for this identity as eligible but not active: %s. "
+                       "checkAccess reports what is active now, so if one of them carries "
+                       "roleAssignments/write, activating it (portal: PIM -> My roles -> Activate) "
+                       "fixes this. Activation is time-bound, so activate for longer than the apply "
+                       "will take." % "; ".join(sorted(set(eligible))))
     else:
-        out.append("fail Deny assignment \"%s\" at %s denies roleAssignments/write. Deny "
-                   "assignments override every role assignment including Owner, so no role grant "
-                   "will fix this: it has to be removed or this principal added to its exclusion "
-                   "list." % (name, props.get("scope") or "?"))
-
-if any(grants(a.get("roleDefinitionName"), RES_WRITE) and covers_deployment(a.get("scope"))
-       for a in assignments):
-    out.append("pass Resource creation granted at subscription scope")
-else:
-    out.append("warn No subscription-scope grant for creating resources (checked against "
-               "Microsoft.Storage/storageAccounts/write). A resource-group-scoped grant is fine "
-               "if the resource group already exists and the deployment stays inside it.")
+        out.append("warn Terraform will authenticate as a principal other than the one running this "
+                   "script, so its PIM eligibilities cannot be read here. A role that is held but "
+                   "not activated looks exactly like a role that is not held.")
 
 print("\n".join(out))
 PY
   )
 
-  while IFS= read -r LINE; do
-    case "$LINE" in
-      pass\ *) pass "${LINE#pass }" ;;
-      warn\ *) warn "${LINE#warn }" ;;
-      fail\ *) fail "${LINE#fail }" ;;
-      *) [ -z "$LINE" ] || warn "$LINE" ;;
+  if [ "$RBAC_VERDICT" = "unavailable" ]; then
+    warn "checkAccess (Microsoft.Authorization/checkAccess, 2018-09-01-preview) did not answer at any scope. It is an unversioned preview API, so it may have changed or this tenant may refuse it. Falling back to a role-name check, which cannot see deny assignments, ABAC conditions, or custom roles."
+    HELD=$(az role assignment list \
+      --scope "/subscriptions/${SUB_ID_CHECK}" \
+      --include-inherited \
+      --assignee-object-id "$PRINCIPAL_ID" \
+      --include-groups \
+      --query "[].roleDefinitionName" -o tsv 2>/dev/null || echo "")
+    HELD_FLAT=$(printf '%s' "$HELD" | tr '\n' ',' | sed 's/,$//')
+    case ",${HELD_FLAT}," in
+      *,Owner,*|*,"User Access Administrator",*|*,"Role Based Access Control Administrator",*)
+        pass "Holds ${HELD_FLAT} at or above the subscription, which carries roleAssignments/write" ;;
+      ,,)
+        fail "No role assignments could be read for this principal, and checkAccess did not answer. Nothing here can tell you whether apply will succeed — check the identity by hand before applying." ;;
+      *)
+        fail "No Owner, User Access Administrator, or Role Based Access Control Administrator grant found at or above the subscription. Roles held: ${HELD_FLAT}. A custom role carrying roleAssignments/write would also work and is not detected on this path." ;;
     esac
-  done <<EOF
+  else
+    while IFS= read -r LINE; do
+      case "$LINE" in
+        pass\ *) pass "${LINE#pass }" ;;
+        warn\ *) warn "${LINE#warn }" ;;
+        fail\ *) fail "${LINE#fail }" ;;
+        *) [ -z "$LINE" ] || warn "$LINE" ;;
+      esac
+    done <<EOF
 $RBAC_VERDICT
 EOF
+  fi
 fi
 
 # ── 5. Subscription offer type ────────────────────────────────────────────────

--- a/modules/azure/infra/scripts/preflight.sh
+++ b/modules/azure/infra/scripts/preflight.sh
@@ -432,6 +432,7 @@ PY
         fail "No Owner, User Access Administrator, or Role Based Access Control Administrator grant found at or above the subscription. Roles held: ${HELD_FLAT}. A custom role carrying roleAssignments/write would also work and is not detected on this path." ;;
     esac
   else
+    pass "checkAccess answered, so the verdicts below are this principal's effective access with deny assignments and ABAC conditions applied"
     while IFS= read -r LINE; do
       case "$LINE" in
         pass\ *) pass "${LINE#pass }" ;;

--- a/modules/azure/infra/scripts/preflight.sh
+++ b/modules/azure/infra/scripts/preflight.sh
@@ -11,7 +11,7 @@
 #   1. az CLI is installed and logged in
 #   2. Correct subscription is selected
 #   3. Required resource providers are registered
-#   4. Deployer has required RBAC roles (Contributor + User Access Admin)
+#   4. The identity Terraform will use can write role assignments
 #   5. terraform.tfvars exists with required fields populated
 #
 # Run before: terraform init / terraform apply
@@ -86,49 +86,387 @@ for PROVIDER in "${REQUIRED_PROVIDERS[@]}"; do
   fi
 done
 
-# ── 4. RBAC roles ─────────────────────────────────────────────────────────────
+# ── 4. Deployer identity and RBAC ─────────────────────────────────────────────
+# Terraform does not necessarily authenticate as your az login. The azurerm
+# provider reads its ARM_* environment variables before falling back to the CLI,
+# so a stale ARM_CLIENT_ID in the shell means every check below validates a
+# principal Terraform will never use: preflight passes, apply 403s as somebody
+# else. Resolve the identity the provider will actually present, then ask what
+# that identity can do.
+echo ""
+echo "── Deployer Identity ─────────────────────────────────"
+
+SUB_ID_CHECK=$(az account show --query id -o tsv 2>/dev/null || echo "")
+TENANT_ID_CHECK=$(az account show --query tenantId -o tsv 2>/dev/null || echo "")
+
+if [ -n "${ARM_SUBSCRIPTION_ID:-}" ] && [ "$ARM_SUBSCRIPTION_ID" != "$SUB_ID_CHECK" ]; then
+  fail "ARM_SUBSCRIPTION_ID is ${ARM_SUBSCRIPTION_ID} but the active az subscription is ${SUB_ID_CHECK}. Terraform would deploy into the former; every check in this script reads the latter."
+fi
+if [ -n "${ARM_TENANT_ID:-}" ] && [ "$ARM_TENANT_ID" != "$TENANT_ID_CHECK" ]; then
+  fail "ARM_TENANT_ID is ${ARM_TENANT_ID} but the active az tenant is ${TENANT_ID_CHECK}."
+fi
+
+# Turning an application ID into its service principal object ID takes a
+# directory read, which plenty of deployers are not granted. Without an object
+# ID there is no assignee to query, so the RBAC block below degrades to a
+# warning rather than reporting a verdict it cannot support.
+PRINCIPAL_ID=""
+if [ -n "${ARM_CLIENT_ID:-}" ]; then
+  PRINCIPAL_KIND="service principal from ARM_CLIENT_ID"
+  PRINCIPAL_ID=$(az ad sp show --id "$ARM_CLIENT_ID" --query id -o tsv 2>/dev/null || echo "")
+  warn "ARM_CLIENT_ID is set — Terraform authenticates as that service principal, not as your az login"
+elif [ "${ARM_USE_MSI:-}" = "true" ] || [ "${ARM_USE_OIDC:-}" = "true" ]; then
+  PRINCIPAL_KIND="managed identity or OIDC federation"
+  warn "ARM_USE_MSI or ARM_USE_OIDC is set — Terraform authenticates as a workload identity this script cannot resolve"
+elif [ "$(az account show --query user.type -o tsv 2>/dev/null || echo "")" = "servicePrincipal" ]; then
+  PRINCIPAL_KIND="service principal from az login"
+  SP_APP_ID=$(az account show --query user.name -o tsv 2>/dev/null || echo "")
+  PRINCIPAL_ID=$(az ad sp show --id "$SP_APP_ID" --query id -o tsv 2>/dev/null || echo "")
+else
+  PRINCIPAL_KIND="signed-in user"
+  PRINCIPAL_ID=$(az ad signed-in-user show --query id -o tsv 2>/dev/null || echo "")
+fi
+
+if [ -n "$PRINCIPAL_ID" ]; then
+  pass "Terraform will authenticate as ${PRINCIPAL_KIND} (object ID ${PRINCIPAL_ID})"
+else
+  warn "Could not resolve an object ID for the ${PRINCIPAL_KIND} — a denied directory read will do this"
+fi
+
+# ── RBAC ──────────────────────────────────────────────────────────────────────
+# Eight resources across the Azure modules create role assignments (storage,
+# keyvault ×2, dns, bastion, k8s-cluster ×3), so
+# Microsoft.Authorization/roleAssignments/write decides whether apply finishes.
+# Looking for the role names "Owner" and "User Access Administrator" does not
+# decide it, in either direction: a custom role can carry the action, an ABAC
+# condition can restrict which roles a delegate may assign, a deny assignment
+# overrides every grant including Owner, PIM-eligible roles grant nothing until
+# activated, and a grant inherited from a management group or held through a
+# group carries the same weight as a direct one. So read the role definitions
+# behind the assignments and the deny assignments that override them.
 echo ""
 echo "── RBAC Roles ────────────────────────────────────────"
-CURRENT_USER_ID=$(az ad signed-in-user show --query id -o tsv 2>/dev/null || echo "")
-SUB_ID_CHECK=$(az account show --query id -o tsv 2>/dev/null || echo "")
 
-if [ -z "$CURRENT_USER_ID" ]; then
-  warn "Could not determine current user object ID — skipping RBAC check (service principal?)"
+RBAC_TMP=$(mktemp -d)
+trap 'rm -rf "$RBAC_TMP"' EXIT
+
+if [ -z "$PRINCIPAL_ID" ] || [ -z "$SUB_ID_CHECK" ]; then
+  warn "Skipping RBAC check — no principal object ID to query"
 else
-  # Check Contributor
-  CONTRIBUTOR=$(az role assignment list \
-    --assignee "$CURRENT_USER_ID" \
-    --role "Contributor" \
+  # Two queries, because neither direction is a superset of the other. ARM's
+  # atScope() filter returns assignments at and above a scope, so the first call
+  # is the only one that reports a grant inherited from a management group; --all
+  # drops the scope filter entirely, so it is the only one that reports a grant
+  # made below the subscription on a resource group. --include-inherited is what
+  # keeps the above-subscription results in the first call, and has no effect on
+  # the second (--all sends no scope for anything to be inherited from).
+  # --include-groups makes the server filter transitive through group membership,
+  # and --assignee-object-id skips the Graph lookup --assignee would need.
+  ASSIGNMENTS_READ=1
+  az role assignment list \
     --scope "/subscriptions/${SUB_ID_CHECK}" \
-    --query "length(@)" -o tsv 2>/dev/null || echo "0")
+    --include-inherited \
+    --assignee-object-id "$PRINCIPAL_ID" \
+    --include-groups \
+    -o json > "${RBAC_TMP}/at-and-above.json" 2>/dev/null || ASSIGNMENTS_READ=0
+  az role assignment list \
+    --all \
+    --assignee-object-id "$PRINCIPAL_ID" \
+    --include-groups \
+    -o json > "${RBAC_TMP}/at-and-below.json" 2>/dev/null || ASSIGNMENTS_READ=0
 
-  if [ "$CONTRIBUTOR" -gt "0" ]; then
-    pass "Contributor role on subscription"
-  else
-    warn "Contributor role not found at subscription scope — may have it at resource group scope (acceptable)"
+  # Merged into one list so the evaluation below reads a single file. The
+  # subscription scope itself answers both queries, hence the dedupe.
+  python3 - "${RBAC_TMP}/at-and-above.json" "${RBAC_TMP}/at-and-below.json" \
+    > "${RBAC_TMP}/assignments.json" <<'PY' || ASSIGNMENTS_READ=0
+import json, sys
+
+seen, merged = set(), []
+for path in sys.argv[1:]:
+    try:
+        with open(path) as fh:
+            entries = json.load(fh) or []
+    except (OSError, ValueError):
+        continue
+    for entry in entries:
+        key = entry.get("id") or json.dumps(entry, sort_keys=True)
+        if key in seen:
+            continue
+        seen.add(key)
+        merged.append(entry)
+print(json.dumps(merged))
+PY
+
+  # Eligible-but-inactive PIM roles are absent from the list above, which is why
+  # a deployer who "has Owner" can still be denied. Fetching them here turns the
+  # failure message from "you lack the role" into "activate the role you hold".
+  # asTarget() reports eligibilities for the calling identity only, so this is
+  # empty (harmlessly) when Terraform runs as a service principal.
+  az rest --method get \
+    --url "https://management.azure.com/subscriptions/${SUB_ID_CHECK}/providers/Microsoft.Authorization/roleEligibilityScheduleInstances?api-version=2020-10-01&\$filter=asTarget()" \
+    -o json > "${RBAC_TMP}/eligibilities.json" 2>/dev/null || echo "{}" > "${RBAC_TMP}/eligibilities.json"
+
+  # atScope() returns deny assignments at or above the subscription, which is
+  # where landing-zone blueprints and managed applications put them. Two kinds
+  # stay invisible and surface as a 403 at apply: one created directly on a
+  # resource group that does not exist yet, and one that names a group this
+  # principal belongs to rather than the principal itself (the matching below
+  # reads principal IDs, and resolving group membership needs a directory read
+  # this account may not have).
+  az rest --method get \
+    --url "https://management.azure.com/subscriptions/${SUB_ID_CHECK}/providers/Microsoft.Authorization/denyAssignments?api-version=2022-04-01&\$filter=atScope()" \
+    -o json > "${RBAC_TMP}/deny.json" 2>/dev/null || DENY_READ=0
+
+  # A failed read is not an empty result. Reporting "no roles found" when the
+  # query itself was refused would send the operator to their tenant admin for
+  # a grant they may already hold, so say which read failed and stop instead.
+  if [ "$ASSIGNMENTS_READ" -eq 0 ]; then
+    warn "Could not list role assignments for this principal — skipping the RBAC verdict rather than reading a failed query as \"no access\""
+  fi
+  if [ "${DENY_READ:-1}" -eq 0 ]; then
+    echo "{}" > "${RBAC_TMP}/deny.json"
+    warn "Could not read deny assignments (needs Microsoft.Authorization/denyAssignments/read). One that blocks roleAssignments/write would be invisible here and would override every role grant below."
   fi
 
-  # Check User Access Administrator or Owner (required for role assignments in modules).
-  # Owner implicitly includes all User Access Administrator permissions.
-  UAA=$(az role assignment list \
-    --assignee "$CURRENT_USER_ID" \
-    --role "User Access Administrator" \
-    --scope "/subscriptions/${SUB_ID_CHECK}" \
-    --query "length(@)" -o tsv 2>/dev/null || echo "0")
+  # Resolve every role behind those assignments and eligibilities to its actual
+  # permission set. One JSON object per line so each az call can append without
+  # the shell having to assemble an array.
+  ROLE_NAMES=$(python3 - "${RBAC_TMP}/assignments.json" "${RBAC_TMP}/eligibilities.json" <<'PY' || echo ""
+import json, sys
 
-  OWNER=$(az role assignment list \
-    --assignee "$CURRENT_USER_ID" \
-    --role "Owner" \
-    --scope "/subscriptions/${SUB_ID_CHECK}" \
-    --query "length(@)" -o tsv 2>/dev/null || echo "0")
+names = set()
+try:
+    with open(sys.argv[1]) as fh:
+        for a in json.load(fh) or []:
+            if a.get("roleDefinitionName"):
+                names.add(a["roleDefinitionName"])
+except (OSError, ValueError, AttributeError):
+    pass
+try:
+    with open(sys.argv[2]) as fh:
+        for e in (json.load(fh) or {}).get("value") or []:
+            expanded = (e.get("properties") or {}).get("expandedProperties") or {}
+            name = (expanded.get("roleDefinition") or {}).get("displayName")
+            if name:
+                names.add(name)
+except (OSError, ValueError, AttributeError):
+    pass
+print("\n".join(sorted(names)))
+PY
+  )
 
-  if [ "$UAA" -gt "0" ]; then
-    pass "User Access Administrator role on subscription"
-  elif [ "$OWNER" -gt "0" ]; then
-    pass "Owner role on subscription (includes User Access Administrator permissions)"
-  else
-    fail "Neither Owner nor User Access Administrator role found. Required for RBAC role assignments in keyvault, storage, and WAF modules."
-  fi
+  : > "${RBAC_TMP}/roledefs.jsonl"
+  while IFS= read -r ROLE_NAME; do
+    [ -n "$ROLE_NAME" ] || continue
+    { az role definition list --name "$ROLE_NAME" \
+        --query "[0].{roleName:roleName,permissions:permissions}" -o json 2>/dev/null | tr -d '\n'; } \
+      >> "${RBAC_TMP}/roledefs.jsonl" || true
+    echo "" >> "${RBAC_TMP}/roledefs.jsonl"
+  done <<EOF
+$ROLE_NAMES
+EOF
+
+  # The evaluation is one pass over four files so that the shell only renders
+  # verdicts. Each line it prints is "<severity> <message>".
+  RBAC_VERDICT=$(python3 - \
+    "${RBAC_TMP}/assignments.json" \
+    "${RBAC_TMP}/eligibilities.json" \
+    "${RBAC_TMP}/deny.json" \
+    "${RBAC_TMP}/roledefs.jsonl" \
+    "$PRINCIPAL_ID" \
+    "$SUB_ID_CHECK" \
+    "$ASSIGNMENTS_READ" <<'PY' || echo "warn RBAC evaluation failed to run — falling back to no verdict"
+import fnmatch, json, sys
+
+assign_path, elig_path, deny_path, defs_path, principal_id, sub_id, read_ok = sys.argv[1:8]
+
+# The assignment list could not be read, so there is nothing to render. The
+# shell has already warned; anything printed here would be a verdict built on
+# an empty file.
+if read_ok != "1":
+    sys.exit(0)
+
+# Microsoft.Authorization/roleAssignments/write is the action the modules need
+# and the one the 403 names. The storage write is a proxy for ordinary resource
+# creation: every deployment path builds a storage account.
+ROLE_WRITE = "microsoft.authorization/roleassignments/write"
+RES_WRITE = "microsoft.storage/storageaccounts/write"
+
+# Assigned to the modules by name, so an ABAC condition that omits any of them
+# breaks apply even though roleAssignments/write is granted.
+ASSIGNED_ROLES = (
+    "Storage Blob Data Contributor, Key Vault Secrets Officer, "
+    "Key Vault Secrets User, DNS Zone Contributor, "
+    "Virtual Machine Administrator Login, Reader, Contributor, "
+    "Network Contributor"
+)
+
+ALL_PRINCIPALS = "00000000-0000-0000-0000-000000000000"
+MG_PREFIX = "/providers/microsoft.management/managementgroups/"
+principal_id = principal_id.lower()
+
+
+def load(path, default):
+    try:
+        with open(path) as fh:
+            text = fh.read().strip()
+    except OSError:
+        return default
+    if not text:
+        return default
+    try:
+        return json.loads(text)
+    except ValueError:
+        return default
+
+
+role_perms = {}
+try:
+    with open(defs_path) as fh:
+        for line in fh:
+            line = line.strip()
+            if not line or line == "null":
+                continue
+            try:
+                definition = json.loads(line)
+            except ValueError:
+                continue
+            if definition and definition.get("roleName"):
+                role_perms[definition["roleName"]] = definition.get("permissions") or []
+except OSError:
+    pass
+
+assignments = load(assign_path, []) or []
+eligibilities = (load(elig_path, {}) or {}).get("value") or []
+deny_assignments = (load(deny_path, {}) or {}).get("value") or []
+
+
+def matches(action, patterns):
+    # Azure action patterns wildcard with *, which fnmatch spans across / — the
+    # same way ARM reads Microsoft.Authorization/* as covering a nested action.
+    return any(fnmatch.fnmatch(action, (p or "").lower()) for p in patterns or [])
+
+
+def grants(role_name, action):
+    for perm in role_perms.get(role_name, []):
+        if matches(action, perm.get("actions")) and not matches(action, perm.get("notActions")):
+            return True
+    return False
+
+
+def covers_deployment(scope):
+    scope = (scope or "").lower()
+    # --include-inherited only returns management groups above this
+    # subscription, so a management group scope here is always an ancestor.
+    return scope in ("/", "/subscriptions/%s" % sub_id.lower()) or scope.startswith(MG_PREFIX)
+
+
+out = []
+qualifying = [a for a in assignments if grants(a.get("roleDefinitionName"), ROLE_WRITE)]
+broad = [a for a in qualifying if covers_deployment(a.get("scope"))]
+narrow = [a for a in qualifying if not covers_deployment(a.get("scope"))]
+
+if broad:
+    winner = broad[0]
+    out.append("pass roleAssignments/write granted by %s at %s"
+               % (winner.get("roleDefinitionName"), winner.get("scope")))
+elif narrow:
+    scopes = ", ".join(sorted({a.get("scope") or "?" for a in narrow}))
+    out.append("warn roleAssignments/write is granted only below the subscription (%s). "
+               "Anything the deployment creates outside that scope will 403 — confirm every "
+               "resource lands inside it." % scopes)
+else:
+    eligible = []
+    for instance in eligibilities:
+        props = instance.get("properties") or {}
+        expanded = (props.get("expandedProperties") or {}).get("roleDefinition") or {}
+        name = expanded.get("displayName")
+        if name and grants(name, ROLE_WRITE):
+            eligible.append("%s at %s" % (name, props.get("scope") or "?"))
+    if eligible:
+        out.append("fail roleAssignments/write is not active, but PIM holds it as eligible: %s. "
+                   "Activate it (portal: PIM -> My roles -> Activate), then re-run this script. "
+                   "Activation is time-bound, so activate for longer than the apply will take."
+                   % "; ".join(sorted(set(eligible))))
+    elif not assignments:
+        out.append("fail No role assignments found for this principal at any scope in the "
+                   "subscription. Either it holds nothing here, or the grant is PIM-eligible and "
+                   "this account cannot read its own eligibilities.")
+    else:
+        held = ", ".join(sorted({a.get("roleDefinitionName") or "?" for a in assignments}))
+        out.append("fail No role held by this principal grants "
+                   "Microsoft.Authorization/roleAssignments/write, which all eight role "
+                   "assignments in the Azure modules need. Roles found: %s." % held)
+
+# A role whose definition could not be read carries no permissions here, which
+# reads exactly like a role that grants nothing. Say which ones, so a verdict
+# resting on an unreadable custom role is not mistaken for a settled one.
+if not broad:
+    unresolved = sorted({a.get("roleDefinitionName") or "(unnamed role)"
+                         for a in assignments
+                         if (a.get("roleDefinitionName") or "") not in role_perms})
+    if unresolved:
+        out.append("warn Could not read the permissions behind these roles held by this "
+                   "principal: %s. They count as granting nothing above, so if one of them is a "
+                   "custom role carrying roleAssignments/write, the verdict is wrong."
+                   % ", ".join(unresolved))
+
+for assignment in broad + narrow:
+    if assignment.get("condition"):
+        out.append("warn %s at %s carries an ABAC condition, so roleAssignments/write is "
+                   "restricted to the roles that condition allows. The modules assign: %s. "
+                   "Condition: %s"
+                   % (assignment.get("roleDefinitionName"), assignment.get("scope"),
+                      ASSIGNED_ROLES, " ".join(assignment["condition"].split())[:240]))
+
+for entry in deny_assignments:
+    props = entry.get("properties") or {}
+    principals = [(p.get("id") or "").lower() for p in props.get("principals") or []]
+    excluded = [(p.get("id") or "").lower() for p in props.get("excludePrincipals") or []]
+    if principal_id not in principals and ALL_PRINCIPALS not in principals:
+        continue
+    if principal_id in excluded:
+        continue
+    blocked = any(
+        matches(ROLE_WRITE, perm.get("actions")) and not matches(ROLE_WRITE, perm.get("notActions"))
+        for perm in props.get("permissions") or []
+    )
+    if not blocked:
+        continue
+    name = props.get("denyAssignmentName") or entry.get("name") or "?"
+    if excluded:
+        out.append("warn Deny assignment \"%s\" at %s denies roleAssignments/write. Its exclusion "
+                   "list may exempt this principal through a group this script cannot read — if "
+                   "not, apply will 403 no matter which roles are held."
+                   % (name, props.get("scope") or "?"))
+    else:
+        out.append("fail Deny assignment \"%s\" at %s denies roleAssignments/write. Deny "
+                   "assignments override every role assignment including Owner, so no role grant "
+                   "will fix this: it has to be removed or this principal added to its exclusion "
+                   "list." % (name, props.get("scope") or "?"))
+
+if any(grants(a.get("roleDefinitionName"), RES_WRITE) and covers_deployment(a.get("scope"))
+       for a in assignments):
+    out.append("pass Resource creation granted at subscription scope")
+else:
+    out.append("warn No subscription-scope grant for creating resources (checked against "
+               "Microsoft.Storage/storageAccounts/write). A resource-group-scoped grant is fine "
+               "if the resource group already exists and the deployment stays inside it.")
+
+print("\n".join(out))
+PY
+  )
+
+  while IFS= read -r LINE; do
+    case "$LINE" in
+      pass\ *) pass "${LINE#pass }" ;;
+      warn\ *) warn "${LINE#warn }" ;;
+      fail\ *) fail "${LINE#fail }" ;;
+      *) [ -z "$LINE" ] || warn "$LINE" ;;
+    esac
+  done <<EOF
+$RBAC_VERDICT
+EOF
 fi
 
 # ── 5. terraform.tfvars ───────────────────────────────────────────────────────

--- a/modules/azure/infra/scripts/test-preflight-rbac.py
+++ b/modules/azure/infra/scripts/test-preflight-rbac.py
@@ -140,7 +140,7 @@ CASES = [
         "expect": [
             f"[✗] roleAssignments/write is not permitted at {SUB_SCOPE}. All eight role assignments",
         ],
-        "reject": ["deny assignment", "PIM holds"],
+        "reject": ["by deny assignment", "PIM holds"],
     },
     {
         "name": "a deny assignment is named and called out as overriding Owner",

--- a/modules/azure/infra/scripts/test-preflight-rbac.py
+++ b/modules/azure/infra/scripts/test-preflight-rbac.py
@@ -1,0 +1,439 @@
+"""Exercise preflight.sh's RBAC block against a stubbed az CLI.
+
+The checks worth testing are the ones you cannot produce on demand in a real
+subscription: a deny assignment that overrides Owner, a PIM role held but not
+activated, an ABAC-conditioned grant, and a preview API that changes shape or
+stops answering. Each case builds an infra directory, copies the real script into
+it so INFRA_DIR resolves inside the fixture, runs it with a stub `az` first on
+PATH, and asserts on substrings of the rendered output.
+
+Usage: python3 test_rbac_preflight.py
+"""
+
+import json
+import os
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+
+ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+HERE = pathlib.Path(__file__).resolve().parent
+STUB_DIR = HERE / "test-support"
+SOURCE_SCRIPT = HERE / "preflight.sh"
+WORKDIR = pathlib.Path(tempfile.mkdtemp(prefix="preflight-rbac-"))
+
+SUB = "11111111-1111-1111-1111-111111111111"
+SUB_SCOPE = f"/subscriptions/{SUB}"
+RG_SCOPE = f"{SUB_SCOPE}/resourceGroups/langsmith-rg-dev"
+VNET_ID = f"{SUB_SCOPE}/resourceGroups/platform-network-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet"
+USER_OID = "33333333-3333-3333-3333-333333333333"
+SP_OID = "44444444-4444-4444-4444-444444444444"
+
+OWNER_GUID = "8e3af657a8ff443ca75c2fe8c4bcb635"
+CONTRIB_GUID = "b24988ac618042a0ab8820f7382dd24c"
+CUSTOM_GUID = "aaaaaaaabbbbccccddddeeeeeeeeeeee"
+
+ROLE_WRITE = "Microsoft.Authorization/roleAssignments/write"
+ROLE_DELETE = "Microsoft.Authorization/roleAssignments/delete"
+RESOURCE_ACTIONS = [
+    "Microsoft.Resources/subscriptions/resourceGroups/write",
+    "Microsoft.ContainerService/managedClusters/write",
+    "Microsoft.KeyVault/vaults/write",
+    "Microsoft.Storage/storageAccounts/write",
+    "Microsoft.Network/virtualNetworks/write",
+    "Microsoft.DBforPostgreSQL/flexibleServers/write",
+    "Microsoft.Cache/redis/write",
+]
+
+ABAC = (
+    "@Request[Microsoft.Authorization/roleAssignments:RoleDefinitionId] "
+    "ForAnyOfAnyValues:GuidEquals{acdd72a7-3385-48ef-bd42-f606fba81ae7}"
+)
+
+
+def granted(role_guid=OWNER_GUID, scope=SUB_SCOPE, condition=None, custom=False):
+    return {
+        "roleDefinitionId": role_guid,
+        "scope": scope,
+        "condition": condition,
+        "conditionVersion": "2.0" if condition else None,
+        "assignedToCustomRole": custom,
+        "isBuiltIn": not custom,
+        "principalType": "User",
+    }
+
+
+def decision(action, allowed=True, assignment=None, deny=None):
+    return {
+        "actionId": action,
+        "accessDecision": "Allowed" if allowed else "NotAllowed",
+        "isDataAction": False,
+        "roleAssignment": assignment if allowed else None,
+        "denyAssignment": deny,
+        "auditAssignments": [],
+        "timeToLiveInMs": 300000,
+    }
+
+
+def response(
+    write=True,
+    delete=True,
+    resources=True,
+    assignment=None,
+    deny=None,
+    refuse_resources=(),
+):
+    """A full nine-action checkAccess response for one scope."""
+    assignment = assignment if assignment is not None else granted()
+    out = [
+        decision(ROLE_WRITE, write, assignment, deny),
+        decision(ROLE_DELETE, delete, assignment),
+    ]
+    for action in RESOURCE_ACTIONS:
+        allowed = resources and action not in refuse_resources
+        out.append(decision(action, allowed, assignment))
+    return out
+
+
+def eligibility(role, scope=SUB_SCOPE):
+    return {
+        "properties": {
+            "scope": scope,
+            "endDateTime": "2026-12-01T00:00:00Z",
+            "expandedProperties": {"roleDefinition": {"displayName": role}},
+        }
+    }
+
+
+DENY = {"id": "deny-1", "displayName": "Landing zone RBAC lock"}
+
+ALL_GOOD = response()
+
+CASES = [
+    {
+        "name": "everything permitted passes at both scopes",
+        "ca_all": ALL_GOOD,
+        "expect": [
+            f"[✓] roleAssignments/write permitted at {SUB_SCOPE}, granted by Owner held at",
+            f"[✓] roleAssignments/write permitted at {RG_SCOPE}",
+            f"[✓] Every resource type the deployment creates is writable at {SUB_SCOPE}",
+        ],
+        "reject": ["[✗]", "Falling back"],
+    },
+    {
+        "name": "contributor is named as the granting role when it is the one that answered",
+        "ca_all": response(assignment=granted(role_guid=CONTRIB_GUID)),
+        "expect": ["granted by Contributor held at"],
+    },
+    {
+        "name": "a custom role that grants the action is reported as custom, not as unknown",
+        "ca_all": response(assignment=granted(role_guid=CUSTOM_GUID, custom=True)),
+        "expect": [f"granted by custom role {CUSTOM_GUID} held at"],
+    },
+    {
+        "name": "roleAssignments/write refused fails without inventing a reason",
+        "ca_all": response(write=False),
+        "expect": [
+            f"[✗] roleAssignments/write is not permitted at {SUB_SCOPE}. All eight role assignments",
+        ],
+        "reject": ["deny assignment", "PIM holds"],
+    },
+    {
+        "name": "a deny assignment is named and called out as overriding Owner",
+        "ca_all": response(write=False, deny=DENY),
+        "expect": [
+            '[✗] roleAssignments/write is denied at',
+            'deny assignment "Landing zone RBAC lock"',
+            "override every role assignment including Owner",
+        ],
+    },
+    {
+        "name": "an inactive PIM role turns the failure into an activation step",
+        "ca_all": response(write=False),
+        "eligibilities": [eligibility("Owner")],
+        "expect": [
+            "[✗] PIM holds these roles for this identity as eligible but not active: Owner at",
+            "activating it (portal: PIM -> My roles -> Activate)",
+        ],
+    },
+    {
+        "name": "an ABAC condition on the granting assignment warns",
+        "ca_all": response(assignment=granted(condition=ABAC)),
+        "expect": [
+            "[!] That grant carries an ABAC condition",
+            "The modules assign: Storage Blob Data Contributor",
+            "GuidEquals",
+        ],
+    },
+    {
+        "name": "a refused resource write fails and names the action",
+        "ca_all": response(refuse_resources=("Microsoft.Cache/redis/write",)),
+        "expect": ["[✗] Not permitted at", "Microsoft.Cache/redis/write"],
+        "reject": ["[✗] roleAssignments/write"],
+    },
+    {
+        "name": "no delete permission warns about destroy without failing apply",
+        "ca_all": response(delete=False),
+        "expect": ["[!] roleAssignments/delete is not permitted at", "terraform destroy"],
+        "reject": ["[✗]"],
+    },
+    {
+        "name": "permitted at the subscription but denied on the resource group fails on the scope",
+        "ca_sub": ALL_GOOD,
+        "ca_rg": response(write=False, deny=DENY),
+        "expect": [
+            f"[✓] roleAssignments/write permitted at {SUB_SCOPE}",
+            f"[✗] roleAssignments/write is denied at {RG_SCOPE}",
+        ],
+    },
+    {
+        "name": "a scope that does not answer is reported, and the others still render",
+        "ca_sub": ALL_GOOD,
+        "ca_rg_fail": True,
+        "expect": [
+            f"[!] checkAccess did not answer at {RG_SCOPE}",
+            f"[✓] roleAssignments/write permitted at {SUB_SCOPE}",
+        ],
+        "reject": ["Falling back"],
+    },
+    {
+        "name": "checkAccess unavailable everywhere falls back and says so",
+        "ca_fail": True,
+        "held": "Owner\nReader",
+        "expect": [
+            "[!] checkAccess (Microsoft.Authorization/checkAccess, 2018-09-01-preview) did not answer",
+            "cannot see deny assignments, ABAC conditions, or custom roles",
+            "[✓] Holds Owner,Reader at or above the subscription",
+        ],
+    },
+    {
+        "name": "fallback fails when no qualifying role name is held",
+        "ca_fail": True,
+        "held": "Reader\nMonitoring Contributor",
+        "expect": [
+            "[✗] No Owner, User Access Administrator, or Role Based Access Control Administrator",
+            "Roles held: Reader,Monitoring Contributor",
+            "custom role carrying roleAssignments/write would also work and is not detected",
+        ],
+    },
+    {
+        "name": "fallback with nothing readable refuses to render a verdict",
+        "ca_fail": True,
+        "assignments_fail": True,
+        "expect": ["[✗] No role assignments could be read for this principal"],
+        "reject": ["[✓] Holds"],
+    },
+    {
+        "name": "a reshaped response counts as unavailable rather than as a verdict",
+        "ca_all_raw": json.dumps({"value": [decision(ROLE_WRITE, True, granted())]}),
+        "held": "Owner",
+        "expect": ["Falling back to a role-name check"],
+        "reject": ["[✓] roleAssignments/write permitted"],
+    },
+    {
+        "name": "a non-JSON response counts as unavailable",
+        "ca_all_raw": "<html>gateway timeout</html>",
+        "held": "Owner",
+        "expect": ["Falling back to a role-name check"],
+    },
+    {
+        "name": "an empty array counts as unavailable rather than as nothing permitted",
+        "ca_all_raw": "[]",
+        "held": "Owner",
+        "expect": ["Falling back to a role-name check"],
+        "reject": ["[✗] roleAssignments/write is not permitted"],
+    },
+    {
+        "name": "ARM_CLIENT_ID makes the service principal the Subject, not the operator",
+        "env": {"ARM_CLIENT_ID": "app-guid"},
+        "ca_all": ALL_GOOD,
+        "expect": [
+            "[!] ARM_CLIENT_ID is set",
+            f"service principal from ARM_CLIENT_ID (object ID {SP_OID})",
+        ],
+        "assert_subject": SP_OID,
+        "reject_calls": ["roleEligibilityScheduleInstances"],
+    },
+    {
+        "name": "a denied service principal is not handed the operator's PIM eligibilities",
+        "env": {"ARM_CLIENT_ID": "app-guid"},
+        "ca_all": response(write=False),
+        "eligibilities": [eligibility("Owner")],
+        "expect": [
+            "[!] Terraform will authenticate as a principal other than the one running this script",
+        ],
+        "reject": ["PIM holds these roles"],
+    },
+    {
+        "name": "an invalid identifier drops the resource group scope instead of building a bad URL",
+        "tfvars_identifier": '"-Prod Corp"',
+        "ca_all": ALL_GOOD,
+        "expect": ["[!] terraform.tfvars: identifier is not a valid resource-name suffix"],
+        "reject_calls": ["resourceGroups"],
+    },
+    {
+        "name": "an empty identifier still yields a resource group scope",
+        "tfvars_identifier": '""',
+        "ca_all": ALL_GOOD,
+        "expect_calls": [f"{SUB_SCOPE}/resourceGroups/langsmith-rg/providers"],
+    },
+    {
+        "name": "a bring-your-own VNet is checked as its own scope",
+        "tfvars_extra": f'vnet_id = "{VNET_ID}"',
+        "ca_all": ALL_GOOD,
+        "ca_vnet": response(write=False, deny=DENY),
+        "expect": [f"[✗] roleAssignments/write is denied at {VNET_ID}"],
+        "expect_calls": [VNET_ID],
+    },
+    {
+        "name": "a malformed vnet_id is dropped rather than interpolated",
+        "tfvars_extra": 'vnet_id = "https://evil.example.com/x"',
+        "ca_all": ALL_GOOD,
+        "expect": ["[!] terraform.tfvars: vnet_id is not a VNet resource ID"],
+        "reject_calls": ["evil.example.com"],
+    },
+    {
+        "name": "an unresolvable principal skips the RBAC check entirely",
+        "no_graph": True,
+        "ca_all": ALL_GOOD,
+        "expect": ["[!] Could not resolve an object ID", "[!] Skipping RBAC check"],
+        "reject": ["[✗] roleAssignments/write"],
+    },
+    {
+        "name": "an ARM_SUBSCRIPTION_ID mismatch fails before any verdict is trusted",
+        "env": {"ARM_SUBSCRIPTION_ID": "99999999-9999-9999-9999-999999999999"},
+        "ca_all": ALL_GOOD,
+        "expect": ["[✗] ARM_SUBSCRIPTION_ID is 99999999", "every check in this script reads"],
+    },
+]
+
+
+def build_case(case, index):
+    root = WORKDIR / f"case{index:02d}"
+    infra = root / "infra"
+    (infra / "scripts").mkdir(parents=True)
+    shutil.copy2(SOURCE_SCRIPT, infra / "scripts" / "preflight.sh")
+
+    identifier = case.get("tfvars_identifier", '"-dev"')
+    (infra / "terraform.tfvars").write_text(
+        f'subscription_id = "{SUB}"\n'
+        'location    = "eastus"\n'
+        f"identifier  = {identifier}\n"
+        f"{case.get('tfvars_extra', '')}\n"
+    )
+    (infra / "secrets.auto.tfvars").write_text('langsmith_license_key = "lsv2_pt_stub"\n')
+
+    fixture = root / "fixtures"
+    fixture.mkdir()
+    (fixture / "sub_id").write_text(SUB)
+    (fixture / "principal_id").write_text(case.get("principal_id", USER_OID))
+    (fixture / "sp_principal_id").write_text(SP_OID)
+    if "ARM_CLIENT_ID" not in case.get("env", {}):
+        (fixture / "user_type").write_text("user")
+
+    for key, name in (
+        ("ca_all", "ca_all.json"),
+        ("ca_sub", "ca_sub.json"),
+        ("ca_rg", "ca_rg.json"),
+        ("ca_vnet", "ca_vnet.json"),
+    ):
+        if key in case:
+            (fixture / name).write_text(json.dumps(case[key]))
+    if "ca_all_raw" in case:
+        (fixture / "ca_all.json").write_text(case["ca_all_raw"])
+
+    (fixture / "eligibilities.json").write_text(
+        json.dumps({"value": case.get("eligibilities", [])})
+    )
+    if "held" in case:
+        (fixture / "held").write_text(case["held"])
+
+    for flag in ("no_graph", "ca_fail", "ca_rg_fail", "ca_sub_fail", "ca_vnet_fail",
+                 "assignments_fail"):
+        if case.get(flag):
+            (fixture / flag).write_text("1")
+
+    return infra / "scripts" / "preflight.sh", fixture
+
+
+def run_case(case, index):
+    script, fixture = build_case(case, index)
+
+    env = dict(os.environ)
+    env["PATH"] = f"{STUB_DIR}:{env['PATH']}"
+    env["FIXTURE_DIR"] = str(fixture)
+    for key in ("ARM_CLIENT_ID", "ARM_SUBSCRIPTION_ID", "ARM_TENANT_ID",
+                "ARM_USE_MSI", "ARM_USE_OIDC"):
+        env.pop(key, None)
+    env.update(case.get("env", {}))
+
+    proc = subprocess.run(
+        ["bash", str(script)], capture_output=True, text=True, env=env, timeout=120
+    )
+    output = ANSI.sub("", proc.stdout + proc.stderr)
+    if "STUB: unhandled" in output or "STUB: unexpected" in output:
+        return False, [line for line in output.splitlines() if "STUB:" in line]
+
+    calls_path = fixture / "calls.log"
+    calls = calls_path.read_text() if calls_path.exists() else ""
+
+    problems = []
+    for needle in case.get("expect", []):
+        if needle not in output:
+            problems.append(f"missing: {needle}")
+    for needle in case.get("reject", []):
+        if needle in output:
+            problems.append(f"unexpected: {needle}")
+    for needle in case.get("expect_calls", []):
+        if needle not in calls:
+            problems.append(f"never requested: {needle}")
+    for needle in case.get("reject_calls", []):
+        if needle in calls:
+            problems.append(f"unexpectedly requested: {needle}")
+
+    if "assert_subject" in case:
+        body_path = fixture / "last_body.json"
+        if not body_path.exists():
+            problems.append("no checkAccess body was sent")
+        else:
+            got = json.loads(body_path.read_text())["Subject"]["Attributes"]["ObjectId"]
+            if got != case["assert_subject"]:
+                problems.append(f"Subject was {got}, expected {case['assert_subject']}")
+
+    if problems:
+        rendered = [
+            line for line in output.splitlines()
+            if any(mark in line for mark in ("[✓]", "[!]", "[✗]"))
+            and "Microsoft." not in line.split("]")[-1][:30]
+        ]
+        problems.append("--- rendered ---")
+        problems.extend(rendered)
+    return not problems, problems
+
+
+def main():
+    for required in (SOURCE_SCRIPT, STUB_DIR / "az"):
+        if not required.exists():
+            print(f"not found: {required}")
+            return 1
+    failures = 0
+    try:
+        for index, case in enumerate(CASES, start=1):
+            ok, problems = run_case(case, index)
+            print(f"{'PASS' if ok else 'FAIL'}  {case['name']}")
+            if not ok:
+                failures += 1
+                for line in problems:
+                    print(f"        {line}")
+    finally:
+        shutil.rmtree(WORKDIR, ignore_errors=True)
+    print(f"\n{len(CASES) - failures}/{len(CASES)} cases passed")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/modules/azure/infra/scripts/test-support/az
+++ b/modules/azure/infra/scripts/test-support/az
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Stub `az` for exercising preflight.sh's RBAC block without a real subscription.
+# Fixtures come from $FIXTURE_DIR; anything unset falls back to a benign default.
+# Any invocation the script makes that is not handled here exits non-zero with a
+# STUB marker, so a call the tests do not model fails loudly instead of passing.
+set -uo pipefail
+
+FIX="${FIXTURE_DIR:?FIXTURE_DIR must be set}"
+ARGS="$*"
+
+emit_file() { if [ -f "$1" ]; then cat "$1"; else printf '%s' "$2"; fi; }
+
+# First existing file wins; an empty JSON array if none exist.
+pick() {
+  for candidate in "$@"; do
+    if [ -f "$candidate" ]; then cat "$candidate"; return 0; fi
+  done
+  printf '[]'
+}
+
+case "$ARGS" in
+  "version"*)
+    echo "2.88.0" ;;
+  "account show --query id"*)
+    emit_file "$FIX/sub_id" "11111111-1111-1111-1111-111111111111" ;;
+  "account show --query tenantId"*)
+    emit_file "$FIX/tenant_id" "22222222-2222-2222-2222-222222222222" ;;
+  "account show --query user.type"*)
+    emit_file "$FIX/user_type" "user" ;;
+  "account show --query user.name"*)
+    emit_file "$FIX/user_name" "app-id-here" ;;
+  "account show")
+    emit_file "$FIX/account.json" '{"name":"stub-sub","id":"11111111-1111-1111-1111-111111111111","tenantId":"22222222-2222-2222-2222-222222222222","user":{"name":"stub@example.com","type":"user"}}' ;;
+  "provider show"*)
+    echo "Registered" ;;
+  "ad signed-in-user show"*)
+    if [ -f "$FIX/no_graph" ]; then exit 1; fi
+    emit_file "$FIX/principal_id" "33333333-3333-3333-3333-333333333333" ;;
+  "ad sp show"*)
+    if [ -f "$FIX/no_graph" ]; then exit 1; fi
+    emit_file "$FIX/sp_principal_id" "44444444-4444-4444-4444-444444444444" ;;
+  *checkAccess*)
+    # Record the request so a test can assert which scopes were probed and which
+    # principal was named as the Subject.
+    printf '%s\n' "$ARGS" >> "$FIX/calls.log"
+    BODY_PATH=${ARGS#*--body @}
+    BODY_PATH=${BODY_PATH%% *}
+    if [ -f "$BODY_PATH" ]; then cp "$BODY_PATH" "$FIX/last_body.json"; fi
+
+    if [ -f "$FIX/ca_fail" ]; then exit 1; fi
+    case "$ARGS" in
+      *virtualNetworks*)
+        if [ -f "$FIX/ca_vnet_fail" ]; then exit 1; fi
+        pick "$FIX/ca_vnet.json" "$FIX/ca_all.json" ;;
+      *resourceGroups*)
+        if [ -f "$FIX/ca_rg_fail" ]; then exit 1; fi
+        pick "$FIX/ca_rg.json" "$FIX/ca_all.json" ;;
+      *)
+        if [ -f "$FIX/ca_sub_fail" ]; then exit 1; fi
+        pick "$FIX/ca_sub.json" "$FIX/ca_all.json" ;;
+    esac ;;
+  "role assignment list --scope"*)
+    # Only the fallback path reaches this, and only for the role-name list.
+    if [ -f "$FIX/assignments_fail" ]; then exit 1; fi
+    case "$ARGS" in
+      *roleDefinitionName*) emit_file "$FIX/held" "" ;;
+      *) echo "STUB: unexpected role assignment query: $ARGS" >&2; exit 1 ;;
+    esac ;;
+  *roleEligibilityScheduleInstances*)
+    printf '%s\n' "$ARGS" >> "$FIX/calls.log"
+    emit_file "$FIX/eligibilities.json" '{"value":[]}' ;;
+  *)
+    echo "STUB: unhandled az invocation: $ARGS" >&2
+    exit 1 ;;
+esac

--- a/modules/azure/infra/variables.tf
+++ b/modules/azure/infra/variables.tf
@@ -134,6 +134,12 @@ variable "postgres_source" {
   }
 }
 
+variable "postgres_sku_name" {
+  type        = string
+  description = "SKU for the PostgreSQL Flexible Server. Exposed because LocationIsOfferRestricted is sometimes scoped to a SKU family, so switching tiers can clear it without changing region."
+  default     = "GP_Standard_D2ds_v4"
+}
+
 variable "redis_source" {
   type        = string
   description = "Redis deployment type. 'external' provisions Azure Cache for Redis (private VNet). 'in-cluster' uses the chart-managed in-cluster Redis pod (dev/demo only)."


### PR DESCRIPTION
## Why

A customer hit two failures on the same deployment. Both surfaced well into a long apply, after AKS and the ingress controller were already built, and neither had to get that far before being caught.

**`403 AuthorizationFailed`** on `Microsoft.Authorization/roleAssignments/write` at `azurerm_role_assignment.blob_data_contributor`, after `make preflight` reported RBAC as fine. Preflight was checking for the role *names* Owner and User Access Administrator at subscription scope, which answers a different question than the one apply asks.

Holding the role and being able to use it are not the same thing. Owner does include `roleAssignments/write`, so a 403 means one of these:

- the grant is PIM-eligible and was never activated (`az role assignment list` shows only active assignments, so the old check saw nothing while the portal showed Owner)
- an ABAC condition on the grant restricts which `roleDefinitionId`s the holder may assign
- a deny assignment from a landing zone or managed application overrides it, and no role grant will fix that
- the grant is at a different scope than the resource
- Terraform authenticated as a different principal than the one checked, because `ARM_CLIENT_ID` / `ARM_USE_MSI` / `ARM_USE_OIDC` outrank the `az login` preflight reads

The name check also fails in the other direction, reporting a working setup as broken when the action comes from a custom role, a group membership, or a management-group grant.

**`LocationIsOfferRestricted`** on `azurerm_postgresql_flexible_server`. This one is a property of how the subscription was bought, not of regional capacity, so retrying and resizing do nothing. Free Trial, MSDN, Visual Studio, Azure Pass, MPN, and sponsored subscriptions are blocked from provisioning PostgreSQL Flexible Server in high-demand regions.

## What changed

### Preflight asks ARM for the RBAC verdict

Reconstructing the answer from role definitions cannot get it right, because an ABAC condition can restrict which roles a delegate may assign, a deny assignment overrides every grant including Owner, a PIM-eligible role grants nothing until activated, and a custom role can carry the action under any name. So preflight asks `Microsoft.Authorization/checkAccess` for the decision ARM will actually make, per action and per scope.

A new **Deployer Identity** section resolves the principal the azurerm provider will present, following the provider's own precedence (`ARM_CLIENT_ID` → MSI/OIDC → `az login`), and hard-fails when `ARM_SUBSCRIPTION_ID` or `ARM_TENANT_ID` disagrees with the active account. Without that, preflight validates one subscription while Terraform deploys into another.

The **RBAC** section then probes nine actions:

```
Microsoft.Authorization/roleAssignments/write        Microsoft.Storage/storageAccounts/write
Microsoft.Authorization/roleAssignments/delete       Microsoft.Network/virtualNetworks/write
Microsoft.Resources/subscriptions/resourceGroups/write   Microsoft.DBforPostgreSQL/flexibleServers/write
Microsoft.ContainerService/managedClusters/write     Microsoft.Cache/redis/write
Microsoft.KeyVault/vaults/write
```

at up to three scopes: the subscription, the resource group the deployment creates, and a bring-your-own VNet when `vnet_id` is set. `roleAssignments/write` is the one that decides whether apply finishes, since eight resources across the storage, Key Vault, DNS, bastion, and AKS modules create role assignments.

Deny assignments and ABAC conditions are already applied in the answer, so a refusal names the deny assignment when there is one, and a grant carrying a condition is flagged because the condition can still reject the specific roles the modules assign. A refusal is cross-checked against PIM, so a role held but not activated reads as "activate it" rather than "you do not have it."

`checkAccess` is the call the portal's Access control blade makes. It is also undocumented: nothing in `azure-rest-api-specs`, no `az` command, and `2018-09-01-preview` is the only api-version ever registered. What it does that nothing documented can is evaluate any named principal, including one other than the caller, at a scope that does not exist yet, with deny assignments and conditions already applied. A missing or reshaped response is therefore treated as unavailable and degrades to a role-name check, never as a verdict. The script reports which path produced the answer, because a clean result on the fallback is weaker than a clean result on the primary path.

### Preflight checks the subscription offer type

A new **Subscription Offer Type** section reads `subscriptionPolicies.quotaId` and warns when the offer is one of the restricted families. `quotaId` is the only field that reports the offer type, and it is a prefix match because the suffix is a signup date.

This changes the section numbering: offer type is 5, `terraform.tfvars` moves to 6, tooling to 7.

### `postgres_sku_name` is wired through

The root module never passed `sku_name` to the postgres module, so the SKU was pinned to the module default with no way to override it. The offer restriction is sometimes scoped to a SKU family, which makes a tier switch a real workaround, so the variable now exists and reaches the module.

### `PERMISSIONS.md`

The reference the README's "run `make preflight` rather than reasoning from the role list in the portal" line points at. It covers the roles the deployment needs with their definition GUIDs, the eight role assignments it creates and their scopes, how to restrict which roles the deployer may assign via ABAC, and how to read a 403 on `roleAssignments/write`. It also carries a standalone `checkAccess` probe for inspecting an arbitrary action or principal, which is the part `make preflight` does not cover.

`Role Based Access Control Administrator` replaces `User Access Administrator` in the README's role table. It is the narrower of the two and grants exactly the action the deployment needs.

`TROUBLESHOOTING.md` gains entries for both errors, with the `LocationIsOfferRestricted` fixes ranked: convert the subscription to Pay-As-You-Go, request an exemption, switch SKU family, run Postgres in-cluster for a dev deployment, change region last.

## Known limits

Deliberate, and stated in code comments rather than papered over:

- ABAC conditions are surfaced, not evaluated. Preflight prints the condition and the roles the modules assign; deciding whether they intersect is the operator's call.
- A deny assignment that names a group the principal belongs to rather than the principal itself is invisible, and surfaces as a 403 at apply.
- With `ARM_USE_MSI` or `ARM_USE_OIDC` there is no object ID to query, so the RBAC block warns and skips rather than reporting a verdict about the wrong identity.
- The offer-type list is a prefix match against Microsoft's published offer IDs. A restricted offer outside those families reads as a pass.

## Testing

- `make test-preflight` runs 25 cases against a stubbed `az`, covering each verdict, both `ARM_*` mismatches, the PIM cross-check, every read-failure and malformed-response path, and the scope-construction edge cases. Verified passing locally at 25/25.
- `bash -n` and `shellcheck -S warning` clean. `terraform validate` and `terraform fmt -check -recursive` clean.
- Run live against a Pay-As-You-Go subscription: the `checkAccess` path returns real verdicts and names the granting role and scope, and the offer-type check reads `PayAsYouGo_2014-09-01` and passes.
- **Not** verified against a live restricted subscription, a live deny assignment, or a live PIM-eligible grant. Those paths are covered by the stubbed tests only.
