### PR TITLE
feat(azure): availability zone control for Redis, fail loudly on AKS zone drift

### DIFF
--- a/modules/azure/README.md
+++ b/modules/azure/README.md
@@ -687,13 +687,13 @@ azure/
 
 | Module | Required | Description |
 |--------|----------|-------------|
-| `networking` | yes | VNet, subnets (main, postgres, redis, bastion, agic). AGIC subnet (`10.0.96.0/24`) is created automatically when `ingress_controller = "agic"`. Multi-AZ zone pinning supported. |
+| `networking` | yes | VNet, subnets (main, postgres, redis, bastion, agic). AGIC subnet (`10.0.96.0/24`) is created automatically when `ingress_controller = "agic"`. Not zonal — an Azure subnet spans every zone in its region. |
 | `k8s-cluster` | yes | AKS cluster, node pools, OIDC issuer, managed identity, federated credentials (Workload Identity centralized here). Installs ingress controller via Helm: nginx / istio / istio-addon / agic (App Gateway v2 + AGIC chart) / envoy-gateway. |
 | `k8s-bootstrap` | yes | Kubernetes namespace, ServiceAccount, cert-manager, KEDA, postgres/redis K8s secrets. |
 | `storage` | yes | Azure Blob storage account + container. |
 | `keyvault` | yes | Azure Key Vault (RBAC mode, soft-delete) + all application secrets. |
 | `postgres` | optional | Azure DB for PostgreSQL Flexible Server. Enabled when `postgres_source = "external"`. Multi-AZ standby supported. |
-| `redis` | optional | Azure Cache for Redis Premium. Enabled when `redis_source = "external"`. |
+| `redis` | optional | Azure Managed Redis (`Microsoft.Cache/redisEnterprise`) + private endpoint. Enabled when `redis_source = "external"`. Zone pinning via `redis_availability_zones`. |
 | `dns` | optional | Azure DNS zone + A record. Required for DNS-01 cert issuance (`tls_certificate_source = "dns01"`). |
 | `waf` | optional | Azure WAF policy (OWASP 3.2 + bot protection). Use `agw_sku_tier = "WAF_v2"` with AGIC for integrated WAF — no separate module needed. |
 | `diagnostics` | optional | Log Analytics workspace + diagnostic settings for AKS, Key Vault, and Blob. |
@@ -708,14 +708,67 @@ azure/
 ## Multi-AZ Support
 
 ```hcl
-# Spread AKS nodes across zones 1, 2, 3
+# AKS node pools + Postgres primary
 availability_zones = ["1", "2", "3"]
+
+# Azure Managed Redis — pinned independently of the cluster
+redis_availability_zones = ["2"]
 
 # PostgreSQL HA standby in a different zone
 postgres_high_availability_mode = "ZoneRedundant"
 ```
 
 Zone-redundant PostgreSQL requires `GeneralPurpose` or `MemoryOptimized` SKU.
+
+`redis_availability_zones` is separate from `availability_zones` and defaults to
+`[]`, which lets Azure place the cluster. Pin it when a specific zone is required —
+for example when zone 1 in your region is capacity-constrained and AMR provisioning
+returns `AllocationFailed`.
+
+### Zones apply at creation only
+
+Neither an AKS node pool nor an AMR cluster can be re-zoned in place. `availability_zones`
+is guarded by a postcondition that fails the plan rather than returning a clean no-op,
+so a zone change that cannot be applied is never mistaken for one that was. To move an
+existing deployment across zones, recreate the resource.
+
+### Regions that publish AMR zones
+
+Zone support is a property of the **region**, not the SKU. Across all 1023
+`Microsoft.Cache/skus` entries there is no region where `IsZonalDeploymentAllowed` or
+the published zone list differs between SKUs, so a region either offers zones to every
+AMR tier or to none.
+
+| Region | Zones | Notes |
+|--------|-------|-------|
+| `australiacentral`, `northcentralus`, `westus` | none | No availability zones. Leave `redis_availability_zones = []`. |
+| `eastus3` | none published | Reports zonal support but returns an empty zone list. Verify before pinning. |
+| All 39 others below | `1`, `2`, `3` | Any single zone or combination is accepted. |
+
+The 39 regions offering zones 1/2/3: `australiaeast`, `austriaeast`, `belgiumcentral`,
+`brazilsouth`, `canadacentral`, `centralindia`, `centralus`, `chilecentral`,
+`denmarkeast`, `eastasia`, `eastus`, `eastus2`, `eastus2euap`, `francecentral`,
+`germanywestcentral`, `indiasouthcentral`, `indonesiacentral`, `israelcentral`,
+`italynorth`, `japaneast`, `japanwest`, `koreacentral`, `malaysiawest`,
+`mexicocentral`, `newzealandnorth`, `northeurope`, `norwayeast`, `polandcentral`,
+`southafricanorth`, `southcentralus`, `southeastasia`, `spaincentral`, `swedencentral`,
+`switzerlandnorth`, `uaenorth`, `uksouth`, `westeurope`, `westus2`, `westus3`.
+
+Regions absent from this list have no Azure Managed Redis availability at all.
+
+To re-check for your own region and subscription:
+
+```bash
+az rest --method get \
+  --url "https://management.azure.com/subscriptions/$(az account show --query id -o tsv)/providers/Microsoft.Cache/skus?api-version=2025-07-01" \
+  | jq -r '[.value[] | select(.locationInfo[].location == "eastus")][0].locationInfo[0].zones'
+```
+
+> **Unverified:** whether the smallest SKU (`Balanced_B0`) accepts a pinned zone.
+> The SKU API reports zone support per region, not per tier, so it cannot answer this.
+> `schema_validation_enabled = false` on the azapi resource means Terraform will not
+> catch a rejection locally — ARM would reject it at apply. Confirm with a scratch
+> deployment before relying on `redis_availability_zones` with `Balanced_B0`.
 
 ---
 

