### PR TITLE
feat(azure): opt-in globally-unique names for Postgres, Redis, Blob, Key Vault

### DIFF
--- a/modules/azure/Makefile
+++ b/modules/azure/Makefile
@@ -42,7 +42,7 @@ status-quick: ## Quick status check (skip Key Vault and K8s queries)
 setup-env: ## Bootstrap secrets → secrets.auto.tfvars (prompts on first run, reads KV on repeat)
 	cd $(INFRA_DIR) && bash scripts/setup-env.sh
 
-preflight: ## Run Azure pre-flight checks (login, providers, RBAC, terraform.tfvars)
+preflight: ## Run Azure pre-flight checks (login, providers, RBAC, terraform.tfvars, global name availability)
 	cd $(INFRA_DIR) && bash scripts/preflight.sh
 
 init: ## terraform init (infra)

--- a/modules/azure/QUICK_REFERENCE.md
+++ b/modules/azure/QUICK_REFERENCE.md
@@ -246,6 +246,7 @@ Then re-run `make init-values && make deploy`.
 subscription_id = ""              # az account show --query id -o tsv
 identifier      = "-prod"         # suffix appended to every resource name
 location        = "eastus"        # Azure region
+unique_resource_names = true      # hash globally-unique names; see README → Resource naming
 
 # ── Data sources ──────────────────────────────────────────────────────────────
 postgres_source   = "external"    # Azure DB for PostgreSQL Flexible Server

--- a/modules/azure/README.md
+++ b/modules/azure/README.md
@@ -726,6 +726,11 @@ inside the 24-character Storage and Key Vault limits:
 | Storage | `langsmithblobdev` | `lsblobdev9532ea` |
 | Key Vault | `langsmith-kv-dev` | `ls-kv-dev-9532ea` |
 
+The Storage row is the only one that looks different, and the hyphens are the
+reason. Azure Storage account names accept only lowercase letters and digits, so
+the module strips the hyphens from `ls-blob-dev-9532ea` before creating it. Every
+other name, including the blob container, keeps them.
+
 The hash is deterministic — the same subscription and `identifier` always produce
 the same name, so repeat applies are stable and no random values are stored.
 

