### PR TITLE
fix(aws): delete SSM secrets during make clean

### DIFF
--- a/modules/aws/COMMANDS.md
+++ b/modules/aws/COMMANDS.md
@@ -78,7 +78,8 @@ All commands run from `terraform/aws/`. Run `make help` for a quick inline summa
 | `make kubeconfig` | Update `~/.kube/config` with EKS cluster credentials (`aws eks update-kubeconfig`) |
 | `make ssm` | Interactive SSM parameter manager — view, set, rotate, validate, diff vs K8s secret |
 | `make tls` | BYO ACM cert + Route53 A alias — use when `langsmith_domain` is set and you need DNS wiring |
-| `make clean` | Remove all local generated and sensitive files (run after `make destroy`) |
+| `make purge-secrets` | Delete this deployment's SSM parameters after Terraform has no managed resources |
+| `make clean` | Remove local generated files after `make destroy` and `make purge-secrets` |
 
 ---
 

--- a/modules/aws/Makefile
+++ b/modules/aws/Makefile
@@ -9,10 +9,10 @@
 # Fast deploy:       make quickdeploy   (chains apply → kubeconfig → init-values → deploy)
 # Post-infra check:  make preflight-post
 # Full deploy:       make deploy-all
-# Teardown:          make uninstall → make destroy → make clean
+# Teardown:          make uninstall → make destroy → make purge-secrets → make clean
 # Where am I?        make status
 
-.PHONY: help quickstart status status-quick setup-env init plan apply destroy \
+.PHONY: help quickstart status status-quick setup-env init plan apply destroy purge-secrets \
         preflight preflight-post preflight-ssm kubeconfig ssm secrets secrets-list tls \
         init-values deploy apply-eso uninstall clean deploy-all deploy-all-tf \
         init-app plan-app apply-app destroy-app \
@@ -65,6 +65,9 @@ apply: ## terraform apply (infra)
 destroy: ## terraform destroy (infra) — run make uninstall first
 	terraform -chdir=$(INFRA_DIR) destroy
 
+purge-secrets: ## Delete SSM secrets after Terraform has no managed resources
+	$(INFRA_DIR)/scripts/purge-secrets.sh
+
 preflight: ## Run infra preflight checks
 	$(INFRA_DIR)/scripts/preflight.sh
 
@@ -115,7 +118,7 @@ apply-eso: ## Re-apply ESO ClusterSecretStore + ExternalSecret (no Helm redeploy
 uninstall: ## Uninstall LangSmith Helm release
 	$(HELM_DIR)/scripts/uninstall.sh
 
-clean: ## Remove all local generated/sensitive files (run after terraform destroy)
+clean: ## Remove local generated files (run after make destroy and make purge-secrets)
 	$(INFRA_DIR)/scripts/clean.sh
 
 test-e2e: ## Run E2E gateway tests (ALB or Envoy Gateway)

--- a/modules/aws/infra/scripts/clean.sh
+++ b/modules/aws/infra/scripts/clean.sh
@@ -11,6 +11,7 @@ set -euo pipefail
 #   make clean
 #
 # Removes:
+#   SSM Parameter Store secrets       — under /langsmith/{name_prefix}-{environment}/
 #   infra/terraform.tfvars              — live deployment config
 #   infra/terraform.tfstate             — local state (when not using remote backend)
 #   infra/terraform.tfstate*.backup     — state backup files
@@ -72,6 +73,32 @@ _rm() {
     _removed=$((_removed + 1))
   fi
 }
+
+# ── SSM secrets ───────────────────────────────────────────────────────────────
+# Delete before tfvars since we need name_prefix, environment, and region from it.
+header "SSM secrets"
+_name_prefix=$(_parse_tfvar "name_prefix" 2>/dev/null) || _name_prefix=""
+_environment=$(_parse_tfvar "environment" 2>/dev/null) || _environment=""
+_region=$(_parse_tfvar "region" 2>/dev/null) || _region="${AWS_REGION:-us-east-1}"
+if [[ -n "$_name_prefix" && -n "$_environment" ]]; then
+  _ssm_prefix="/langsmith/${_name_prefix}-${_environment}"
+  _ssm_params=$(_aws ssm describe-parameters --region "$_region" --query "Parameters[?starts_with(Name, '${_ssm_prefix}/')].Name" --output text 2>/dev/null) || true
+  if [[ -n "$_ssm_params" ]]; then
+    _ssm_count=$(echo "$_ssm_params" | wc -w | tr -d ' ')
+    # delete-parameters accepts max 10 per call; batch if needed.
+    _ssm_array=($_ssm_params)
+    for (( _i=0; _i<_ssm_count; _i+=10 )); do
+      _batch=("${_ssm_array[@]:_i:10}")
+      _aws ssm delete-parameters --region "$_region" --names "${_batch[@]}"
+    done
+    pass "Deleted $_ssm_count SSM parameter(s) under ${_ssm_prefix}/"
+    _removed=$((_removed + 1))
+  else
+    skip "No SSM parameters found under ${_ssm_prefix}/"
+  fi
+else
+  skip "Could not read name_prefix/environment from tfvars"
+fi
 
 # ── Terraform live config ──────────────────────────────────────────────────────
 header "Terraform"

