### PR TITLE
fix(azure): validate aks_service_cidr at the prompt and at plan

### DIFF
--- a/modules/azure/README.md
+++ b/modules/azure/README.md
@@ -864,7 +864,9 @@ Terraform builds, and an overlap with your own address space can be accepted whe
 the cluster is created and break later, so plan makes you name one and rejects one
 that lands inside your VNet. Peered and on-premises ranges are still yours to keep
 clear of, since plan only sees the VNet itself. `aks_dns_service_ip` follows from
-`aks_service_cidr` automatically as the eleventh address unless you set one.
+`aks_service_cidr` automatically as the eleventh address unless you set one, and
+plan rejects a value outside the range — worth knowing if you set both by hand,
+because changing the range strands an address written against the old one.
 
 Attaching to an existing cluster (`create_cluster = false`) ignores both. Azure
 fixes the ClusterIP range when the cluster is created and it cannot be changed
@@ -908,8 +910,9 @@ an apply:
   space. The defaults describe the VNet Terraform builds, so this is usually the
   first thing to change on a network of your own
 - `aks_service_cidr` is set, and does not overlap your VNet's address space, when
-  Terraform creates the cluster. Attaching to an existing one skips both checks,
-  since its ClusterIP range is already fixed and this value cannot change it
+  Terraform creates the cluster, and `aks_dns_service_ip` sits inside it when you
+  set one. Attaching to an existing cluster skips all three, since its ClusterIP
+  range is already fixed and neither value can change it
 - subnet IDs are not set while `create_vnet = true`, where they would be ignored
 
 Whoever runs Terraform needs two kinds of access to the VNet, which normally

