### PR TITLE
feat(azure): opt-in globally-unique names for Postgres, Redis, Blob, Key Vault (stacked on #96)

### DIFF
--- a/modules/azure/Makefile
+++ b/modules/azure/Makefile
@@ -42,7 +42,7 @@ status-quick: ## Quick status check (skip Key Vault and K8s queries)
 setup-env: ## Bootstrap secrets → secrets.auto.tfvars (prompts on first run, reads KV on repeat)
 	cd $(INFRA_DIR) && bash scripts/setup-env.sh
 
-preflight: ## Run Azure pre-flight checks (login, providers, RBAC, terraform.tfvars)
+preflight: ## Run Azure pre-flight checks (login, providers, RBAC, terraform.tfvars, global name availability)
 	cd $(INFRA_DIR) && bash scripts/preflight.sh
 
 init: ## terraform init (infra)

--- a/modules/azure/QUICK_REFERENCE.md
+++ b/modules/azure/QUICK_REFERENCE.md
@@ -25,7 +25,8 @@ make quickstart
 #    reads silently from Key Vault on every subsequent run
 make setup-env
 
-# 3. Check prerequisites (az CLI logged in, resource providers registered, RBAC, quotas)
+# 3. Check prerequisites (az CLI logged in, resource providers registered, RBAC,
+#    quotas, and that the globally-unique resource names are still free)
 make preflight
 
 # 4. Deploy infrastructure (~15–20 min)

--- a/modules/azure/README.md
+++ b/modules/azure/README.md
@@ -151,9 +151,10 @@ For demo/POC (all in-cluster DBs), see [BUILDING_LIGHT_LANGSMITH.md](BUILDING_LI
 
 One variable names the deployment. `name_prefix` is appended to every resource
 name and doubles as the `environment` tag, so `name_prefix = "prod"` gives
-`langsmith-rg-prod`, `langsmith-aks-prod`, `langsmith-kv-prod` and tags
-everything `environment = prod`. Terraform inserts the separating hyphen, so
-write `prod`, not `-prod`.
+`ls-rg-prod`, `ls-aks-prod`, `ls-kv-prod-<hash>` and tags everything
+`environment = prod`. Terraform inserts the separating hyphen, so write `prod`,
+not `-prod`. Keep it under about 12 characters; [Resource naming](#resource-naming)
+explains the ceiling and where the hash comes from.
 
 Set `environment` explicitly only when the tag needs to differ from the
 deployment name, e.g. `name_prefix = "prod-eastus"` with `environment = "prod"`.
@@ -291,7 +292,7 @@ make keyvault delete langsmith-deployments-encryption-key   # soft-delete (recov
 ```
 
 Key behaviors:
-- Resolves Key Vault name from `terraform output keyvault_name` → falls back to `langsmith-kv-{name_prefix}`
+- Resolves Key Vault name from `terraform output keyvault_name` → falls back to `_derive_kv_name` in `infra/scripts/_common.sh`, which mirrors the naming scheme
 - `validate` — checks all 4 required secrets exist and are non-empty; validates admin password symbol requirement
 - `diff` — compares Key Vault values vs `langsmith-config-secret` K8s secret key-by-key
 - Warns on `langsmith-api-key-salt` and `langsmith-jwt-secret` (stable secrets — changing them invalidates all API keys / sessions)
@@ -305,7 +306,7 @@ Key behaviors:
 
 Collects all sensitive values and writes them to `infra/secrets.auto.tfvars` (gitignored, chmod 600). Terraform picks this file up automatically — no shell exports needed.
 
-- Derives the Key Vault name from `name_prefix` in `terraform.tfvars` (e.g. `langsmith-kv-demo`)
+- Derives the Key Vault name via `_derive_kv_name` (`infra/scripts/_common.sh`), which mirrors `local.keyvault_name` — e.g. `ls-kv-demo-a1b2c3` with `unique_resource_names = true`, or `langsmith-kv-demo` without
 - **First run:** prompts for PostgreSQL password, LangSmith license key, admin password, and admin email
 - **Subsequent runs:** reads all values silently from Azure Key Vault — no prompts
 - Stable secrets (API key salt, JWT secret, 4 Fernet encryption keys): reads from Key Vault → falls back to local dot-files → generates fresh if neither exists
@@ -727,6 +728,63 @@ azure/
 > **Workload Identity** is centralized in `k8s-cluster`. Federated credentials for blob-accessing pods (backend, platform-backend, queue, ingest-queue, host-backend, listener, agent-builder-tool-server, agent-builder-trigger-server) are registered there. Adding a new pod that needs Blob access requires updating `service_accounts_for_workload_identity` in `k8s-cluster` and running `terraform apply -target=module.aks`.
 >
 > **AGIC Workload Identity** uses a separate managed identity (`<cluster>-agic-identity`) with Contributor on the App Gateway and Reader on the resource group. The federated credential binds to `system:serviceaccount:ingress-basic:ingress-azure`.
+
+---
+
+## Resource naming
+
+Most Azure resource names only need to be unique inside your resource group. Four
+do not: **PostgreSQL**, **Redis**, **Storage**, and **Key Vault** names live in a
+namespace shared by every Azure tenant, as does the public-IP `dns_label`. Two
+deployments that ask for the same name collide, and the second one fails partway
+through `terraform apply`.
+
+`unique_resource_names = true` (set in every `terraform.tfvars` template and by
+`quickstart.sh`) appends a 6-character hash derived from your subscription ID and
+`name_prefix`, and shortens the base from `langsmith-` to `ls-` to make room
+inside the 24-character Storage and Key Vault limits:
+
+| | `unique_resource_names = false` | `unique_resource_names = true` |
+|---|---|---|
+| Resource group | `langsmith-rg-dev` | `ls-rg-dev` |
+| Postgres | `langsmith-postgres-dev` | `ls-postgres-dev-a1b2c3` |
+| Redis | `langsmith-redis-dev` | `ls-redis-dev-a1b2c3` |
+| Storage | `langsmithblobdev` | `lsblobdeva1b2c3` |
+| Key Vault | `langsmith-kv-dev` | `ls-kv-dev-a1b2c3` |
+
+The Storage row is the only one that looks different, and the hyphens are the
+reason. Azure Storage account names accept only lowercase letters and digits, so
+the module strips the hyphens from `ls-blob-dev-a1b2c3` before creating it. Every
+other name, including the blob container, keeps them.
+
+The hash is deterministic — the same subscription and `name_prefix` always produce
+the same name, so repeat applies are stable and no random values are stored.
+`a1b2c3` above stands in for it; yours differs.
+
+Key Vault is what caps `name_prefix` at roughly 12 characters: it keeps its
+hyphens inside the same 24-character limit Storage has, so it runs out of room
+first. `terraform plan` reports the exact overage rather than letting Azure
+reject the name mid-apply.
+
+> **On an existing deployment, leave `unique_resource_names = false`.** Turning it
+> on renames every resource, which Terraform carries out as destroy-and-recreate:
+> Postgres and Storage would lose their data. It defaults to `false` so bumping to
+> a newer tag is a no-op.
+
+To pin one name, either to keep an existing resource or to dodge a collision
+without renaming the whole deployment, set it explicitly:
+
+```hcl
+postgres_name        = "langsmith-postgres-dev"
+redis_name           = "langsmith-redis-mycorp-dev"
+storage_account_name = "langsmithblobdev"
+keyvault_name        = "langsmith-kv-dev"
+```
+
+`make preflight` checks these four names plus `dns_label` against Azure's
+availability APIs before you apply. Redis is the exception: Azure exposes no
+working name-availability endpoint for Managed Redis, so a cross-tenant Redis
+collision only surfaces at apply time.
 
 ---
 

--- a/modules/azure/TROUBLESHOOTING.md
+++ b/modules/azure/TROUBLESHOOTING.md
@@ -13,6 +13,58 @@ Issues, gotchas, and fixes. Updated as deployments are validated.
 
 ## Pass 1 — Infrastructure
 
+### Resource name is already taken globally
+
+**Symptom — Redis:**
+```
+Error: creating Redis Enterprise "langsmith-redis-dev": unexpected status 400
+The name 'langsmith-redis-dev' is not available.
+```
+
+**Symptom — Storage or Key Vault:** `StorageAccountAlreadyTaken`, or `VaultAlreadyExists`
+on `langsmith-kv-dev`.
+
+**Cause:** Postgres, Redis, Storage and Key Vault names live in a namespace
+shared by every Azure tenant — they become public DNS names like
+`langsmith-postgres-dev.postgres.database.azure.com`. The legacy naming scheme
+derives them from `name_prefix` alone, so every deployment of this module that
+uses the same `name_prefix` asks for the same name. Somebody else already has it.
+
+**Fix — new deployment:** set `unique_resource_names = true` in `terraform.tfvars`.
+Every `terraform.tfvars.*` template and `quickstart.sh` already do. This appends a
+per-subscription hash to the four global names. Refer to
+[Resource naming](README.md#resource-naming).
+
+**Fix — existing deployment** (do *not* flip `unique_resource_names`, it renames and
+therefore destroys and recreates everything): pin just the colliding name.
+
+```hcl
+redis_name = "langsmith-redis-mycorp-dev"
+```
+
+The available overrides are `postgres_name`, `redis_name`, `storage_account_name`,
+and `keyvault_name`.
+
+A soft-deleted Key Vault holds its name for the duration of the retention window,
+so a `VaultAlreadyExists` may be your own vault from an earlier `terraform destroy`:
+
+```bash
+az keyvault list-deleted --query "[].{name:name, scheduledPurgeDate:properties.scheduledPurgeDate}" -o table
+az keyvault purge --name langsmith-kv-dev   # only if you are certain
+```
+
+**Catch it before applying:** `make preflight` checks Postgres, Storage, Key Vault
+and `dns_label` against Azure's availability APIs.
+
+> Redis has no pre-check. Azure exposes no working `CheckNameAvailability`
+> endpoint for `Microsoft.Cache/redisEnterprise` — the subscription-scoped
+> endpoint rejects the type and the location-scoped one rejects every region. So
+> preflight can only report whether the name already exists in *your*
+> subscription. A cross-tenant Redis collision surfaces at apply time; the hashed
+> name is what makes it unlikely.
+
+---
+
 ### K8sVersionNotSupported — version is LTS-only
 
 **Symptom:**

--- a/modules/azure/infra/main.tf
+++ b/modules/azure/infra/main.tf
@@ -26,17 +26,35 @@ locals {
   deployment_name = trimprefix(var.name_prefix, "-")
   name_suffix     = local.deployment_name == "" ? "" : "-${local.deployment_name}"
 
-  # Derived resource names — all "langsmith-<resource><name_suffix>"
-  resource_group_name = "langsmith-rg${local.name_suffix}"
-  vnet_name           = "langsmith-vnet${local.name_suffix}"
-  aks_name            = "langsmith-aks${local.name_suffix}"
-  postgres_name       = "langsmith-postgres${local.name_suffix}"
-  redis_name          = "langsmith-redis${local.name_suffix}"
-  blob_name           = "langsmith-blob${local.name_suffix}" # blob module strips hyphens → "langsmithblobdz"
+  # Postgres, Redis, Storage and Key Vault names live in a namespace shared with
+  # every other Azure tenant, so "langsmith-postgres-dev" is one deployment
+  # anywhere in the world, not one per subscription. unique_resource_names adds a
+  # per-subscription hash to those four and shortens the base from "langsmith" to
+  # "ls" to buy back the characters inside the 24-char Storage/Key Vault limits.
+  #
+  #   false — legacy "langsmith-<resource><name_suffix>". Still the default so an
+  #           existing deployment plans clean; see the warning on the variable.
+  #   true  — "ls-<resource><name_suffix>", plus the hash on the four global names.
+  #
+  # sha256 of subscription_id + name_suffix rather than the random provider: the
+  # value is derived, so repeat applies are stable and nothing is kept in state.
+  name_base   = var.unique_resource_names ? "ls" : "langsmith"
+  uniq_suffix = var.unique_resource_names ? "-${substr(sha256("${var.subscription_id}${local.name_suffix}"), 0, 6)}" : ""
+
+  # Regional names — unique within the subscription, so no hash needed.
+  resource_group_name = "${local.name_base}-rg${local.name_suffix}"
+  vnet_name           = "${local.name_base}-vnet${local.name_suffix}"
+  aks_name            = "${local.name_base}-aks${local.name_suffix}"
+
+  # Globally-unique names — hashed, and each takes an explicit override so a
+  # single colliding name can be pinned without renaming the whole deployment.
+  postgres_name = var.postgres_name != "" ? var.postgres_name : "${local.name_base}-postgres${local.name_suffix}${local.uniq_suffix}"
+  redis_name    = var.redis_name != "" ? var.redis_name : "${local.name_base}-redis${local.name_suffix}${local.uniq_suffix}"
+  blob_name     = var.storage_account_name != "" ? var.storage_account_name : "${local.name_base}-blob${local.name_suffix}${local.uniq_suffix}" # blob module strips hyphens → "lsblobdeva1b2c3"
 
   # Key Vault name: max 24 chars, globally unique.
   # Uses the user-supplied keyvault_name or derives from name_prefix.
-  keyvault_name = var.keyvault_name != "" ? var.keyvault_name : "langsmith-kv${local.name_suffix}"
+  keyvault_name = var.keyvault_name != "" ? var.keyvault_name : "${local.name_base}-kv${local.name_suffix}${local.uniq_suffix}"
 
   # Subnet ID resolution: use newly-created VNet subnets OR bring-your-own
   # existing ones (set create_vnet = false and supply the IDs via variables).
@@ -69,6 +87,27 @@ resource "azurerm_resource_group" "resource_group" {
   name     = local.resource_group_name
   location = var.location
   tags     = local.common_tags
+
+  # Assert the derived names fit Azure's limits before anything is created.
+  # Without this, an over-long name_prefix surfaces as an Azure 400 partway
+  # through the apply, after the resource group, VNet, and AKS already exist.
+  # Key Vault binds first: it keeps its hyphens inside the same 24-char limit
+  # Storage has, so a ~12-char name_prefix is the practical ceiling under
+  # unique_resource_names.
+  lifecycle {
+    precondition {
+      condition     = length(replace(local.blob_name, "-", "")) >= 3 && length(replace(local.blob_name, "-", "")) <= 24
+      error_message = "Storage account name '${replace(local.blob_name, "-", "")}' is ${length(replace(local.blob_name, "-", ""))} chars; Azure allows 3-24. Shorten var.name_prefix or set var.storage_account_name explicitly."
+    }
+    precondition {
+      condition     = length(local.keyvault_name) >= 3 && length(local.keyvault_name) <= 24
+      error_message = "Key Vault name '${local.keyvault_name}' is ${length(local.keyvault_name)} chars; Azure allows 3-24. Shorten var.name_prefix or set var.keyvault_name explicitly."
+    }
+    precondition {
+      condition     = length(local.postgres_name) <= 63 && length(local.redis_name) <= 60
+      error_message = "Postgres name '${local.postgres_name}' must be <= 63 chars and Redis name '${local.redis_name}' <= 60. Shorten var.name_prefix or set var.postgres_name / var.redis_name explicitly."
+    }
+  }
 }
 
 # ── Networking ────────────────────────────────────────────────────────────────

--- a/modules/azure/infra/scripts/_common.sh
+++ b/modules/azure/infra/scripts/_common.sh
@@ -12,6 +12,7 @@
 #   _parse_tfvar <key>        — Read a value from terraform.tfvars
 #   _tfvar_is_true <key>      — Return 0 if tfvar == true
 #   _name_suffix              — Resource-name suffix derived from name_prefix
+#   _derive_kv_name           — Key Vault name, mirroring local.keyvault_name
 #   Color helpers: _bold, _green, _red, _yellow, _cyan, _dim
 #   Status helpers: pass, warn, fail, skip, info, header, action
 
@@ -55,6 +56,31 @@ _name_suffix() {
   local val
   val=$(_parse_tfvar "name_prefix") || val=$(_parse_tfvar "identifier") || return 1
   printf -- '-%s' "${val#-}"
+}
+
+# Key Vault name, mirroring local.keyvault_name in main.tf including the
+# unique_resource_names hash. Four scripts need this name and each derived it
+# independently before, so they all went looking for the wrong vault the moment
+# the naming scheme changed. Keep this in step with main.tf.
+_derive_kv_name() {
+  local explicit suffix sub hash
+  explicit=$(_parse_tfvar keyvault_name || true)
+  if [[ -n "$explicit" ]]; then
+    echo "$explicit"
+    return 0
+  fi
+  suffix=$(_name_suffix || true)
+  if _tfvar_is_true unique_resource_names; then
+    sub=$(_parse_tfvar subscription_id || true)
+    if command -v shasum &>/dev/null; then
+      hash=$(printf '%s' "${sub}${suffix}" | shasum -a 256 | cut -c1-6)
+    else
+      hash=$(printf '%s' "${sub}${suffix}" | sha256sum | cut -c1-6)
+    fi
+    echo "ls-kv${suffix}-${hash}"
+  else
+    echo "langsmith-kv${suffix}"
+  fi
 }
 
 # ── Color helpers ────────────────────────────────────────────────────────────

--- a/modules/azure/infra/scripts/create-k8s-secrets.sh
+++ b/modules/azure/infra/scripts/create-k8s-secrets.sh
@@ -32,16 +32,11 @@ RED='\033[0;31m'; GREEN='\033[0;32m'; NC='\033[0m'
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 INFRA_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
+source "$SCRIPT_DIR/_common.sh"
+
 # ── Resolve Key Vault name from terraform output ───────────────────────────────
 if ! KV_NAME=$(cd "$INFRA_DIR" && terraform output -raw keyvault_name 2>/dev/null); then
-  # fallback: read name_prefix from terraform.tfvars (or the retired
-  # `identifier` key, for a tfvars that predates the rename)
-  _name_prefix=$(grep -E '^\s*(name_prefix|identifier)\s*=' "$INFRA_DIR/terraform.tfvars" \
-    | head -1 \
-    | sed 's/.*=[[:space:]]*"\([^"]*\)".*/\1/' | tr -d '[:space:]') || _name_prefix=""
-  _suffix=""
-  [[ -n "$_name_prefix" ]] && _suffix="-${_name_prefix#-}"
-  KV_NAME="langsmith-kv${_suffix}"
+  KV_NAME=$(_derive_kv_name)
   echo "  (terraform output unavailable — using derived KV name: $KV_NAME)"
 fi
 

--- a/modules/azure/infra/scripts/manage-keyvault.sh
+++ b/modules/azure/infra/scripts/manage-keyvault.sh
@@ -21,12 +21,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/_common.sh"
 
 # ── Resolve Key Vault name ───────────────────────────────────────────────────
-# Priority: terraform output → derived from name_prefix in terraform.tfvars
+# Priority: terraform output → derived from terraform.tfvars
 if KV_NAME=$(cd "$INFRA_DIR" && terraform output -raw keyvault_name 2>/dev/null) && [[ -n "$KV_NAME" ]]; then
   : # got it from terraform output
 else
-  _suffix=$(_name_suffix) || _suffix=""
-  KV_NAME="langsmith-kv${_suffix}"
+  KV_NAME=$(_derive_kv_name)
 fi
 
 NAMESPACE="${NAMESPACE:-langsmith}"

--- a/modules/azure/infra/scripts/preflight.sh
+++ b/modules/azure/infra/scripts/preflight.sh
@@ -13,6 +13,7 @@
 #   3. Required resource providers are registered
 #   4. Deployer has required RBAC roles (Contributor + User Access Admin)
 #   5. terraform.tfvars exists with required fields populated
+#   6. Globally-unique names (Postgres, Storage, Key Vault, dns_label) are free
 #
 # Run before: terraform init / terraform apply
 # Usage: bash infra/scripts/preflight.sh
@@ -167,7 +168,139 @@ else
   fi
 fi
 
-# ── 6. Other tooling ──────────────────────────────────────────────────────────
+# ── 6. Globally-unique resource names ────────────────────────────────────────
+# Postgres, Redis, Storage, and Key Vault names live in a namespace shared by
+# every Azure tenant, as does the public-IP DNS label. A collision surfaces as a
+# raw Azure 400 partway through the apply, after the resource group, VNet, and
+# AKS already exist — so check up front instead.
+echo ""
+echo "── Global Name Availability ──────────────────────────"
+
+if [ ! -f "$TFVARS" ] || [ -z "${SUB_ID:-}" ]; then
+  warn "Skipping name checks (need terraform.tfvars and an active az login)"
+else
+  # Read a tfvars value, quoted or bare. Mirrors _parse_tfvar in _common.sh;
+  # preflight.sh deliberately has no external sourcing.
+  _tfvar() {
+    local raw val
+    raw=$(grep -E "^[[:space:]]*$1[[:space:]]*=" "$TFVARS" 2>/dev/null | head -1) || true
+    [ -n "$raw" ] || return 1
+    val=$(echo "$raw" | sed -n 's/.*=[[:space:]]*"\([^"]*\)".*/\1/p' | tr -d '[:space:]')
+    [ -n "$val" ] || val=$(echo "$raw" | sed 's/.*=[[:space:]]*//' | sed 's/#.*//' | tr -d '[:space:]"')
+    [ -n "$val" ] || return 1
+    echo "$val"
+  }
+
+  NAME_PREFIX=$(_tfvar name_prefix || _tfvar identifier || echo "")
+  LOCATION=$(_tfvar location || echo "")
+  DNS_LABEL=$(_tfvar dns_label || echo "")
+  UNIQUE_NAMES=$(_tfvar unique_resource_names || echo "false")
+
+  # Recompute exactly what main.tf's locals derive, so the check covers the names
+  # Terraform will actually request. name_prefix may carry a leading hyphen or
+  # not; normalize the same way local.name_suffix does. Keep in sync with
+  # local.name_base / local.name_suffix / local.uniq_suffix in infra/main.tf.
+  NAME_SUFFIX=""
+  [ -n "$NAME_PREFIX" ] && NAME_SUFFIX="-${NAME_PREFIX#-}"
+
+  if [ "$UNIQUE_NAMES" = "true" ]; then
+    NAME_BASE="ls"
+    if command -v shasum &>/dev/null; then
+      HASH=$(printf '%s' "${SUB_ID}${NAME_SUFFIX}" | shasum -a 256 | cut -c1-6)
+    else
+      HASH=$(printf '%s' "${SUB_ID}${NAME_SUFFIX}" | sha256sum | cut -c1-6)
+    fi
+    UNIQ_SUFFIX="-${HASH}"
+  else
+    NAME_BASE="langsmith"
+    UNIQ_SUFFIX=""
+    warn "unique_resource_names is false — using the legacy shared-namespace names, which collide between deployments"
+  fi
+
+  PG_NAME=$(_tfvar postgres_name || echo "${NAME_BASE}-postgres${NAME_SUFFIX}${UNIQ_SUFFIX}")
+  REDIS_NAME=$(_tfvar redis_name || echo "${NAME_BASE}-redis${NAME_SUFFIX}${UNIQ_SUFFIX}")
+  KV_NAME=$(_tfvar keyvault_name || echo "${NAME_BASE}-kv${NAME_SUFFIX}${UNIQ_SUFFIX}")
+  BLOB_RAW=$(_tfvar storage_account_name || echo "${NAME_BASE}-blob${NAME_SUFFIX}${UNIQ_SUFFIX}")
+  BLOB_NAME=$(echo "$BLOB_RAW" | tr -d '-') # the blob module strips hyphens
+
+  # Reject anything that isn't a plain Azure resource name before it reaches a
+  # URL or a JSON body — terraform.tfvars is user-authored input.
+  _name_is_safe() {
+    echo "$1" | grep -qE '^[a-zA-Z0-9][a-zA-Z0-9-]{0,62}$'
+  }
+
+  # _check_name <label> <name> <url> <json-body> <availability-field>
+  # A definitive "taken" fails the run. Anything else (auth blip, api-version
+  # drift, unparseable body) only warns — preflight must never block a deploy
+  # because Azure rotated an API version.
+  _check_name() {
+    local label="$1" name="$2" url="$3" body="$4" field="$5" resp avail msg
+    if ! _name_is_safe "$name"; then
+      warn "${label}: '${name}' is not a valid Azure resource name — check skipped"
+      return 0
+    fi
+    if [ -n "$body" ]; then
+      resp=$(az rest --method post --url "$url" --body "$body" -o json 2>/dev/null || true)
+    else
+      resp=$(az rest --method get --url "$url" -o json 2>/dev/null || true)
+    fi
+    if [ -z "$resp" ]; then
+      warn "${label}: '${name}' — could not verify (Azure API error); collision would surface during apply"
+      return 0
+    fi
+    avail=$(echo "$resp" | python3 -c "import sys,json; print(json.load(sys.stdin).get('${field}',''))" 2>/dev/null || echo "")
+    # Azure's Key Vault message runs several hundred chars of soft-delete prose;
+    # keep the first sentence so one failure doesn't bury the rest of the report.
+    msg=$(echo "$resp" | python3 -c "
+import sys, json
+m = (json.load(sys.stdin).get('message', '') or '').strip()
+print(m if len(m) <= 110 else m[:110].rsplit(' ', 1)[0] + ' …')" 2>/dev/null || echo "")
+    case "$avail" in
+      True)  pass "${label}: '${name}' is available" ;;
+      False) fail "${label}: '${name}' is ALREADY TAKEN globally. ${msg}" ;;
+      *)     warn "${label}: '${name}' — unexpected API response; collision would surface during apply" ;;
+    esac
+  }
+
+  _check_name "Postgres" "$PG_NAME" \
+    "https://management.azure.com/subscriptions/${SUB_ID}/providers/Microsoft.DBforPostgreSQL/locations/${LOCATION}/checkNameAvailability?api-version=2023-03-01-preview" \
+    "{\"name\":\"${PG_NAME}\",\"type\":\"Microsoft.DBforPostgreSQL/flexibleServers\"}" "nameAvailable"
+
+  _check_name "Storage account" "$BLOB_NAME" \
+    "https://management.azure.com/subscriptions/${SUB_ID}/providers/Microsoft.Storage/checkNameAvailability?api-version=2023-01-01" \
+    "{\"name\":\"${BLOB_NAME}\",\"type\":\"Microsoft.Storage/storageAccounts\"}" "nameAvailable"
+
+  _check_name "Key Vault" "$KV_NAME" \
+    "https://management.azure.com/subscriptions/${SUB_ID}/providers/Microsoft.KeyVault/checkNameAvailability?api-version=2023-07-01" \
+    "{\"name\":\"${KV_NAME}\",\"type\":\"Microsoft.KeyVault/vaults\"}" "nameAvailable"
+
+  if [ -n "$DNS_LABEL" ]; then
+    _check_name "Public IP DNS label" "$DNS_LABEL" \
+      "https://management.azure.com/subscriptions/${SUB_ID}/providers/Microsoft.Network/locations/${LOCATION}/CheckDnsNameAvailability?domainNameLabel=${DNS_LABEL}&api-version=2023-09-01" \
+      "" "available"
+  else
+    warn "dns_label not set — skipping DNS label check"
+  fi
+
+  # Azure Managed Redis (Microsoft.Cache/redisEnterprise) exposes no working
+  # CheckNameAvailability endpoint: the subscription-scoped one rejects the
+  # redisEnterprise type, and the location-scoped one returns "The requested
+  # location is invalid" for every valid region and api-version. So only the
+  # in-subscription case can be pre-checked — a leftover from a failed apply.
+  # A cross-tenant Redis collision still surfaces at apply time; the hashed name
+  # under unique_resource_names is what makes that unlikely.
+  if _name_is_safe "$REDIS_NAME"; then
+    REDIS_HIT=$(az redisenterprise list --query "length([?name=='${REDIS_NAME}'])" -o tsv 2>/dev/null || echo "0")
+    echo "$REDIS_HIT" | grep -qE '^[0-9]+$' || REDIS_HIT=0
+    if [ "$REDIS_HIT" -gt "0" ]; then
+      fail "Redis: '${REDIS_NAME}' already exists in this subscription — import it or delete it before applying"
+    else
+      warn "Redis: '${REDIS_NAME}' not present in this subscription (Azure exposes no global name check for Managed Redis)"
+    fi
+  fi
+fi
+
+# ── 7. Other tooling ──────────────────────────────────────────────────────────
 echo ""
 echo "── Tooling ───────────────────────────────────────────"
 for TOOL in terraform kubectl helm; do

--- a/modules/azure/infra/scripts/quickstart.sh
+++ b/modules/azure/infra/scripts/quickstart.sh
@@ -146,7 +146,9 @@ _run_section_2() {
   _section "2. Subscription & Naming"
   _hint "The deployment name is appended to every Azure resource name (RG, AKS, KV, blob...)"
   _hint "and becomes the 'environment' tag. Write it without a hyphen — we add the separator."
-  _hint "Example: prod → langsmith-rg-prod, langsmith-aks-prod, langsmith-kv-prod"
+  _hint "Example: prod → ls-rg-prod, ls-aks-prod, ls-kv-prod-<hash>"
+  _hint "Postgres, Redis, Storage and Key Vault names must be unique across all of Azure,"
+  _hint "so those four get a hash of your subscription appended. Keep it under ~12 chars."
   _hint "Changing it later creates entirely new resources — choose something stable."
 
   AUTO_SUB=""
@@ -175,8 +177,8 @@ _run_section_2() {
     # Same rule as the name_prefix validation in variables.tf: hyphens only
     # between alphanumerics, since a trailing or doubled hyphen produces a
     # Key Vault and AKS name Azure rejects at apply. A leading digit is fine,
-    # because the prefix always lands on the end of "langsmith-<resource>" and
-    # the composed name still starts with a letter.
+    # because the prefix always lands on the end of "ls-<resource>" and the
+    # composed name still starts with a letter.
     if [[ "$NAME_PREFIX" =~ ^[a-z0-9](-?[a-z0-9])*$ ]]; then
       break
     fi
@@ -193,7 +195,7 @@ _run_section_2() {
   COST_CENTER="$_REPLY"
 
   echo ""
-  printf "  Resources: langsmith-{resource}$(_cyan "${NAME_PREFIX:+-$NAME_PREFIX}")  in  $(_cyan "$LOCATION")\n"
+  printf "  Resources: ls-{resource}$(_cyan "${NAME_PREFIX:+-$NAME_PREFIX}")  in  $(_cyan "$LOCATION")\n"
 }
 
 # -- 3. Networking -----------------------------------------------------------
@@ -744,6 +746,10 @@ name_prefix     = "${NAME_PREFIX}"
 location        = "${LOCATION}"
 # environment tag defaults to name_prefix. Uncomment to tag it differently:
 # environment   = "${NAME_PREFIX}"
+
+# Per-subscription hash on the globally-unique names (Postgres, Redis, Storage,
+# Key Vault) so they cannot collide with another LangSmith deployment.
+unique_resource_names = true
 TFVARS
 
 [[ -n "$OWNER" ]]       && echo "owner           = \"${OWNER}\"" >> "$OUTPUT"

--- a/modules/azure/infra/scripts/setup-env.sh
+++ b/modules/azure/infra/scripts/setup-env.sh
@@ -22,20 +22,15 @@ set -euo pipefail
 
 SECRETS_FILE="secrets.auto.tfvars"
 
-# ── Read name_prefix from terraform.tfvars ────────────────────────────────────
-# Accepts the retired `identifier` key too, so a tfvars that predates the
-# rename still resolves the right Key Vault. The separator hyphen is added
-# here (name_prefix = "prod" → langsmith-kv-prod), mirroring main.tf.
-_name_prefix=""
-if [[ -f "terraform.tfvars" ]]; then
-  _name_prefix=$(grep -E '^\s*(name_prefix|identifier)\s*=' terraform.tfvars \
-    | head -1 \
-    | sed 's/.*=[[:space:]]*"\([^"]*\)".*/\1/' \
-    | tr -d '[:space:]') || _name_prefix=""
-fi
-_suffix=""
-[[ -n "$_name_prefix" ]] && _suffix="-${_name_prefix#-}"
-_kv_name="langsmith-kv${_suffix}"
+# ── Resolve the Key Vault name ────────────────────────────────────────────────
+# _derive_kv_name mirrors local.keyvault_name, including the name_prefix suffix,
+# an explicit keyvault_name, and the unique_resource_names hash. Deriving it here
+# by hand is how this script and three others drifted apart.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/_common.sh"
+
+_name_prefix=$(_parse_tfvar name_prefix || _parse_tfvar identifier || true)
+_kv_name=$(_derive_kv_name)
 
 # ── Prompt helper (skips if env var already set) ──────────────────────────────
 # If stdin is not a tty and the env var is not set, exit with a clear error

--- a/modules/azure/infra/scripts/status.sh
+++ b/modules/azure/infra/scripts/status.sh
@@ -45,8 +45,7 @@ if [[ -f "$INFRA_DIR/terraform.tfvars" ]]; then
   _pg_source=$(_read_tfvar postgres_source)
   _redis_source=$(_read_tfvar redis_source)
   _sizing=$(_read_tfvar sizing_profile)
-  _suffix=$(_name_suffix) || _suffix=""
-  _kv_name="langsmith-kv${_suffix}"
+  _kv_name=$(_derive_kv_name)
 
   if [[ -n "$_subscription" ]]; then
     pass "Required fields: subscription_id set  name_prefix=${_name_prefix:-'(empty)'}  environment=${_environment:-${_name_prefix:-dev}}"

--- a/modules/azure/infra/terraform.tfvars.dev
+++ b/modules/azure/infra/terraform.tfvars.dev
@@ -24,6 +24,12 @@ subscription_id = "your-azure-subscription-id"   # az account show --query id -o
 name_prefix = "dev"
 location    = "eastus"
 
+# Give the globally-unique names (Postgres, Redis, Storage, Key Vault) a
+# per-subscription hash so they cannot collide with another LangSmith deployment.
+# On an EXISTING deployment leave this false — flipping it renames every resource,
+# which Terraform executes as destroy-and-recreate.
+unique_resource_names = true
+
 #------------------------------------------------------------------------------
 # Sources
 #------------------------------------------------------------------------------

--- a/modules/azure/infra/terraform.tfvars.example
+++ b/modules/azure/infra/terraform.tfvars.example
@@ -17,6 +17,12 @@ subscription_id = "your-azure-subscription-id"   # az account show --query id -o
 name_prefix = "prod"
 location    = "eastus"
 
+# Give the globally-unique names (Postgres, Redis, Storage, Key Vault) a
+# per-subscription hash so they cannot collide with another LangSmith deployment.
+# On an EXISTING deployment leave this false — flipping it renames every resource,
+# which Terraform executes as destroy-and-recreate.
+unique_resource_names = true
+
 # Optional tags for cost allocation and compliance
 # environment = "prod"   # defaults to name_prefix; set only to tag it differently
 # owner       = "platform-team"

--- a/modules/azure/infra/terraform.tfvars.minimum
+++ b/modules/azure/infra/terraform.tfvars.minimum
@@ -29,6 +29,12 @@ subscription_id = "your-azure-subscription-id"   # az account show --query id -o
 name_prefix = "demo"       # appended to every resource name; no leading hyphen
 location    = "eastus"
 
+# Give the globally-unique names (Postgres, Redis, Storage, Key Vault) a
+# per-subscription hash so they cannot collide with another LangSmith deployment.
+# On an EXISTING deployment leave this false — flipping it renames every resource,
+# which Terraform executes as destroy-and-recreate.
+unique_resource_names = true
+
 #------------------------------------------------------------------------------
 # Sources — in-cluster for minimum footprint
 #------------------------------------------------------------------------------

--- a/modules/azure/infra/terraform.tfvars.production
+++ b/modules/azure/infra/terraform.tfvars.production
@@ -24,6 +24,12 @@ subscription_id = "your-azure-subscription-id"   # az account show --query id -o
 name_prefix = "prod"
 location    = "eastus"   # pick the region closest to your users
 
+# Give the globally-unique names (Postgres, Redis, Storage, Key Vault) a
+# per-subscription hash so they cannot collide with another LangSmith deployment.
+# On an EXISTING deployment leave this false — flipping it renames every resource,
+# which Terraform executes as destroy-and-recreate.
+unique_resource_names = true
+
 #------------------------------------------------------------------------------
 # Sources
 #------------------------------------------------------------------------------

--- a/modules/azure/infra/variables.tf
+++ b/modules/azure/infra/variables.tf
@@ -30,6 +30,45 @@ variable "identifier" {
   }
 }
 
+# ── Resource naming scheme ────────────────────────────────────────────────────
+# Redis, Postgres, Storage, and Key Vault names live in a GLOBAL Azure namespace
+# shared by every tenant. The legacy scheme ("langsmith-<resource><name_suffix>")
+# produces the same name for every deployment of this module, so two customers
+# both running name_prefix = "dev" collide and the second one fails mid-apply.
+#
+# unique_resource_names switches to "ls-<resource><name_suffix>-<hash>", where the
+# hash is derived from subscription + name_suffix: deterministic (stable across
+# applies, no random provider) and unique per subscription. The shorter "ls"
+# base is what buys back the characters the hash needs inside the 24-char
+# Storage and Key Vault limits.
+variable "unique_resource_names" {
+  type        = bool
+  description = "Use the collision-resistant naming scheme (ls- base + per-subscription hash on globally-unique names). Enabled in every terraform.tfvars template. Leave false on an existing deployment: turning it on renames every resource, which Terraform executes as destroy-and-recreate, losing Postgres and Storage data. Pin current names via postgres_name/redis_name/storage_account_name/keyvault_name instead."
+  default     = false
+}
+
+# ── Explicit name overrides ───────────────────────────────────────────────────
+# Each defaults to "" meaning "derive it". Set one to pin an existing resource's
+# name, or to work around a collision without renaming the whole deployment.
+
+variable "postgres_name" {
+  type        = string
+  description = "Name for the PostgreSQL Flexible Server. Globally unique (becomes <name>.postgres.database.azure.com), 3-63 chars. Empty derives from the naming scheme."
+  default     = ""
+}
+
+variable "redis_name" {
+  type        = string
+  description = "Name for the Azure Managed Redis cluster. Globally unique (becomes <name>.<region>.redisenterprise.cache.azure.net), 1-60 chars. Empty derives from the naming scheme."
+  default     = ""
+}
+
+variable "storage_account_name" {
+  type        = string
+  description = "Name for the blob Storage Account. Globally unique, 3-24 chars, lowercase alphanumeric only — hyphens are stripped before use. Empty derives from the naming scheme."
+  default     = ""
+}
+
 # ── Resource tagging ──────────────────────────────────────────────────────────
 # Tags are applied to every Azure resource for cost allocation, compliance,
 # and incident response. Required by most enterprise Azure policies.
@@ -56,9 +95,9 @@ variable "cost_center" {
 
 variable "keyvault_name" {
   type        = string
-  description = "Name for the Azure Key Vault. Must be globally unique, 3-24 chars. Defaults to 'langsmith-kv-<name_prefix>' which you may need to customize to avoid naming conflicts."
+  description = "Name for the Azure Key Vault. Globally unique, 3-24 chars. Empty derives it from the naming scheme."
   default     = ""
-  # When empty, main.tf computes: "langsmith-kv${local.name_suffix}"
+  # When empty, main.tf computes: "${local.name_base}-kv${local.name_suffix}${local.uniq_suffix}"
 }
 
 variable "keyvault_purge_protection" {


### PR DESCRIPTION
> **Stacked on [#96](https://github.com/langchain-ai/terraform/pull/96).** Base branch is `feat/azure-unify-name-prefix`, so the diff shown here is only this change. Merge #96 first.
>
> This is [#110](https://github.com/langchain-ai/terraform/pull/110) rebuilt on `name_prefix`. #110 targets `main` and is the version to review if #96 does not land. **Merge one, close the other.**

## Why

A customer's `terraform apply` failed on Redis with a name-unavailable 400. The name was `langsmith-redis-dev`, straight out of the shipped `terraform.tfvars.dev`, and someone else already had it.

Four of the resources this module creates live in a namespace shared with every other Azure tenant: PostgreSQL Flexible Server, Azure Managed Redis, Storage Account, and Key Vault. The public-IP `dns_label` shares one too, regionally. Those names derive from `name_prefix` alone, so two customers who both follow the quickstart both ask for `langsmith-postgres-dev`, and the second one fails partway through an apply that has already built a VNet and an AKS cluster.

This is not hypothetical. Against the live `CheckNameAvailability` APIs, run from `make preflight` on this branch:

```
[✓] Postgres: 'langsmith-postgres-dev' is available
[✗] Storage account: 'langsmithblobdev' is ALREADY TAKEN globally.
[✗] Key Vault: 'langsmith-kv-dev' is ALREADY TAKEN globally.
```

Postgres is still free, which is the only reason the customer hit Redis first rather than Storage.

## What changed

`unique_resource_names = true` shortens the base from `langsmith` to `ls` and appends a 6-character hash of `subscription_id` + `name_suffix` to the four global names:

| | `false` (default) | `true` |
|---|---|---|
| Resource group | `langsmith-rg-dev` | `ls-rg-dev` |
| Postgres | `langsmith-postgres-dev` | `ls-postgres-dev-a1b2c3` |
| Redis | `langsmith-redis-dev` | `ls-redis-dev-a1b2c3` |
| Storage | `langsmithblobdev` | `lsblobdeva1b2c3` |
| Key Vault | `langsmith-kv-dev` | `ls-kv-dev-a1b2c3` |

`a1b2c3` stands in for the real hash here and in the README. It is per-subscription, so no two subscriptions see the same one.

The base change is what makes this fit. Storage and Key Vault cap at 24 characters, and `langsmith-kv-dev` plus a 7-character suffix is already 23, leaving no room for a realistic `name_prefix`. At `ls`, `name_prefix = "production"` still lands at 23 for Key Vault and 22 for Storage.

Storage looks like the odd one out because Azure Storage account names accept only lowercase letters and digits. The local is `ls-blob-dev-a1b2c3` like every other name; the storage module strips the hyphens on the way in, which it already did before this change.

The hash uses `substr(sha256(...), 0, 6)` rather than the `random` provider, so it is derived rather than stored: repeat applies are stable, and nothing breaks if the state is rebuilt.

Regional names (resource group, VNet, AKS) get the shorter base but no hash. They only need to be unique inside the subscription.

### Two locals, named to stay clear of #96's

This is the whole reason the change needed rebuilding rather than rebasing. #96 introduces `local.name_suffix` for the deployment suffix (`-prod`). #110 had used that same name for the hash. Here they are separate:

| Local | Meaning | Owner |
|---|---|---|
| `local.name_suffix` | `-prod`, the deployment suffix | #96, unchanged |
| `local.name_base` | `ls` or `langsmith` | this PR |
| `local.uniq_suffix` | `-a1b2c3`, the hash | this PR |

```hcl
name_base   = var.unique_resource_names ? "ls" : "langsmith"
uniq_suffix = var.unique_resource_names ? "-${substr(sha256("${var.subscription_id}${local.name_suffix}"), 0, 6)}" : ""

postgres_name = var.postgres_name != "" ? var.postgres_name : "${local.name_base}-postgres${local.name_suffix}${local.uniq_suffix}"
```

The hash keys on `local.name_suffix` rather than `var.name_prefix`, so `name_prefix = "prod"` and `name_prefix = "-prod"` produce the same hash. #96 already normalizes the two forms for names; this keeps the hash normalized with them.

### Plan-time length checks

Three `lifecycle` preconditions catch an over-long name before apply: Storage and Key Vault at 24, Postgres at 63, Redis at 60. Storage measures the length *after* hyphens are stripped, since that is what Azure receives.

Key Vault binds first, because it keeps its hyphens inside the same 24-character limit. Measured from `terraform console` at `name_prefix = "development1"`:

| | Name | Length | Limit |
|---|---|---|---|
| Storage | `lsblobdevelopment1<hash>` | 24 | 24, passes |
| Key Vault | `ls-kv-development1-<hash>` | **25** | 24, fails |
| Postgres | `ls-postgres-development1-<hash>` | 31 | 63 |

so `terraform plan` stops:

```
Error: Resource precondition failed

  on main.tf line 103, in resource "azurerm_resource_group" "resource_group":
 103:       condition     = length(local.keyvault_name) >= 3 && length(local.keyvault_name) <= 24
    ├────────────────
    │ local.keyvault_name is "ls-kv-development1-fcc125"

Key Vault name 'ls-kv-development1-fcc125' is 25 chars; Azure allows 3-24.
Shorten var.name_prefix or set var.keyvault_name explicitly.
```

That puts the practical ceiling on `name_prefix` at about 12 characters, which the README and the quickstart prompt both state.

### Preflight availability checks

`preflight.sh` gains section 6, which calls `CheckNameAvailability` for Postgres, Storage, and Key Vault, plus `CheckDnsNameAvailability` for the `dns_label`. Only a definitive `nameAvailable: false` calls `fail`. An API error, an unexpected body, or a name that fails the format guard only `warn`s, because preflight must not block a deploy over a transport problem. Names are validated against `^[a-zA-Z0-9][a-zA-Z0-9-]{0,62}$` before they reach a URL or a JSON body, since `terraform.tfvars` is user-authored.

### Per-name overrides

`postgres_name`, `redis_name`, and `storage_account_name` join the existing `keyvault_name` as explicit escape hatches, for keeping an existing resource or dodging one collision without renaming a whole deployment.

## Migration

**Nothing changes for an existing deployment.** With `unique_resource_names = false`, `name_base` is `"langsmith"` and `uniq_suffix` is `""`, so every name expression reduces character-for-character to what #96 produces. Verified against #96's own published behavior matrix:

| `name_prefix` | resource group | key vault |
|---|---|---|
| `"prod"` | `langsmith-rg-prod` | `langsmith-kv-prod` |
| `"-prod"` | `langsmith-rg-prod` | `langsmith-kv-prod` |
| unset | `langsmith-rg` | `langsmith-kv` |

Turning it on renames every resource, which Terraform carries out as destroy-and-recreate. Postgres and Storage would lose their data. The variable description, the README, and TROUBLESHOOTING all say so. There is no automatic migration and this PR does not attempt one: the safe path for an existing deployment that hits a collision is to pin the one colliding name.

Note the interaction with #96's migration promise. #96 tells an operator upgrading from `identifier` that resource names are unchanged, and that stays true when they rename the variable in their existing `terraform.tfvars`. It stops being true if they instead copy a fresh template, because the templates enable this flag. The README warning and the template comment both call that out.

New deployments get unique names without reading any of it, because all four `terraform.tfvars.*` templates and `quickstart.sh` set the flag to `true`.

## Redis has no working pre-check

`Microsoft.Cache/CheckNameAvailability` rejects type `redisEnterprise` at api-versions 2024-03-01, 2024-11-01, and 2025-08-01-preview; the location-scoped form returns "The requested location is invalid" at 2025-07-01 and 2026-05-01-preview. Rather than ship a check that silently never fires, preflight falls back to `az redisenterprise list` for the in-subscription case (a leftover from a failed apply, which it can catch) and TROUBLESHOOTING says plainly that a cross-tenant Redis collision only surfaces at apply. The hash makes one unlikely; it does not make it detectable in advance.

## Also in here

Four scripts derived the Key Vault name independently: `manage-keyvault.sh`, `status.sh`, `setup-env.sh`, and `create-k8s-secrets.sh`. All four would have gone looking for `langsmith-kv-dev` once the flag was on and reported a missing vault. They now share `_derive_kv_name` in `scripts/_common.sh`, built on #96's `_name_suffix`.

`setup-env.sh` and `create-k8s-secrets.sh` each carried their own inline `grep | sed | tr` tfvars parser and did not source `_common.sh` at all. Both now source it, which removes the two parsers along with the drift.

`_derive_kv_name` keeps #96's fallback to the retired `identifier` key, so a read-only script still resolves the right vault for a tfvars that predates the rename, even though Terraform now rejects that key.

## Verified

- `terraform fmt -check -recursive` and `terraform validate` clean
- `bash -n` clean on all 7 changed scripts
- `_derive_kv_name` compared against `local.keyvault_name` across 8 combinations (legacy/unique × unset/`prod`/`-prod`, explicit `keyvault_name`, retired `identifier`): 7 match. The 8th is the `identifier` fallback, which the shell honors by design and Terraform rejects.
- Back-compat names read out of `terraform console` for three `name_prefix` values, matching the table above
- Precondition confirmed firing by a targeted `terraform plan` against a live subscription, output above. A valid `name_prefix` plans clean: `1 to add`, `name = "ls-rg-prod"`.
- `preflight.sh` run against a live subscription on both paths: reports the hashed names available, and the legacy Storage and Key Vault names as taken

Not exercised end to end: `setup-env.sh` prompts for secrets and `create-k8s-secrets.sh` writes to a cluster. Their `_derive_kv_name` call is covered by `bash -n` and by the 8-case comparison above.

## Scope

Azure only. GCS bucket names are globally unique across all of Google Cloud and S3 bucket names across all of AWS, so both modules have the same exposure with the same shipped defaults. Neither is touched here; worth its own PR.

## Other conflicts

[#95](https://github.com/langchain-ai/terraform/pull/95) touches `infra/main.tf` and [#99](https://github.com/langchain-ai/terraform/pull/99) touches `README.md`, both in regions this PR also edits. Whichever merges second resolves them. [#108](https://github.com/langchain-ai/terraform/pull/108) already contains #96 along with five other open Azure branches, so it will need this change applied on top rather than merged alongside.