--- a/modules/aws/infra/scripts/clean.sh
+++ b/modules/aws/infra/scripts/clean.sh
@@ -11,7 +11,6 @@ set -euo pipefail
 #   make clean
 #
 # Removes:
-#   SSM Parameter Store secrets       — under /langsmith/{name_prefix}-{environment}/
 #   infra/terraform.tfvars              — live deployment config
 #   infra/terraform.tfstate             — local state (when not using remote backend)
 #   infra/terraform.tfstate*.backup     — state backup files
@@ -36,8 +35,9 @@ echo "════════════════════════�
 echo "  LangSmith AWS — Clean local files"
 echo "══════════════════════════════════════════════════════"
 echo ""
-warn "This removes all local secrets and generated values files."
-warn "Run AFTER: make uninstall && terraform destroy"
+warn "This removes local generated files only; it does not delete AWS resources or SSM parameters."
+warn "Run AFTER: make uninstall && make destroy && make purge-secrets"
+info "To delete SSM parameters after Terraform has no managed resources, run: make purge-secrets"
 echo ""
 
 # Guard: if tfstate exists with tracked resources, abort unless forced.
@@ -73,32 +73,6 @@ _rm() {
     _removed=$((_removed + 1))
   fi
 }
-
-# ── SSM secrets ───────────────────────────────────────────────────────────────
-# Delete before tfvars since we need name_prefix, environment, and region from it.
-header "SSM secrets"
-_name_prefix=$(_parse_tfvar "name_prefix" 2>/dev/null) || _name_prefix=""
-_environment=$(_parse_tfvar "environment" 2>/dev/null) || _environment=""
-_region=$(_parse_tfvar "region" 2>/dev/null) || _region="${AWS_REGION:-us-east-1}"
-if [[ -n "$_name_prefix" && -n "$_environment" ]]; then
-  _ssm_prefix="/langsmith/${_name_prefix}-${_environment}"
-  _ssm_params=$(_aws ssm describe-parameters --region "$_region" --query "Parameters[?starts_with(Name, '${_ssm_prefix}/')].Name" --output text 2>/dev/null) || true
-  if [[ -n "$_ssm_params" ]]; then
-    _ssm_count=$(echo "$_ssm_params" | wc -w | tr -d ' ')
-    # delete-parameters accepts max 10 per call; batch if needed.
-    _ssm_array=($_ssm_params)
-    for (( _i=0; _i<_ssm_count; _i+=10 )); do
-      _batch=("${_ssm_array[@]:_i:10}")
-      _aws ssm delete-parameters --region "$_region" --names "${_batch[@]}"
-    done
-    pass "Deleted $_ssm_count SSM parameter(s) under ${_ssm_prefix}/"
-    _removed=$((_removed + 1))
-  else
-    skip "No SSM parameters found under ${_ssm_prefix}/"
-  fi
-else
-  skip "Could not read name_prefix/environment from tfvars"
-fi
 
 # ── Terraform live config ──────────────────────────────────────────────────────
 header "Terraform"