--- a/modules/azure/infra/main.tf
+++ b/modules/azure/infra/main.tf
@@ -189,6 +189,8 @@ locals {
     local.vnet_address_space,
     [for entry in local.carved_prefixes : entry.prefix],
     [local.aks_service_cidr],
+    # A single address, measured as a /32 so the bounds below cover it too.
+    ["${local.aks_dns_service_ip}/32"],
   ))
   cidr_first = { for cidr in local.measured_cidrs : cidr => sum([
     for i, octet in split(".", cidrhost(cidr, 0)) : tonumber(octet) * pow(256, 3 - i)
@@ -213,6 +215,14 @@ locals {
     local.cidr_first[local.aks_service_cidr] <= local.cidr_last[space] &&
     local.cidr_last[local.aks_service_cidr] >= local.cidr_first[space]
   ])
+
+  # AKS takes the CoreDNS address out of the service range and rejects one that
+  # sits outside it. A /32 starts and ends at the same number, so its first
+  # bound is the address.
+  dns_service_ip_outside_service_cidr = (
+    local.cidr_first["${local.aks_dns_service_ip}/32"] < local.cidr_first[local.aks_service_cidr] ||
+    local.cidr_first["${local.aks_dns_service_ip}/32"] > local.cidr_last[local.aks_service_cidr]
+  )
 
   # ── Common tags ─────────────────────────────────────────────────────────────
   # Applied to every Azure resource in every sub-module.
@@ -466,6 +476,18 @@ resource "terraform_data" "validate_network" {
     precondition {
       condition     = !var.create_cluster || length(data.azurerm_virtual_network.byo_vnet) == 0 || !local.service_cidr_overlaps_vnet
       error_message = "aks_service_cidr (${local.aks_service_cidr}) overlaps the address space of vnet_id (${join(", ", local.vnet_address_space)}). Kubernetes ClusterIPs are not carved from the VNet, and AKS requires a range nothing on or connected to it uses. This check only sees the VNet's own address space, so keep clear of peered and on-premises ranges too."
+    }
+
+    # Left empty the address is derived from the range and is always inside it.
+    # Set explicitly it is a second place the range is written down, and a change
+    # to aks_service_cidr strands it — the pair is exactly what an operator edits
+    # while working out a range their VNet does not already use. Azure rejects
+    # the mismatch partway through apply, once the resource group and Key Vault
+    # exist. Gated on create_cluster because both values land on the cluster
+    # resource and nowhere else.
+    precondition {
+      condition     = !var.create_cluster || !local.dns_service_ip_outside_service_cidr
+      error_message = "aks_dns_service_ip (${local.aks_dns_service_ip}) is outside aks_service_cidr (${local.aks_service_cidr}). AKS takes the CoreDNS ClusterIP out of the service range. Leave aks_dns_service_ip empty to get ${cidrhost(local.aks_service_cidr, 10)}, the eleventh address, which is the Azure convention."
     }
 
     # The subnet prefix defaults describe the 10.0.0.0/17 VNet Terraform builds,

--- a/modules/azure/infra/scripts/quickstart.sh
+++ b/modules/azure/infra/scripts/quickstart.sh
@@ -881,7 +881,19 @@ _run_section_3() {
     _hint "Kubernetes assigns ClusterIPs from a range that must not be used by anything"
     _hint "in your VNet or any network peered to it. It is not carved from your VNet —"
     _hint "pick a range that sits outside your VNet's address space entirely."
-    _ask "Kubernetes service CIDR" "${AKS_SERVICE_CIDR:-10.0.64.0/20}"
+    # Four subnet ID prompts run immediately above this one, and a resource ID
+    # pasted here reaches Terraform as a string the locals hand to cidrhost() —
+    # an invalid-CIDR error against a main.tf line the operator never wrote.
+    while true; do
+      _ask "Kubernetes service CIDR" "${AKS_SERVICE_CIDR:-10.0.64.0/20}"
+      if _valid_cidr "$_REPLY"; then break; fi
+      if _valid_subnet_id "$_REPLY"; then
+        _red "  ERROR: that is a subnet resource ID. No subnet is created for this range — Kubernetes allocates ClusterIPs from it, so it takes an address range like 10.0.64.0/20."
+      else
+        _red "  ERROR: expected an IPv4 CIDR, e.g. 10.0.64.0/20."
+      fi
+      echo ""
+    done
     AKS_SERVICE_CIDR="$_REPLY"
   else
     AKS_SERVICE_CIDR=""

--- a/modules/azure/infra/variables.tf
+++ b/modules/azure/infra/variables.tf
@@ -385,6 +385,21 @@ variable "aks_service_cidr" {
     condition     = var.aks_service_cidr == "" || can(cidrnetmask(var.aks_service_cidr))
     error_message = "aks_service_cidr must be an IPv4 CIDR range such as 10.128.0.0/20, not a subnet resource ID. No subnet is created for this range — Kubernetes allocates ClusterIPs from it, so it must sit outside your VNet's address space."
   }
+
+  # Host bits set is the value that parses and still sends Azure something other
+  # than what plan checked. Every CIDR function masks them off, so the overlap
+  # precondition and the derived CoreDNS address are computed against the network
+  # address while main.tf hands the cluster the literal string. Azure then either
+  # rejects it partway through apply or stores the masked form, and service_cidr
+  # forces replacement, so a stored mismatch reads as drift and proposes
+  # rebuilding the cluster on every later plan.
+  #
+  # try(..., true) rather than can(): a value that is not a CIDR at all already
+  # fails the check above, and failing both reports two errors for one typo.
+  validation {
+    condition     = var.aks_service_cidr == "" || try(var.aks_service_cidr == cidrsubnet(var.aks_service_cidr, 0, 0), true)
+    error_message = "aks_service_cidr (${var.aks_service_cidr}) has host bits set. Use ${try(cidrsubnet(var.aks_service_cidr, 0, 0), "the network address")}, the network address of that range. Terraform masks the host bits when it checks the range against your VNet, but sends the value as written to Azure, so the range checked and the range created are not the same one."
+  }
 }
 
 variable "aks_dns_service_ip" {

--- a/modules/azure/infra/variables.tf
+++ b/modules/azure/infra/variables.tf
@@ -389,8 +389,21 @@ variable "aks_service_cidr" {
 
 variable "aks_dns_service_ip" {
   type        = string
-  description = "CoreDNS ClusterIP. Must sit inside aks_service_cidr. Defaults to the eleventh address of aks_service_cidr, which is the Azure convention (10.0.64.10 for the default range). Ignored when create_cluster = false, for the same reason aks_service_cidr is."
+  description = "CoreDNS ClusterIP. Must sit inside aks_service_cidr, which plan checks. Defaults to the eleventh address of aks_service_cidr, which is the Azure convention (10.0.64.10 for the default range). Ignored when create_cluster = false, for the same reason aks_service_cidr is."
   default     = ""
+
+  # Shape only, for the ordering reason aks_service_cidr is checked here: the
+  # containment precondition reduces this to a number in the locals, locals
+  # evaluate first, and anything that is not four dotted octets fails there as a
+  # tonumber() error naming neither the variable nor the fix. Appending /32 is
+  # what makes cidrnetmask() a bare-address check — a value that already carries
+  # a prefix produces two and fails to parse. Containment itself needs
+  # aks_service_cidr, which a validation block cannot reach under this module's
+  # >= 1.5 floor, so it lives on validate_network instead.
+  validation {
+    condition     = var.aks_dns_service_ip == "" || can(cidrnetmask("${var.aks_dns_service_ip}/32"))
+    error_message = "aks_dns_service_ip must be a bare IPv4 address such as 10.128.0.10, with no prefix length. It is one ClusterIP taken out of aks_service_cidr, not a range."
+  }
 }
 
 variable "additional_node_pools" {

--- a/modules/azure/infra/variables.tf
+++ b/modules/azure/infra/variables.tf
@@ -367,8 +367,18 @@ variable "default_node_pool_max_pods" {
 # bring-your-own, where the operator's address space is unknown here.
 variable "aks_service_cidr" {
   type        = string
-  description = "Kubernetes ClusterIP range for the AKS cluster. Defaults to 10.0.64.0/20, which is chosen to sit outside the Terraform-managed 10.0.0.0/17 VNet. Required when create_vnet = false and Terraform creates the cluster: AKS needs a range that nothing on or connected to your VNet uses, and an overlap can be accepted at create time and break later. Plan rejects a range that overlaps your VNet's address space, but cannot see peered or on-premises networks. Ignored when create_cluster = false — the range is fixed on the cluster resource at creation, so an existing cluster keeps whatever Azure gave it and this value configures nothing."
+  description = "Kubernetes ClusterIP range for the AKS cluster. Defaults to 10.0.64.0/20, which is chosen to sit outside the Terraform-managed 10.0.0.0/17 VNet. Required when create_vnet = false and Terraform creates the cluster: AKS needs a range that nothing on or connected to your VNet uses, and an overlap can be accepted at create time and break later. Plan rejects a range that overlaps your VNet's address space, but cannot see peered or on-premises networks. Size it /20: the range is virtual, so a large one costs no address space, and /24 (Azure's floor) caps the cluster at 251 Services, which a Pass 4 deployment can reach because LangGraph Platform adds Services per deployment. Fixed on the cluster at creation — outgrowing it means rebuilding the cluster. Ignored when create_cluster = false — the range is fixed on the cluster resource at creation, so an existing cluster keeps whatever Azure gave it and this value configures nothing."
   default     = ""
+
+  # Empty is the not-set sentinel main.tf falls back on, so it has to pass. Any
+  # other value is parsed here rather than in the locals: cidrhost() derives the
+  # CoreDNS address and the overlap bounds from it, and locals evaluate before
+  # preconditions, so a bad value fails as a function error that names neither
+  # the variable nor the fix.
+  validation {
+    condition     = var.aks_service_cidr == "" || can(cidrhost(var.aks_service_cidr, 0))
+    error_message = "aks_service_cidr must be an IPv4 CIDR range such as 10.128.0.0/20, not a subnet resource ID. No subnet is created for this range — Kubernetes allocates ClusterIPs from it, so it must sit outside your VNet's address space."
+  }
 }
 
 variable "aks_dns_service_ip" {

--- a/modules/azure/infra/variables.tf
+++ b/modules/azure/infra/variables.tf
@@ -375,8 +375,14 @@ variable "aks_service_cidr" {
   # CoreDNS address and the overlap bounds from it, and locals evaluate before
   # preconditions, so a bad value fails as a function error that names neither
   # the variable nor the fix.
+  #
+  # cidrnetmask() rather than cidrhost() because it is the CIDR function that
+  # rejects IPv6, which cidrhost() accepts and the overlap math cannot use — it
+  # splits the network address on "." and subtracts the prefix from 32, so an
+  # IPv6 range reaches tonumber() whole and fails as the same unattributable
+  # function error. Every other verdict is identical between the two.
   validation {
-    condition     = var.aks_service_cidr == "" || can(cidrhost(var.aks_service_cidr, 0))
+    condition     = var.aks_service_cidr == "" || can(cidrnetmask(var.aks_service_cidr))
     error_message = "aks_service_cidr must be an IPv4 CIDR range such as 10.128.0.0/20, not a subnet resource ID. No subnet is created for this range — Kubernetes allocates ClusterIPs from it, so it must sit outside your VNet's address space."
   }
 }


### PR DESCRIPTION
## What

Validates `aks_service_cidr` in two places: the quickstart prompt, and the variable declaration.

## Why

Found during a customer install on this branch. The service CIDR prompt runs immediately after four subnet resource ID prompts, and the customer pasted a subnet resource ID into it. Nothing caught it:

- `_ask` took the string as-is, even though the script already has a `_valid_cidr` helper (whose own comment describes this failure mode for the three `*_subnet_address_prefix` variables)
- the variable carried no `validation` block
- the first thing to touch the value was `cidrhost()` inside the locals

Locals evaluate before preconditions, so the plan failed like this, twice, against `main.tf` lines the operator never wrote:

```
Error: Error in function call
  on main.tf line 90, in locals:
  90:   aks_dns_service_ip = ... : cidrhost(local.aks_service_cidr, 10)
Call to function "cidrhost" failed: invalid CIDR expression: invalid CIDR address:
/subscriptions/.../virtualNetworks/vnet-.../subnets/langsmith-aks-services
```

The three `validate_network` preconditions on this branch are correct and their messages are good, but none of them could report until the value parsed as a CIDR. The install took three plan cycles to surface problems that were all present on the first one.

## Changes

**`quickstart.sh`** — the prompt loops on `_valid_cidr`, matching the idiom already used for the carve-a-subnet CIDR prompt. A pasted resource ID gets its own message rather than the generic one, since it's the predictable wrong answer after four ID prompts:

```
Kubernetes service CIDR [10.0.64.0/20]:   ERROR: that is a subnet resource ID. No subnet is
                                          created for this range — Kubernetes allocates
                                          ClusterIPs from it, so it takes an address range
                                          like 10.0.64.0/20.
Kubernetes service CIDR [10.0.64.0/20]:   ERROR: expected an IPv4 CIDR, e.g. 10.0.64.0/20.
Kubernetes service CIDR [10.0.64.0/20]: RESULT=10.128.0.0/20
```

**`variables.tf`** — a `validation` block, which runs ahead of the locals and turns the function error into one readable message on the first plan. It accepts the empty not-set sentinel that `main.tf` falls back on, matching the `name_prefix` pattern in this file.

Also records sizing guidance in the description: /20, because the range is virtual and costs no address space, while /24 (Azure's floor) caps the cluster at 251 Services and is fixed at cluster creation. The customer chose /24 for a dev environment knowing this.

## Testing

| check | result |
|---|---|
| `bash -n quickstart.sh` | clean |
| `terraform validate` | Success |
| `terraform fmt -check` | clean |
| prompt loop, real helpers sourced | rejects subnet ID, rejects `10.0.24.0`, accepts `10.128.0.0/20` |

Validation block exercised against a throwaway module: `10.128.0.0/20` accepted, `""` accepted, `10.0.24.0` rejected, pasted subnet ID rejected with the new message.

## Notes

Based on `feat/azure-existing-cluster-support`, not `main` — it depends on the `local.aks_service_cidr` fallback and the `validate_network` preconditions that only exist on that branch. Merge order matters.

`main.tf` is untouched. Its preconditions were already right; they just never got to run.