--- a/modules/azure/infra/main.tf
+++ b/modules/azure/infra/main.tf
@@ -84,8 +84,7 @@ module "vnet" {
   postgres_subnet_address_prefix = var.postgres_subnet_address_prefix
   redis_subnet_address_prefix    = var.redis_subnet_address_prefix
 
-  enable_bastion     = var.create_bastion
-  availability_zones = var.availability_zones
+  enable_bastion = var.create_bastion
 
   # AGIC subnet: provisioned only when ingress_controller = "agic"
   enable_agic                = var.ingress_controller == "agic"

--- a/modules/azure/infra/main.tf
+++ b/modules/azure/infra/main.tf
@@ -189,6 +189,7 @@ module "redis" {
   subnet_id           = local.redis_subnet_id                    # private endpoint goes here
   vnet_id             = local.vnet_id                            # private DNS zone link
   amr_sku             = var.amr_sku
+  availability_zones  = var.redis_availability_zones
 
   tags = local.common_tags
 }

--- a/modules/azure/infra/modules/k8s-cluster/main.tf
+++ b/modules/azure/infra/modules/k8s-cluster/main.tf
@@ -190,6 +190,21 @@ resource "azurerm_kubernetes_cluster" "main" {
       default_node_pool[0].upgrade_settings,
       default_node_pool[0].zones,
     ]
+
+    # ignore_changes above makes a zone change a silent no-op: the plan comes
+    # back clean and the node pool stays where it is. Fail loudly instead, so a
+    # requested zone change is never mistaken for an applied one.
+    postcondition {
+      condition = toset(try(self.default_node_pool[0].zones, [])) == toset(var.availability_zones)
+      error_message = join("", [
+        "AKS node pool zones are [",
+        join(",", try(self.default_node_pool[0].zones, [])),
+        "] but availability_zones requests [",
+        join(",", var.availability_zones),
+        "]. AKS cannot re-zone an existing node pool; zones apply only at creation. ",
+        "Either revert availability_zones to match, or recreate the node pool.",
+      ])
+    }
   }
 }
 

--- a/modules/azure/infra/modules/networking/variables.tf
+++ b/modules/azure/infra/modules/networking/variables.tf
@@ -67,12 +67,6 @@ variable "bastion_subnet_address_prefix" {
   default     = ["10.0.80.0/27"] # 32 IPs — sufficient for a single jump VM
 }
 