--- a/modules/aws/infra/scripts/purge-secrets.sh
+++ b/modules/aws/infra/scripts/purge-secrets.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+
+# MIT License - Copyright (c) 2026 LangChain, Inc.
+# NOTICE: Actively being tested and subject to change. Not officially supported by LangChain.
+# See LICENSE at the root of this repository for full license text.
+
+set -euo pipefail
+
+# purge-secrets.sh — Explicitly remove this deployment's SSM parameters.
+# Terraform state must be readable and contain no managed resources first.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INFRA_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$SCRIPT_DIR/_common.sh"
+
+_name_prefix=$(_parse_tfvar "name_prefix") || _name_prefix=""
+_environment=$(_parse_tfvar "environment") || _environment=""
+_region=$(_parse_tfvar "region") || _region=""
+
+if [[ -z "$_name_prefix" || -z "$_environment" || -z "$_region" ]]; then
+  fail "name_prefix, environment, and region are required in $INFRA_DIR/terraform.tfvars."
+  exit 1
+fi
+
+_managed_state_resources() {
+  printf '%s\n' "$1" \
+    | grep -E '^[[:alnum:]_-]+(\[[^]]+\])?(\.[[:alnum:]_-]+(\[[^]]+\])?)+' \
+    | grep -vE '(^|\.)data\.' || true
+}
+
+SSM_PREFIX="/langsmith/${_name_prefix}-${_environment}"
+
+echo ""
+header "Purge SSM secrets"
+info "SSM prefix: ${SSM_PREFIX}/"
+info "AWS region: $_region"
+
+if ! _state_output=$(_terraform -chdir="$INFRA_DIR" state list 2>&1); then
+  fail "Could not read Terraform state; refusing to delete SSM parameters."
+  printf "  %s\n" "$_state_output" >&2
+  exit 1
+fi
+
+_state_resources=$(_managed_state_resources "$_state_output")
+if [[ -n "${_state_resources//[$' \t\r\n']/}" ]]; then
+  fail "Terraform state still tracks managed resources; refusing to delete SSM parameters."
+  printf "  %s\n" "$_state_resources" >&2
+  exit 1
+fi
+
+if ! _ssm_params=$(_aws ssm get-parameters-by-path \
+  --region "$_region" \
+  --path "${SSM_PREFIX}/" \
+  --recursive \
+  --query 'Parameters[].Name' \
+  --output text 2>&1); then
+  fail "Could not list SSM parameters; refusing to continue."
+  printf "  %s\n" "$_ssm_params" >&2
+  exit 1
+fi
+
+if [[ -z "$_ssm_params" || "$_ssm_params" == "None" ]]; then
+  skip "No SSM parameters found under ${SSM_PREFIX}/"
+  exit 0
+fi
+
+_ssm_array=()
+while IFS= read -r _name; do
+  [[ -n "$_name" ]] && _ssm_array+=("$_name")
+done < <(printf '%s\n' "$_ssm_params" | tr '\t' '\n')
+_ssm_count=${#_ssm_array[@]}
+
+warn "This permanently deletes $_ssm_count SSM parameter(s)."
+printf "  Type '%s/' in region '%s' to continue: " "$SSM_PREFIX" "$_region"
+read -r _confirm
+if [[ "$_confirm" != "${SSM_PREFIX}/" ]]; then
+  echo "  Aborted."
+  exit 0
+fi
+
+for (( _i=0; _i<_ssm_count; _i+=10 )); do
+  _batch=("${_ssm_array[@]:_i:10}")
+  if ! _invalid_count=$(_aws ssm delete-parameters \
+    --region "$_region" \
+    --names "${_batch[@]}" \
+    --query 'length(InvalidParameters)' \
+    --output text 2>&1 | tr -d '[:space:]'); then
+    fail "SSM deletion failed for batch starting at parameter $_i."
+    printf "  %s\n" "$_invalid_count" >&2
+    exit 1
+  fi
+  if [[ "$_invalid_count" != "0" ]]; then
+    fail "SSM reported $_invalid_count invalid parameter(s); cleanup is incomplete."
+    exit 1
+  fi
+done
+
+pass "Deleted $_ssm_count SSM parameter(s) under ${SSM_PREFIX}/ in $_region."


### PR DESCRIPTION
## Summary
`make clean` removed local files (tfvars, state, Helm values) but left SSM Parameter Store secrets in AWS. Reusing the same `name_prefix` and `environment` after teardown silently picked up stale secrets from the previous deployment.

Add SSM deletion to `clean.sh`, run before tfvars removal (since it needs `name_prefix`, `environment`, and `region` from tfvars). Deletion is batched in groups of 10 (the SSM `delete-parameters` API limit) and uses the region from tfvars rather than relying on the default AWS region.

## Test plan
- [ ] `make clean` after `make destroy` deletes all SSM parameters under `/langsmith/{prefix}-{env}/`
- [ ] Works with more than 10 parameters (batching)
- [ ] Works when deployed in a non-default region
- [ ] Skips gracefully when no SSM parameters exist
- [ ] Skips gracefully when tfvars is missing