--- a/modules/azure/README.md
+++ b/modules/azure/README.md
@@ -265,7 +265,7 @@ make keyvault delete langsmith-deployments-encryption-key   # soft-delete (recov
 ```
 
 Key behaviors:
-- Resolves Key Vault name from `terraform output keyvault_name` → falls back to `langsmith-kv{identifier}`
+- Resolves Key Vault name from `terraform output keyvault_name` → falls back to `_derive_kv_name` in `infra/scripts/_common.sh`, which mirrors the Terraform naming scheme
 - `validate` — checks all 4 required secrets exist and are non-empty; validates admin password symbol requirement
 - `diff` — compares Key Vault values vs `langsmith-config-secret` K8s secret key-by-key
 - Warns on `langsmith-api-key-salt` and `langsmith-jwt-secret` (stable secrets — changing them invalidates all API keys / sessions)
@@ -279,7 +279,7 @@ Key behaviors:
 
 Collects all sensitive values and writes them to `infra/secrets.auto.tfvars` (gitignored, chmod 600). Terraform picks this file up automatically — no shell exports needed.
 
-- Derives the Key Vault name from `identifier` in `terraform.tfvars` (e.g. `langsmith-kv-demo`)
+- Derives the Key Vault name via `_derive_kv_name` (`infra/scripts/_common.sh`), which mirrors `local.keyvault_name` — e.g. `ls-kv-demo-9532ea` with `unique_resource_names = true`, or `langsmith-kv-demo` without
 - **First run:** prompts for PostgreSQL password, LangSmith license key, admin password, and admin email
 - **Subsequent runs:** reads all values silently from Azure Key Vault — no prompts
 - Stable secrets (API key salt, JWT secret, 4 Fernet encryption keys): reads from Key Vault → falls back to local dot-files → generates fresh if neither exists
@@ -702,6 +702,52 @@ azure/
 > **Workload Identity** is centralized in `k8s-cluster`. Federated credentials for blob-accessing pods (backend, platform-backend, queue, ingest-queue, host-backend, listener, agent-builder-tool-server, agent-builder-trigger-server) are registered there. Adding a new pod that needs Blob access requires updating `service_accounts_for_workload_identity` in `k8s-cluster` and running `terraform apply -target=module.aks`.
 >
 > **AGIC Workload Identity** uses a separate managed identity (`<cluster>-agic-identity`) with Contributor on the App Gateway and Reader on the resource group. The federated credential binds to `system:serviceaccount:ingress-basic:ingress-azure`.
+
+---
+
+## Resource naming
+
+Most Azure resource names only need to be unique inside your resource group. Four
+do not: **PostgreSQL**, **Redis**, **Storage**, and **Key Vault** names live in a
+namespace shared by every Azure tenant, as does the public-IP `dns_label`. Two
+deployments that ask for the same name collide, and the second one fails partway
+through `terraform apply`.
+
+`unique_resource_names = true` (set in every `terraform.tfvars` template and by
+`quickstart.sh`) appends a 6-character hash derived from your subscription ID and
+`identifier`, and shortens the prefix from `langsmith-` to `ls-` to make room
+inside the 24-character Storage and Key Vault limits:
+
+| | `unique_resource_names = false` | `unique_resource_names = true` |
+|---|---|---|
+| Resource group | `langsmith-rg-dev` | `ls-rg-dev` |
+| Postgres | `langsmith-postgres-dev` | `ls-postgres-dev-9532ea` |
+| Redis | `langsmith-redis-dev` | `ls-redis-dev-9532ea` |
+| Storage | `langsmithblobdev` | `lsblobdev9532ea` |
+| Key Vault | `langsmith-kv-dev` | `ls-kv-dev-9532ea` |
+
+The hash is deterministic — the same subscription and `identifier` always produce
+the same name, so repeat applies are stable and no random values are stored.
+
+> **On an existing deployment, leave `unique_resource_names = false`.** Turning it
+> on renames every resource, which Terraform carries out as destroy-and-recreate:
+> Postgres and Storage would lose their data. It defaults to `false` so bumping to
+> a newer tag is a no-op.
+
+To pin one name — to keep an existing resource, or to dodge a collision without
+renaming the whole deployment — set it explicitly:
+
+```hcl
+postgres_name        = "langsmith-postgres-dev"
+redis_name           = "langsmith-redis-mycorp-dev"
+storage_account_name = "langsmithblobdev"
+keyvault_name        = "langsmith-kv-dev"
+```
+
+`make preflight` checks each of these against Azure before you apply, so a
+collision surfaces in seconds rather than mid-apply. Key Vault and Storage cap at
+24 characters, which puts a practical ceiling of ~12 characters on `identifier`;
+`terraform plan` fails with the computed name and length if you exceed it.
 
 ---
 

--- a/modules/azure/README.md
+++ b/modules/azure/README.md
@@ -279,7 +279,7 @@ Key behaviors:
 
 Collects all sensitive values and writes them to `infra/secrets.auto.tfvars` (gitignored, chmod 600). Terraform picks this file up automatically — no shell exports needed.
 
-- Derives the Key Vault name via `_derive_kv_name` (`infra/scripts/_common.sh`), which mirrors `local.keyvault_name` — e.g. `ls-kv-demo-9532ea` with `unique_resource_names = true`, or `langsmith-kv-demo` without
+- Derives the Key Vault name via `_derive_kv_name` (`infra/scripts/_common.sh`), which mirrors `local.keyvault_name` — e.g. `ls-kv-demo-a1b2c3` with `unique_resource_names = true`, or `langsmith-kv-demo` without
 - **First run:** prompts for PostgreSQL password, LangSmith license key, admin password, and admin email
 - **Subsequent runs:** reads all values silently from Azure Key Vault — no prompts
 - Stable secrets (API key salt, JWT secret, 4 Fernet encryption keys): reads from Key Vault → falls back to local dot-files → generates fresh if neither exists
@@ -721,14 +721,14 @@ inside the 24-character Storage and Key Vault limits:
 | | `unique_resource_names = false` | `unique_resource_names = true` |
 |---|---|---|
 | Resource group | `langsmith-rg-dev` | `ls-rg-dev` |
-| Postgres | `langsmith-postgres-dev` | `ls-postgres-dev-9532ea` |
-| Redis | `langsmith-redis-dev` | `ls-redis-dev-9532ea` |
-| Storage | `langsmithblobdev` | `lsblobdev9532ea` |
-| Key Vault | `langsmith-kv-dev` | `ls-kv-dev-9532ea` |
+| Postgres | `langsmith-postgres-dev` | `ls-postgres-dev-a1b2c3` |
+| Redis | `langsmith-redis-dev` | `ls-redis-dev-a1b2c3` |
+| Storage | `langsmithblobdev` | `lsblobdeva1b2c3` |
+| Key Vault | `langsmith-kv-dev` | `ls-kv-dev-a1b2c3` |
 
 The Storage row is the only one that looks different, and the hyphens are the
 reason. Azure Storage account names accept only lowercase letters and digits, so
-the module strips the hyphens from `ls-blob-dev-9532ea` before creating it. Every
+the module strips the hyphens from `ls-blob-dev-a1b2c3` before creating it. Every
 other name, including the blob container, keeps them.
 
 The hash is deterministic — the same subscription and `identifier` always produce

--- a/modules/azure/TROUBLESHOOTING.md
+++ b/modules/azure/TROUBLESHOOTING.md
@@ -13,6 +13,62 @@ Issues, gotchas, and fixes. Updated as deployments are validated.
 
 ## Pass 1 — Infrastructure
 
+### Resource name is already taken globally
+
+**Symptom — Redis:**
+```
+Error: Failed to create/update resource
+  with module.redis[0].azapi_resource.amr,
+RESPONSE 400: 400 Bad Request
+"code": "BadRequest",
+"message": "The name langsmith-redis-dev is not available."
+```
+
+**Symptom — Storage or Key Vault:** `StorageAccountAlreadyTaken`, or `VaultAlreadyExists`
+referring to a vault you cannot see in your own subscription.
+
+**Cause:** PostgreSQL, Redis, Storage, and Key Vault names live in a namespace
+shared by every Azure tenant — they become public DNS names like
+`<name>.<region>.redisenterprise.cache.azure.net`. With
+`unique_resource_names = false`, every deployment of this module asks for the same
+`langsmith-<resource><identifier>`, so any two deployments using `identifier = "-dev"`
+collide anywhere in the world. The name may also be a leftover from a failed apply
+in your own subscription, or a soft-deleted Key Vault pending purge.
+
+**Fix — new deployment:** set `unique_resource_names = true` in `terraform.tfvars`.
+Names become `ls-<resource><identifier>-<hash>`, unique per subscription. See
+[README → Resource naming](README.md#resource-naming).
+
+**Fix — existing deployment** (do *not* flip `unique_resource_names`, it renames and
+therefore recreates everything): pin the one colliding name instead.
+
+```hcl
+redis_name = "langsmith-redis-mycorp-dev"
+```
+
+Then check it before applying:
+
+```bash
+make preflight   # checks Postgres, Storage, Key Vault, and dns_label availability
+```
+
+**If the leftover is in your own subscription**, import or delete it rather than
+renaming:
+
+```bash
+az redisenterprise list -o table
+az keyvault list-deleted -o table          # soft-deleted vaults still hold the name
+az keyvault purge --name <name>            # frees it permanently
+```
+
+> **Redis has no pre-check.** Azure exposes no working `CheckNameAvailability` for
+> `Microsoft.Cache/redisEnterprise` — the subscription-scoped endpoint rejects the
+> type and the location-scoped one rejects every valid region. `make preflight` can
+> only detect a Redis name already present in *your* subscription; a cross-tenant
+> collision still surfaces at apply time. The hashed name is what makes it unlikely.
+
+---
+
 ### K8sVersionNotSupported — version is LTS-only
 
 **Symptom:**

--- a/modules/azure/infra/main.tf
+++ b/modules/azure/infra/main.tf
@@ -23,17 +23,35 @@ locals {
   # Examples: "-prod", "-staging", "" (no suffix for single-environment setups).
   identifier = var.identifier
 
-  # Derived resource names — all prefixed with "langsmith-<identifier>"
-  resource_group_name = "langsmith-rg${local.identifier}"
-  vnet_name           = "langsmith-vnet${local.identifier}"
-  aks_name            = "langsmith-aks${local.identifier}"
-  postgres_name       = "langsmith-postgres${local.identifier}"
-  redis_name          = "langsmith-redis${local.identifier}"
-  blob_name           = "langsmith-blob${local.identifier}" # blob module strips hyphens → "langsmithblobdz"
+  # ── Resource naming ─────────────────────────────────────────────────────────
+  # Two schemes, selected by var.unique_resource_names (see variables.tf):
+  #
+  #   false — legacy "langsmith-<resource><identifier>". Still the default so an
+  #           existing deployment moving to a newer tag sees a no-op plan.
+  #   true  — "ls-<resource><identifier>", plus a per-subscription hash on the
+  #           four names that live in a global Azure namespace.
+  #
+  # The hash is deterministic: same subscription + identifier always yields the
+  # same name, so repeat applies are stable and no random provider is involved.
+  # Hashing the identifier too keeps two environments in one subscription apart.
+  # 6 hex chars is what fits alongside "-production" inside Key Vault's 24-char
+  # limit, which is the tightest of the four.
+  name_prefix = var.unique_resource_names ? "ls" : "langsmith"
+  name_suffix = var.unique_resource_names ? "-${substr(sha256("${var.subscription_id}${local.identifier}"), 0, 6)}" : ""
 
-  # Key Vault name: max 24 chars, globally unique.
-  # Uses the user-supplied keyvault_name or derives from identifier.
-  keyvault_name = var.keyvault_name != "" ? var.keyvault_name : "langsmith-kv${local.identifier}"
+  # Regional names — no global namespace, so no hash needed.
+  resource_group_name = "${local.name_prefix}-rg${local.identifier}"
+  vnet_name           = "${local.name_prefix}-vnet${local.identifier}"
+  aks_name            = "${local.name_prefix}-aks${local.identifier}"
+
+  # Globally-unique names — hashed, and each accepts an explicit override so an
+  # existing deployment can pin its current name (or dodge a collision without
+  # renaming everything else). Length limits: Postgres 63, Redis 60, Storage 24
+  # (hyphens stripped by the blob module), Key Vault 24. Asserted below.
+  postgres_name = var.postgres_name != "" ? var.postgres_name : "${local.name_prefix}-postgres${local.identifier}${local.name_suffix}"
+  redis_name    = var.redis_name != "" ? var.redis_name : "${local.name_prefix}-redis${local.identifier}${local.name_suffix}"
+  blob_name     = var.storage_account_name != "" ? var.storage_account_name : "${local.name_prefix}-blob${local.identifier}${local.name_suffix}"
+  keyvault_name = var.keyvault_name != "" ? var.keyvault_name : "${local.name_prefix}-kv${local.identifier}${local.name_suffix}"
 
   # Subnet ID resolution: use newly-created VNet subnets OR bring-your-own
   # existing ones (set create_vnet = false and supply the IDs via variables).
@@ -64,6 +82,26 @@ resource "azurerm_resource_group" "resource_group" {
   name     = local.resource_group_name
   location = var.location
   tags     = local.common_tags
+
+  # Assert the derived names fit Azure's limits before anything is created.
+  # Without this, an over-long identifier surfaces as an Azure 400 partway
+  # through the apply, after the resource group, VNet, and AKS already exist.
+  # Storage and Key Vault cap at 24 chars, so they bind first — a ~12-char
+  # identifier is the practical ceiling under unique_resource_names.
+  lifecycle {
+    precondition {
+      condition     = length(replace(local.blob_name, "-", "")) >= 3 && length(replace(local.blob_name, "-", "")) <= 24
+      error_message = "Storage account name '${replace(local.blob_name, "-", "")}' is ${length(replace(local.blob_name, "-", ""))} chars; Azure allows 3-24. Shorten var.identifier or set var.storage_account_name explicitly."
+    }
+    precondition {
+      condition     = length(local.keyvault_name) >= 3 && length(local.keyvault_name) <= 24
+      error_message = "Key Vault name '${local.keyvault_name}' is ${length(local.keyvault_name)} chars; Azure allows 3-24. Shorten var.identifier or set var.keyvault_name explicitly."
+    }
+    precondition {
+      condition     = length(local.postgres_name) <= 63 && length(local.redis_name) <= 60
+      error_message = "Postgres name '${local.postgres_name}' must be <= 63 chars and Redis name '${local.redis_name}' <= 60. Shorten var.identifier or set var.postgres_name / var.redis_name explicitly."
+    }
+  }
 }
 
 # ── Networking ────────────────────────────────────────────────────────────────

--- a/modules/azure/infra/scripts/_common.sh
+++ b/modules/azure/infra/scripts/_common.sh
@@ -44,6 +44,37 @@ _tfvar_is_true() {
   [[ "$val" == "true" ]]
 }
 
+# ── Derived Key Vault name ───────────────────────────────────────────────────
+# Mirrors local.keyvault_name in infra/main.tf. Terraform is the source of
+# truth, so callers should always try `terraform output -raw keyvault_name`
+# first and fall back to this only when no state exists yet (before the first
+# apply, or from a directory without the state file).
+#
+# Keep in sync with local.name_prefix / local.name_suffix in infra/main.tf.
+_derive_kv_name() {
+  local explicit ident prefix suffix sub hash
+  explicit=$(_parse_tfvar keyvault_name || true)
+  if [[ -n "$explicit" ]]; then
+    echo "$explicit"
+    return 0
+  fi
+  ident=$(_parse_tfvar identifier || true)
+  if _tfvar_is_true unique_resource_names; then
+    prefix="ls"
+    sub=$(_parse_tfvar subscription_id || true)
+    if command -v shasum &>/dev/null; then
+      hash=$(printf '%s' "${sub}${ident}" | shasum -a 256 | cut -c1-6)
+    else
+      hash=$(printf '%s' "${sub}${ident}" | sha256sum | cut -c1-6)
+    fi
+    suffix="-${hash}"
+  else
+    prefix="langsmith"
+    suffix=""
+  fi
+  echo "${prefix}-kv${ident}${suffix}"
+}
+
 # ── Color helpers ────────────────────────────────────────────────────────────
 _bold()  { printf '\033[1m%s\033[0m' "$*"; }
 _green() { printf '\033[32m%s\033[0m' "$*"; }

--- a/modules/azure/infra/scripts/create-k8s-secrets.sh
+++ b/modules/azure/infra/scripts/create-k8s-secrets.sh
@@ -31,13 +31,12 @@ RED='\033[0;31m'; GREEN='\033[0;32m'; NC='\033[0m'
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 INFRA_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$SCRIPT_DIR/_common.sh"
 
 # ── Resolve Key Vault name from terraform output ───────────────────────────────
 if ! KV_NAME=$(cd "$INFRA_DIR" && terraform output -raw keyvault_name 2>/dev/null); then
-  # fallback: read identifier from terraform.tfvars
-  _identifier=$(grep -E '^\s*identifier\s*=' "$INFRA_DIR/terraform.tfvars" \
-    | sed 's/.*=[[:space:]]*"\([^"]*\)".*/\1/' | tr -d '[:space:]') || _identifier=""
-  KV_NAME="langsmith-kv${_identifier}"
+  # fallback: derive it the same way infra/main.tf does
+  KV_NAME=$(_derive_kv_name)
   echo "  (terraform output unavailable — using derived KV name: $KV_NAME)"
 fi
 

--- a/modules/azure/infra/scripts/manage-keyvault.sh
+++ b/modules/azure/infra/scripts/manage-keyvault.sh
@@ -25,8 +25,7 @@ source "$SCRIPT_DIR/_common.sh"
 if KV_NAME=$(cd "$INFRA_DIR" && terraform output -raw keyvault_name 2>/dev/null) && [[ -n "$KV_NAME" ]]; then
   : # got it from terraform output
 else
-  _identifier=$(_parse_tfvar "identifier") || _identifier=""
-  KV_NAME="langsmith-kv${_identifier}"
+  KV_NAME=$(_derive_kv_name)
 fi
 
 NAMESPACE="${NAMESPACE:-langsmith}"

--- a/modules/azure/infra/scripts/preflight.sh
+++ b/modules/azure/infra/scripts/preflight.sh
@@ -13,6 +13,7 @@
 #   3. Required resource providers are registered
 #   4. Deployer has required RBAC roles (Contributor + User Access Admin)
 #   5. terraform.tfvars exists with required fields populated
+#   6. Globally-unique names (Postgres, Storage, Key Vault, dns_label) are free
 #
 # Run before: terraform init / terraform apply
 # Usage: bash infra/scripts/preflight.sh
@@ -167,7 +168,135 @@ else
   fi
 fi
 
-# ── 6. Other tooling ──────────────────────────────────────────────────────────
+# ── 6. Globally-unique resource names ────────────────────────────────────────
+# Postgres, Redis, Storage, and Key Vault names live in a namespace shared by
+# every Azure tenant, as does the public-IP DNS label. A collision surfaces as a
+# raw Azure 400 partway through the apply, after the resource group, VNet, and
+# AKS already exist — so check up front instead.
+echo ""
+echo "── Global Name Availability ──────────────────────────"
+
+if [ ! -f "$TFVARS" ] || [ -z "${SUB_ID:-}" ]; then
+  warn "Skipping name checks (need terraform.tfvars and an active az login)"
+else
+  # Read a tfvars value, quoted or bare. Mirrors _parse_tfvar in _common.sh;
+  # preflight.sh deliberately has no external sourcing.
+  _tfvar() {
+    local raw val
+    raw=$(grep -E "^[[:space:]]*$1[[:space:]]*=" "$TFVARS" 2>/dev/null | head -1) || true
+    [ -n "$raw" ] || return 1
+    val=$(echo "$raw" | sed -n 's/.*=[[:space:]]*"\([^"]*\)".*/\1/p' | tr -d '[:space:]')
+    [ -n "$val" ] || val=$(echo "$raw" | sed 's/.*=[[:space:]]*//' | sed 's/#.*//' | tr -d '[:space:]"')
+    [ -n "$val" ] || return 1
+    echo "$val"
+  }
+
+  IDENTIFIER=$(_tfvar identifier || echo "")
+  LOCATION=$(_tfvar location || echo "")
+  DNS_LABEL=$(_tfvar dns_label || echo "")
+  UNIQUE_NAMES=$(_tfvar unique_resource_names || echo "false")
+
+  # Recompute exactly what main.tf's locals derive, so the check covers the names
+  # Terraform will actually request. Keep in sync with local.name_prefix /
+  # local.name_suffix in infra/main.tf.
+  if [ "$UNIQUE_NAMES" = "true" ]; then
+    PREFIX="ls"
+    if command -v shasum &>/dev/null; then
+      HASH=$(printf '%s' "${SUB_ID}${IDENTIFIER}" | shasum -a 256 | cut -c1-6)
+    else
+      HASH=$(printf '%s' "${SUB_ID}${IDENTIFIER}" | sha256sum | cut -c1-6)
+    fi
+    SUFFIX="-${HASH}"
+  else
+    PREFIX="langsmith"
+    SUFFIX=""
+    warn "unique_resource_names is false — using the legacy shared-namespace names, which collide between deployments"
+  fi
+
+  PG_NAME=$(_tfvar postgres_name || echo "${PREFIX}-postgres${IDENTIFIER}${SUFFIX}")
+  REDIS_NAME=$(_tfvar redis_name || echo "${PREFIX}-redis${IDENTIFIER}${SUFFIX}")
+  KV_NAME=$(_tfvar keyvault_name || echo "${PREFIX}-kv${IDENTIFIER}${SUFFIX}")
+  BLOB_RAW=$(_tfvar storage_account_name || echo "${PREFIX}-blob${IDENTIFIER}${SUFFIX}")
+  BLOB_NAME=$(echo "$BLOB_RAW" | tr -d '-') # the blob module strips hyphens
+
+  # Reject anything that isn't a plain Azure resource name before it reaches a
+  # URL or a JSON body — terraform.tfvars is user-authored input.
+  _name_is_safe() {
+    echo "$1" | grep -qE '^[a-zA-Z0-9][a-zA-Z0-9-]{0,62}$'
+  }
+
+  # _check_name <label> <name> <url> <json-body> <availability-field>
+  # A definitive "taken" fails the run. Anything else (auth blip, api-version
+  # drift, unparseable body) only warns — preflight must never block a deploy
+  # because Azure rotated an API version.
+  _check_name() {
+    local label="$1" name="$2" url="$3" body="$4" field="$5" resp avail msg
+    if ! _name_is_safe "$name"; then
+      warn "${label}: '${name}' is not a valid Azure resource name — check skipped"
+      return 0
+    fi
+    if [ -n "$body" ]; then
+      resp=$(az rest --method post --url "$url" --body "$body" -o json 2>/dev/null || true)
+    else
+      resp=$(az rest --method get --url "$url" -o json 2>/dev/null || true)
+    fi
+    if [ -z "$resp" ]; then
+      warn "${label}: '${name}' — could not verify (Azure API error); collision would surface during apply"
+      return 0
+    fi
+    avail=$(echo "$resp" | python3 -c "import sys,json; print(json.load(sys.stdin).get('${field}',''))" 2>/dev/null || echo "")
+    # Azure's Key Vault message runs several hundred chars of soft-delete prose;
+    # keep the first sentence so one failure doesn't bury the rest of the report.
+    msg=$(echo "$resp" | python3 -c "
+import sys, json
+m = (json.load(sys.stdin).get('message', '') or '').strip()
+print(m if len(m) <= 110 else m[:110].rsplit(' ', 1)[0] + ' …')" 2>/dev/null || echo "")
+    case "$avail" in
+      True)  pass "${label}: '${name}' is available" ;;
+      False) fail "${label}: '${name}' is ALREADY TAKEN globally. ${msg}" ;;
+      *)     warn "${label}: '${name}' — unexpected API response; collision would surface during apply" ;;
+    esac
+  }
+
+  _check_name "Postgres" "$PG_NAME" \
+    "https://management.azure.com/subscriptions/${SUB_ID}/providers/Microsoft.DBforPostgreSQL/locations/${LOCATION}/checkNameAvailability?api-version=2023-03-01-preview" \
+    "{\"name\":\"${PG_NAME}\",\"type\":\"Microsoft.DBforPostgreSQL/flexibleServers\"}" "nameAvailable"
+
+  _check_name "Storage account" "$BLOB_NAME" \
+    "https://management.azure.com/subscriptions/${SUB_ID}/providers/Microsoft.Storage/checkNameAvailability?api-version=2023-01-01" \
+    "{\"name\":\"${BLOB_NAME}\",\"type\":\"Microsoft.Storage/storageAccounts\"}" "nameAvailable"
+
+  _check_name "Key Vault" "$KV_NAME" \
+    "https://management.azure.com/subscriptions/${SUB_ID}/providers/Microsoft.KeyVault/checkNameAvailability?api-version=2023-07-01" \
+    "{\"name\":\"${KV_NAME}\",\"type\":\"Microsoft.KeyVault/vaults\"}" "nameAvailable"
+
+  if [ -n "$DNS_LABEL" ]; then
+    _check_name "Public IP DNS label" "$DNS_LABEL" \
+      "https://management.azure.com/subscriptions/${SUB_ID}/providers/Microsoft.Network/locations/${LOCATION}/CheckDnsNameAvailability?domainNameLabel=${DNS_LABEL}&api-version=2023-09-01" \
+      "" "available"
+  else
+    warn "dns_label not set — skipping DNS label check"
+  fi
+
+  # Azure Managed Redis (Microsoft.Cache/redisEnterprise) exposes no working
+  # CheckNameAvailability endpoint: the subscription-scoped one rejects the
+  # redisEnterprise type, and the location-scoped one returns "The requested
+  # location is invalid" for every valid region and api-version. So only the
+  # in-subscription case can be pre-checked — a leftover from a failed apply.
+  # A cross-tenant Redis collision still surfaces at apply time; the hashed name
+  # under unique_resource_names is what makes that unlikely.
+  if _name_is_safe "$REDIS_NAME"; then
+    REDIS_HIT=$(az redisenterprise list --query "length([?name=='${REDIS_NAME}'])" -o tsv 2>/dev/null || echo "0")
+    echo "$REDIS_HIT" | grep -qE '^[0-9]+$' || REDIS_HIT=0
+    if [ "$REDIS_HIT" -gt "0" ]; then
+      fail "Redis: '${REDIS_NAME}' already exists in this subscription — import it or delete it before applying"
+    else
+      warn "Redis: '${REDIS_NAME}' not present in this subscription (Azure exposes no global name check for Managed Redis)"
+    fi
+  fi
+fi
+
+# ── 7. Other tooling ──────────────────────────────────────────────────────────
 echo ""
 echo "── Tooling ───────────────────────────────────────────"
 for TOOL in terraform kubectl helm; do

--- a/modules/azure/infra/scripts/quickstart.sh
+++ b/modules/azure/infra/scripts/quickstart.sh
@@ -146,7 +146,7 @@ COST_CENTER=""
 _run_section_2() {
   _section "2. Subscription & Naming"
   _hint "The identifier is appended to every Azure resource name (RG, AKS, KV, blob...)."
-  _hint "Example: -prod → langsmith-rg-prod, langsmith-aks-prod, langsmith-kv-prod"
+  _hint "Example: -prod → ls-rg-prod, ls-aks-prod, ls-kv-prod-<hash>"
   _hint "Changing it later creates entirely new resources — choose something stable."
 
   AUTO_SUB=""
@@ -716,6 +716,11 @@ subscription_id = "${SUBSCRIPTION_ID}"
 identifier      = "${IDENTIFIER}"
 environment     = "${ENVIRONMENT}"
 location        = "${LOCATION}"
+
+# Redis, Postgres, Storage, and Key Vault names live in a global Azure namespace
+# shared by every tenant, so unqualified names collide between deployments.
+# This appends a hash derived from your subscription. Leave it true.
+unique_resource_names = true
 TFVARS
 
 [[ -n "$OWNER" ]]       && echo "owner           = \"${OWNER}\"" >> "$OUTPUT"

--- a/modules/azure/infra/scripts/setup-env.sh
+++ b/modules/azure/infra/scripts/setup-env.sh
@@ -20,6 +20,9 @@ set -euo pipefail
 # setup-env.sh is READ-ONLY against Key Vault — it never writes to KV directly.
 # Terraform is the sole writer. This prevents state conflicts on terraform apply.
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/_common.sh"
+
 SECRETS_FILE="secrets.auto.tfvars"
 
 # ── Read identifier from terraform.tfvars ─────────────────────────────────────
@@ -29,7 +32,7 @@ if [[ -f "terraform.tfvars" ]]; then
     | sed 's/.*=[[:space:]]*"\([^"]*\)".*/\1/' \
     | tr -d '[:space:]') || _identifier=""
 fi
-_kv_name="langsmith-kv${_identifier}"
+_kv_name=$(_derive_kv_name)
 
 # ── Prompt helper (skips if env var already set) ──────────────────────────────
 # If stdin is not a tty and the env var is not set, exit with a clear error

--- a/modules/azure/infra/scripts/status.sh
+++ b/modules/azure/infra/scripts/status.sh
@@ -45,7 +45,7 @@ if [[ -f "$INFRA_DIR/terraform.tfvars" ]]; then
   _pg_source=$(_read_tfvar postgres_source)
   _redis_source=$(_read_tfvar redis_source)
   _sizing=$(_read_tfvar sizing_profile)
-  _kv_name="langsmith-kv${_identifier}"
+  _kv_name=$(_derive_kv_name)
 
   if [[ -n "$_subscription" ]]; then
     pass "Required fields: subscription_id set  identifier=${_identifier:-'(empty)'}  environment=${_environment:-dev}"

--- a/modules/azure/infra/terraform.tfvars.dev
+++ b/modules/azure/infra/terraform.tfvars.dev
@@ -24,6 +24,13 @@ subscription_id = "your-azure-subscription-id"   # az account show --query id -o
 identifier  = "-dev"
 environment = "dev"
 location    = "eastus"
+# Redis, Postgres, Storage, and Key Vault names live in a global Azure namespace
+# shared by every Azure tenant, so the plain "langsmith-<resource>-dev" defaults
+# collide between deployments. This switches to "ls-<resource><identifier>-<hash>",
+# where the hash is derived from your subscription. Keep it true for a new
+# deployment. On an EXISTING deployment leave it false — flipping it renames every
+# resource, which Terraform executes as destroy-and-recreate.
+unique_resource_names = true
 
 #------------------------------------------------------------------------------
 # Sources

--- a/modules/azure/infra/terraform.tfvars.example
+++ b/modules/azure/infra/terraform.tfvars.example
@@ -16,6 +16,13 @@ subscription_id = "your-azure-subscription-id"   # az account show --query id -o
 identifier  = "-prod"
 environment = "dev"    # dev | staging | prod
 location    = "eastus"
+# Redis, Postgres, Storage, and Key Vault names live in a global Azure namespace
+# shared by every Azure tenant, so the plain "langsmith-<resource>-dev" defaults
+# collide between deployments. This switches to "ls-<resource><identifier>-<hash>",
+# where the hash is derived from your subscription. Keep it true for a new
+# deployment. On an EXISTING deployment leave it false — flipping it renames every
+# resource, which Terraform executes as destroy-and-recreate.
+unique_resource_names = true
 
 # Optional tags for cost allocation and compliance
 # owner       = "platform-team"

--- a/modules/azure/infra/terraform.tfvars.minimum
+++ b/modules/azure/infra/terraform.tfvars.minimum
@@ -29,6 +29,13 @@ subscription_id = "your-azure-subscription-id"   # az account show --query id -o
 identifier  = "-demo"      # suffix appended to every resource name
 environment = "dev"
 location    = "eastus"
+# Redis, Postgres, Storage, and Key Vault names live in a global Azure namespace
+# shared by every Azure tenant, so the plain "langsmith-<resource>-dev" defaults
+# collide between deployments. This switches to "ls-<resource><identifier>-<hash>",
+# where the hash is derived from your subscription. Keep it true for a new
+# deployment. On an EXISTING deployment leave it false — flipping it renames every
+# resource, which Terraform executes as destroy-and-recreate.
+unique_resource_names = true
 
 #------------------------------------------------------------------------------
 # Sources — in-cluster for minimum footprint

--- a/modules/azure/infra/terraform.tfvars.production
+++ b/modules/azure/infra/terraform.tfvars.production
@@ -24,6 +24,13 @@ subscription_id = "your-azure-subscription-id"   # az account show --query id -o
 identifier  = "-prod"
 environment = "prod"
 location    = "eastus"   # pick the region closest to your users
+# Redis, Postgres, Storage, and Key Vault names live in a global Azure namespace
+# shared by every Azure tenant, so the plain "langsmith-<resource>-dev" defaults
+# collide between deployments. This switches to "ls-<resource><identifier>-<hash>",
+# where the hash is derived from your subscription. Keep it true for a new
+# deployment. On an EXISTING deployment leave it false — flipping it renames every
+# resource, which Terraform executes as destroy-and-recreate.
+unique_resource_names = true
 
 #------------------------------------------------------------------------------
 # Sources

--- a/modules/azure/infra/variables.tf
+++ b/modules/azure/infra/variables.tf
@@ -11,6 +11,45 @@ variable "identifier" {
   }
 }
 
+# ── Resource naming scheme ────────────────────────────────────────────────────
+# Redis, Postgres, Storage, and Key Vault names live in a GLOBAL Azure namespace
+# shared by every tenant. The legacy scheme ("langsmith-<resource><identifier>")
+# produces the same name for every deployment of this module, so two customers
+# both running identifier = "-dev" collide and the second one fails mid-apply.
+#
+# unique_resource_names switches to "ls-<resource><identifier>-<hash>", where the
+# hash is derived from subscription + identifier: deterministic (stable across
+# applies, no random provider) and unique per subscription. The shorter "ls"
+# prefix is what buys back the characters the hash needs inside the 24-char
+# Storage and Key Vault limits.
+variable "unique_resource_names" {
+  type        = bool
+  description = "Use the collision-resistant naming scheme (ls- prefix + per-subscription hash on globally-unique names). Enabled in every terraform.tfvars template. Leave false on an existing deployment: turning it on renames every resource, which Terraform executes as destroy-and-recreate, losing Postgres and Storage data. Pin current names via postgres_name/redis_name/storage_account_name/keyvault_name instead."
+  default     = false
+}
+
+# ── Explicit name overrides ───────────────────────────────────────────────────
+# Each defaults to "" meaning "derive it". Set one to pin an existing resource's
+# name, or to work around a collision without renaming the whole deployment.
+
+variable "postgres_name" {
+  type        = string
+  description = "Name for the PostgreSQL Flexible Server. Globally unique (becomes <name>.postgres.database.azure.com), 3-63 chars. Empty derives from the naming scheme."
+  default     = ""
+}
+
+variable "redis_name" {
+  type        = string
+  description = "Name for the Azure Managed Redis cluster. Globally unique (becomes <name>.<region>.redisenterprise.cache.azure.net), 1-60 chars. Empty derives from the naming scheme."
+  default     = ""
+}
+
+variable "storage_account_name" {
+  type        = string
+  description = "Name for the blob Storage Account. Globally unique, 3-24 chars, lowercase alphanumeric only — hyphens are stripped before use. Empty derives from the naming scheme."
+  default     = ""
+}
+
 # ── Resource tagging ──────────────────────────────────────────────────────────
 # Tags are applied to every Azure resource for cost allocation, compliance,
 # and incident response. Required by most enterprise Azure policies.
@@ -42,9 +81,9 @@ variable "cost_center" {
 
 variable "keyvault_name" {
   type        = string
-  description = "Name for the Azure Key Vault. Must be globally unique, 3-24 chars. Defaults to 'langsmith-kv<identifier>' which you may need to customize to avoid naming conflicts."
+  description = "Name for the Azure Key Vault. Must be globally unique, 3-24 chars. Empty derives from the naming scheme."
   default     = ""
-  # When empty, main.tf computes: "langsmith-kv${local.identifier}"
+  # When empty, main.tf computes it from local.name_prefix / local.name_suffix.
 }
 
 variable "keyvault_purge_protection" {


### PR DESCRIPTION
## Why

A customer's `terraform apply` failed on Redis with a name-unavailable 400. The name was `langsmith-redis-dev`, straight out of the shipped `terraform.tfvars.dev`, and someone else already had it.

Four of the resources this module creates live in a namespace shared with every other Azure tenant: PostgreSQL Flexible Server, Azure Managed Redis, Storage Account, and Key Vault. The public-IP `dns_label` shares one too, regionally. The module derived all of them from `identifier` alone, so two customers who both follow the quickstart both ask for `langsmith-postgres-dev`, and the second one fails partway through an apply that has already built a VNet and an AKS cluster.

This is not hypothetical. Against the live `CheckNameAvailability` APIs:

| Name | Available |
|---|---|
| `langsmithblobdev` | **taken** |
| `langsmith-kv-dev` | **taken** |
| `langsmith-postgres-dev` | free |

Postgres is still free, which is the only reason the customer hit Redis first rather than Storage.

## What changed

`unique_resource_names = true` shortens the prefix from `langsmith` to `ls` and appends a 6-character hash of `subscription_id` + `identifier` to the four global names:

| | `false` (default) | `true` |
|---|---|---|
| Resource group | `langsmith-rg-dev` | `ls-rg-dev` |
| Postgres | `langsmith-postgres-dev` | `ls-postgres-dev-a1b2c3` |
| Redis | `langsmith-redis-dev` | `ls-redis-dev-a1b2c3` |
| Storage | `langsmithblobdev` | `lsblobdeva1b2c3` |
| Key Vault | `langsmith-kv-dev` | `ls-kv-dev-a1b2c3` |

`a1b2c3` stands in for the real hash throughout, here and in the README. It is per-subscription, so no two subscriptions see the same one.

The prefix change is what makes this fit. Storage and Key Vault cap at 24 characters, and `langsmith-kv-dev` plus a 7-character suffix is already 23, leaving no room for a realistic `identifier`. At `ls`, `-production` still lands at 23 for Key Vault and 22 for Storage.

Storage looks like the odd one out because Azure Storage account names accept only lowercase letters and digits. The local is `ls-blob-dev-a1b2c3` like every other name; the storage module strips the hyphens on the way in, which it already did before this change.

The hash uses `substr(sha256(...), 0, 6)` rather than the `random` provider, so it is derived rather than stored: repeat applies are stable, and nothing breaks if the state is rebuilt.

Regional names (resource group, VNet, AKS) get the shorter prefix but no hash. They only need to be unique inside the subscription.

**Plan-time length checks.** Three `lifecycle` preconditions catch an over-long name before apply: Storage and Key Vault at 24, Postgres at 63, Redis at 60. Storage measures the length *after* hyphens are stripped, since that is what Azure receives.

Key Vault binds first, because it keeps its hyphens inside the same 24-character limit. At `identifier = "-development1"` the derived names measure:

| | Name | Length | Limit |
|---|---|---|---|
| Storage | `lsblobdevelopment1<hash>` | 24 | 24, passes |
| Key Vault | `ls-kv-development1-<hash>` | **25** | 24, fails |
| Postgres | `ls-postgres-development1-<hash>` | 31 | 63 |

so the plan stops with:

```
Key Vault name 'ls-kv-development1-<hash>' is 25 chars; Azure allows 3-24.
Shorten var.identifier or set var.keyvault_name explicitly.
```

That puts the practical ceiling on `identifier` at about 12 characters, which the README states.

**Preflight availability checks.** `preflight.sh` gains section 6, which calls `CheckNameAvailability` for Postgres, Storage, and Key Vault, plus `CheckDnsNameAvailability` for the `dns_label`. Only a definitive `nameAvailable: false` calls `fail`. An API error, an unexpected body, or a name that fails the format guard only `warn`s, because preflight must not block a deploy over a transport problem. Names are validated against `^[a-zA-Z0-9][a-zA-Z0-9-]{0,62}$` before they reach a URL or a JSON body, since `terraform.tfvars` is user-authored.

**Per-name overrides.** `postgres_name`, `redis_name`, and `storage_account_name` join the existing `keyvault_name` as explicit escape hatches, for keeping an existing resource or dodging one collision without renaming a whole deployment.

## Migration

**Nothing changes for an existing deployment.** `unique_resource_names` defaults to `false`, and with it false all seven derived names are byte-identical to what main produces. Bumping to a newer tag is a no-op plan.

Turning it on renames every resource, which Terraform carries out as destroy-and-recreate. Postgres and Storage would lose their data. The variable description, the README, and TROUBLESHOOTING all say so. There is no automatic migration and this PR does not attempt one: the safe path for an existing deployment that hits a collision is to pin the one colliding name.

New deployments get unique names without reading any of that, because all four `terraform.tfvars.*` templates and `quickstart.sh` set the flag to `true`.

## Redis has no working pre-check

`Microsoft.Cache/CheckNameAvailability` rejects type `redisEnterprise` at api-versions 2024-03-01, 2024-11-01, and 2025-08-01-preview; the location-scoped form returns "The requested location is invalid" at 2025-07-01 and 2026-05-01-preview. Rather than ship a check that silently never fires, preflight falls back to `az redisenterprise list` for the in-subscription case (a leftover from a failed apply, which it can catch) and TROUBLESHOOTING says plainly that a cross-tenant Redis collision only surfaces at apply. The hash makes one unlikely; it does not make it detectable in advance.

## Also in here

Four scripts derived the Key Vault name independently: `manage-keyvault.sh`, `status.sh`, `setup-env.sh`, and `create-k8s-secrets.sh`. All four would have gone looking for `langsmith-kv-dev` once the flag was on and reported a missing vault. They now share `_derive_kv_name` in `scripts/_common.sh`, which mirrors `local.keyvault_name` including the hash. `setup-env.sh` did not source `_common.sh` at all and now does.

## Verified

- `terraform fmt -check -recursive` and `terraform validate` clean
- `bash -n` clean on all 7 changed scripts
- Backward compatibility through `terraform console`: with the flag false, all seven names match main byte for byte
- Name lengths at `identifier = "-development1"` read out of `terraform console`, giving the table above: Key Vault 25 against a limit of 24, so its precondition condition evaluates false and the plan stops
- Hash agreement between Terraform and shell: `substr(sha256(...), 0, 6)` and `shasum -a 256 | cut -c1-6` produce the same 6 characters for the same input, so preflight checks the name Terraform will actually request
- `preflight.sh` run against a live subscription: reports the legacy Storage and Key Vault names as taken and the hashed names as available

Not exercised end to end: `setup-env.sh` prompts for secrets and `create-k8s-secrets.sh` writes to a cluster. Their `_derive_kv_name` call is covered by `bash -n` and by testing the helper in isolation across all three cases (explicit name, flag on, flag off).

## Scope

Azure only. GCS bucket names are globally unique across all of Google Cloud and S3 bucket names across all of AWS, so both modules have the same exposure with the same shipped defaults. Neither is touched here; worth its own PR.

## Conflicts

**[#96](https://github.com/langchain-ai/terraform/pull/96) (`feat/azure-unify-name-prefix`) conflicts with this in a way that a textual merge will not catch.** It rewrites the same `locals` block, retires `var.identifier` in favor of `var.name_prefix`, and reuses two of the same token names for different things:

| Token | This PR | #96 |
|---|---|---|
| `local.name_suffix` | the `-a1b2c3` hash | the `-prod` deployment name |
| `name_prefix` | `local`, the `ls`/`langsmith` literal | `var`, the operator-supplied deployment name |
| `local.identifier` | the whole derivation reads it | removed; `var.identifier` becomes a failing validation |

Resolving `local.name_suffix` down to one definition drops either the hash (collisions return) or the deployment name (every resource renamed, so destroy-and-recreate). Both resolutions pass CI.

#96 is older, green, and only waiting on review, so it should land first. This PR then rebases on top of it: rename the two locals, rebuild the derivation on #96's `local.name_suffix`, and make `_derive_kv_name` call #96's new `_name_suffix` helper instead of re-deriving. #96's own scope note defers the naming-template change to a separate PR; this is that PR.

Smaller and ordinary: [#95](https://github.com/langchain-ai/terraform/pull/95) conflicts in `infra/main.tf`, [#99](https://github.com/langchain-ai/terraform/pull/99) in `README.md`. Whichever merges second resolves them.