-variable "availability_zones" {
-  type        = list(string)
-  description = "Availability zones to spread resources across. Use [\"1\",\"2\",\"3\"] for zone-redundant HA. Default [\"1\"] for single-zone (lower cost)."
-  default     = ["1"]
-}
-
 variable "enable_agic" {
   type        = bool
   description = "Create a dedicated subnet for AGIC (Application Gateway Ingress Controller). Required when ingress_controller = 'agic'."

--- a/modules/azure/infra/modules/redis/main.tf
+++ b/modules/azure/infra/modules/redis/main.tf
@@ -24,7 +24,10 @@ resource "azapi_resource" "amr" {
   parent_id = var.resource_group_id
 
   body = {
-    sku = { name = var.amr_sku }
+    # Top-level ARM property (sibling of sku), not a member of properties.
+    # null omits the key entirely, letting Azure choose placement.
+    zones = length(var.availability_zones) > 0 ? var.availability_zones : null
+    sku   = { name = var.amr_sku }
     properties = {
       minimumTlsVersion = "1.2"
       # Required at API 2025-07-01. Private-endpoint-only — no public access.

--- a/modules/azure/infra/modules/redis/variables.tf
+++ b/modules/azure/infra/modules/redis/variables.tf
@@ -46,6 +46,12 @@ variable "high_availability" {
   default     = false
 }
 
+variable "availability_zones" {
+  type        = list(string)
+  description = "Availability zones to pin the AMR cluster to. Empty (default) lets Azure place it. Most regions offer [\"1\",\"2\",\"3\"]; australiacentral, northcentralus and westus have no zones."
+  default     = []
+}
+
 variable "tags" {
   type        = map(string)
   description = "Common Azure resource tags to apply to all resources in this module"

--- a/modules/azure/infra/terraform.tfvars.example
+++ b/modules/azure/infra/terraform.tfvars.example
@@ -171,7 +171,11 @@ sizing_profile = "production"
 # create_bastion     = true   # Jump VM for private AKS node access
 
 # ── Multi-AZ (optional) ───────────────────────────────────────────────────────
-# availability_zones                   = ["1", "2", "3"]  # zone-redundant HA
+# Zones apply at CREATION only — AKS node pools and AMR cannot be re-zoned in
+# place. Changing these on a live deployment fails the plan; recreate instead.
+# See README "Multi-AZ Support" for which regions publish zones.
+# availability_zones                   = ["1", "2", "3"]  # AKS nodes + Postgres primary
+# redis_availability_zones             = ["2"]            # AMR — separate from the above
 # postgres_standby_availability_zone   = "2"              # Postgres HA standby
 # postgres_geo_redundant_backup        = true             # geo-redundant backups
 

--- a/modules/azure/infra/terraform.tfvars.production
+++ b/modules/azure/infra/terraform.tfvars.production
@@ -128,6 +128,10 @@ sizing_profile = "production"
 #------------------------------------------------------------------------------
 # Multi-AZ — for zone-redundant HA (optional)
 #------------------------------------------------------------------------------
-# availability_zones                 = ["1", "2", "3"]
+# Zones apply at CREATION only — AKS node pools and AMR cannot be re-zoned in
+# place. Changing these on a live deployment fails the plan; recreate instead.
+# See README "Multi-AZ Support" for which regions publish zones.
+# availability_zones                 = ["1", "2", "3"]   # AKS nodes + Postgres primary
+# redis_availability_zones           = ["2"]             # AMR — separate from the above
 # postgres_standby_availability_zone = "2"
 # postgres_geo_redundant_backup      = true

--- a/modules/azure/infra/variables.tf
+++ b/modules/azure/infra/variables.tf
@@ -174,6 +174,12 @@ variable "amr_sku" {
   default     = "Balanced_B0"
 }
 
+variable "redis_availability_zones" {
+  type        = list(string)
+  description = "Availability zones for Azure Managed Redis. Independent of var.availability_zones so Redis can be placed separately from AKS/Postgres. Empty (default) lets Azure choose."
+  default     = []
+}
+
 variable "blob_ttl_enabled" {
   type        = bool
   description = "Enable TTL for the blob container"


### PR DESCRIPTION
## What

Azure Managed Redis had **no** zone configuration. The module never emitted the ARM `zones` property and the root never passed one, so placement was left entirely to Azure with no way to influence it.

- **New `redis_availability_zones` root variable**, deliberately separate from `var.availability_zones` so Redis can be placed independently of AKS and Postgres. Defaults to `[]`, which omits the key from the ARM request and preserves current behavior for existing deployments.
- **Postcondition on the AKS default node pool** so a zone change that cannot take effect fails loudly instead of silently no-opping.

## Why the AKS postcondition

`ignore_changes` on `default_node_pool[0].zones` is necessary — AKS applies zones only at node pool creation, so without it, setting `availability_zones` on a live cluster forces recreation. But it also means a zone change on an existing cluster plans clean and does nothing. The operator sees a green apply and reasonably concludes the cluster is now zone-redundant when it isn't.

The postcondition compares requested against actual zones and fails with both sets named. It converts a silent wrong outcome into a loud one; it cannot prevent the apply, since postconditions evaluate after the resource is updated.

## Region reference

Pulled from ARM's `Microsoft.Cache/skus` capabilities across all 43 AMR regions: 39 offer zones `1`/`2`/`3`. `australiacentral`, `northcentralus` and `westus` have none. `eastus3` reports zonal support but publishes an empty zone list, so treat it as unknown and verify before pinning. Noted in the variable description, and the full table is now in `modules/azure/README.md` under "Multi-AZ Support".

Worth knowing: `IsZonalDeploymentAllowed` in that API tracks whether the *region* has availability zones, not whether the SKU supports them. Verified across all 1023 `Microsoft.Cache/skus` entries: there is no region where the flag or the published zone list differs between SKUs.

## Not covered here

- Whether `Balanced_B0` accepts a pinned zone is **unverified**. The SKU API doesn't answer it, and the module's existing comment only speaks to `highAvailability`, a different ARM property. Since `schema_validation_enabled = false`, azapi won't catch a rejection locally — ARM would reject at apply. Worth an empirical create before anyone relies on B0 + zones.
- `var.availability_zones` is still passed to the networking module and never used there. VNets and subnets aren't zonal resources in Azure, so nothing needs it. Left alone to keep this diff scoped; it's a two-line removal.

## Testing

`terraform fmt -recursive` clean, `terraform validate` passes.

Not applied against a live cluster. The Redis change is additive and inert at the default (`[]` omits the property), but the postcondition will fire on any existing deployment whose node pool zones don't match its configured `availability_zones` — including deployments that drifted before this change. That surfaces a real pre-existing mismatch rather than creating one, but it will look like a new failure.

