### PR TITLE
fix(azure): fail loudly on AKS zone drift, drop dead networking zone input

### DIFF
--- a/modules/azure/README.md
+++ b/modules/azure/README.md
@@ -873,6 +873,15 @@ postgres_high_availability_mode = "ZoneRedundant"
 
 Zone-redundant PostgreSQL requires `GeneralPurpose` or `MemoryOptimized` SKU.
 
+Set `availability_zones` before the first apply. The AKS node pool keeps the
+zones it was created with: `azurerm` re-zones a default node pool by cycling the
+system node pool, and that cycle does not cordon and drain, so the module ignores
+zone changes rather than disrupt running pods on a tfvars edit. Plan reports a
+mismatch as a `Check block assertion failed` warning naming both the live and the
+requested zones. To re-zone an existing cluster on purpose, remove
+`default_node_pool[0].zones` from the `ignore_changes` block in
+`infra/modules/k8s-cluster/main.tf` and apply during a maintenance window.
+
 ---
 
 ## Architecture

--- a/modules/azure/README.md
+++ b/modules/azure/README.md
@@ -640,7 +640,7 @@ azure/
 
 | Module | Required | Description |
 |--------|----------|-------------|
-| `networking` | yes | VNet, subnets (main, postgres, redis, bastion, agic). AGIC subnet (`10.0.96.0/24`) is created automatically when `ingress_controller = "agic"`. Multi-AZ zone pinning supported. Can also create subnets inside a VNet you already own — see [Bring your own VNet](#bring-your-own-vnet). |
+| `networking` | yes | VNet, subnets (main, postgres, redis, bastion, agic). AGIC subnet (`10.0.96.0/24`) is created automatically when `ingress_controller = "agic"`. Not zonal — an Azure subnet spans every zone in its region. Can also create subnets inside a VNet you already own — see [Bring your own VNet](#bring-your-own-vnet). |
 | `k8s-cluster` | yes | AKS cluster, node pools, OIDC issuer, managed identity, federated credentials (Workload Identity centralized here). Installs ingress controller via Helm: nginx / istio / istio-addon / agic (App Gateway v2 + AGIC chart) / envoy-gateway. |
 | `k8s-bootstrap` | yes | Kubernetes namespace, ServiceAccount, cert-manager, KEDA, postgres/redis K8s secrets. |
 | `storage` | yes | Azure Blob storage account + container. |

--- a/modules/azure/TEST_CYCLE.md
+++ b/modules/azure/TEST_CYCLE.md
@@ -275,9 +275,16 @@ postgres_standby_availability_zone   = "2"
 postgres_geo_redundant_backup        = true
 ```
 
-**Expected plan**: AKS node pool zones updated; PostgreSQL HA mode set to `ZoneRedundant`.
+**Expected plan**: PostgreSQL HA mode set to `ZoneRedundant`.
 
 > Zone-redundant PostgreSQL requires `GeneralPurpose` or `MemoryOptimized` SKU.
+
+> Set `availability_zones` before the first apply. On an existing cluster the
+> AKS node pool keeps the zones it was created with: the module ignores zone
+> changes so the provider cannot cycle the system node pool out from under
+> running pods. Plan reports the mismatch as a `Check block assertion failed`
+> warning naming both the live and the requested zones, and exits 0. Expect that
+> warning here rather than a node pool change.
 
 ---
 

--- a/modules/azure/infra/main.tf
+++ b/modules/azure/infra/main.tf
@@ -313,8 +313,7 @@ module "vnet" {
 
   # Both are carved only out of a VNet Terraform owns. Under bring-your-own the
   # operator supplies the subnet instead, and local.*_subnet_id selects it.
-  enable_bastion     = var.create_bastion && var.create_vnet
-  availability_zones = var.availability_zones
+  enable_bastion = var.create_bastion && var.create_vnet
 
   # AGIC subnet: provisioned only when ingress_controller = "agic"
   enable_agic                = var.ingress_controller == "agic" && var.create_vnet

--- a/modules/azure/infra/main.tf
+++ b/modules/azure/infra/main.tf
@@ -311,8 +311,9 @@ module "vnet" {
   postgres_subnet_address_prefix = var.postgres_subnet_address_prefix
   redis_subnet_address_prefix    = var.redis_subnet_address_prefix
 
-  # Both are carved only out of a VNet Terraform owns. Under bring-your-own the
-  # operator supplies the subnet instead, and local.*_subnet_id selects it.
+  # The bastion and AGIC subnets below are carved only out of a VNet Terraform
+  # owns. Under bring-your-own the operator supplies the subnet instead, and
+  # local.*_subnet_id selects it.
   enable_bastion = var.create_bastion && var.create_vnet
 
   # AGIC subnet: provisioned only when ingress_controller = "agic"

--- a/modules/azure/infra/modules/k8s-cluster/main.tf
+++ b/modules/azure/infra/modules/k8s-cluster/main.tf
@@ -190,6 +190,21 @@ resource "azurerm_kubernetes_cluster" "main" {
       default_node_pool[0].upgrade_settings,
       default_node_pool[0].zones,
     ]
+
+    # ignore_changes above makes a zone change a silent no-op: the plan comes
+    # back clean and the node pool stays where it is. Fail loudly instead, so a
+    # requested zone change is never mistaken for an applied one.
+    postcondition {
+      condition = toset(try(self.default_node_pool[0].zones, [])) == toset(var.availability_zones)
+      error_message = join("", [
+        "AKS node pool zones are [",
+        join(",", try(self.default_node_pool[0].zones, [])),
+        "] but availability_zones requests [",
+        join(",", var.availability_zones),
+        "]. AKS cannot re-zone an existing node pool; zones apply only at creation. ",
+        "Either revert availability_zones to match, or recreate the node pool.",
+      ])
+    }
   }
 }
 

--- a/modules/azure/infra/modules/k8s-cluster/main.tf
+++ b/modules/azure/infra/modules/k8s-cluster/main.tf
@@ -183,28 +183,46 @@ resource "azurerm_kubernetes_cluster" "main" {
   lifecycle {
     # upgrade_settings change during rolling node upgrades; ignore to prevent
     # drift between Terraform state and live cluster configuration.
-    # zones: AKS does not support changing zones on an existing node pool —
-    # it is only applied at creation time. Ignoring prevents forced recreation
-    # when availability_zones is set on an existing cluster.
+    #
+    # zones: azurerm ~> 4.0 does support re-zoning an existing default node
+    # pool. It is one of the cycleNodePoolProperties, so a change is applied by
+    # cycling the system node pool through temporary_name_for_rotation (set to
+    # "defaulttmp" above) rather than by recreating the cluster. We suppress it
+    # deliberately: the provider's cycle does not cordon and drain, so it hard-
+    # disrupts every pod on the system pool. Editing one tfvars line should not
+    # do that unannounced. The check block below reports the resulting drift.
     ignore_changes = [
       default_node_pool[0].upgrade_settings,
       default_node_pool[0].zones,
     ]
+  }
+}
 
-    # ignore_changes above makes a zone change a silent no-op: the plan comes
-    # back clean and the node pool stays where it is. Fail loudly instead, so a
-    # requested zone change is never mistaken for an applied one.
-    postcondition {
-      condition = toset(try(self.default_node_pool[0].zones, [])) == toset(var.availability_zones)
-      error_message = join("", [
-        "AKS node pool zones are [",
-        join(",", try(self.default_node_pool[0].zones, [])),
-        "] but availability_zones requests [",
-        join(",", var.availability_zones),
-        "]. AKS cannot re-zone an existing node pool; zones apply only at creation. ",
-        "Either revert availability_zones to match, or recreate the node pool.",
-      ])
-    }
+# ignore_changes on default_node_pool[0].zones makes an availability_zones edit
+# a silent no-op: the plan comes back clean and the node pool stays put. Surface
+# that as a warning on every plan so a requested zone change is never mistaken
+# for an applied one.
+#
+# A check block rather than a postcondition on purpose. A failing postcondition
+# aborts planning even when the cluster has no planned changes, so a deployment
+# already sitting in this state cannot apply anything at all until it is
+# resolved. The drift is worth reporting, not worth blocking unrelated work.
+check "aks_node_pool_zone_drift" {
+  assert {
+    condition = toset(azurerm_kubernetes_cluster.main.default_node_pool[0].zones) == toset(var.availability_zones)
+    error_message = join("", [
+      "AKS node pool zones are [",
+      join(",", sort(tolist(azurerm_kubernetes_cluster.main.default_node_pool[0].zones))),
+      "] but availability_zones requests [",
+      join(",", sort(var.availability_zones)),
+      "]. This module ignores zone changes on an existing node pool, so the ",
+      "request was discarded and the live zones above are what you have. To ",
+      "make it take effect, either revert availability_zones to the live value, ",
+      "or drop default_node_pool[0].zones from the ignore_changes block in ",
+      "modules/k8s-cluster/main.tf and apply during a maintenance window. That ",
+      "cycles the system node pool, which does not cordon and drain and will ",
+      "disrupt every pod running on it.",
+    ])
   }
 }
 

--- a/modules/azure/infra/modules/networking/variables.tf
+++ b/modules/azure/infra/modules/networking/variables.tf
@@ -85,12 +85,6 @@ variable "bastion_subnet_address_prefix" {
   default     = ["10.0.80.0/27"] # 32 IPs — sufficient for a single jump VM
 }
 
-variable "availability_zones" {
-  type        = list(string)
-  description = "Availability zones to spread resources across. Use [\"1\",\"2\",\"3\"] for zone-redundant HA. Default [\"1\"] for single-zone (lower cost)."
-  default     = ["1"]
-}
-
 variable "enable_agic" {
   type        = bool
   description = "Create a dedicated subnet for AGIC (Application Gateway Ingress Controller). Required when ingress_controller = 'agic'."


### PR DESCRIPTION
Two independent zone-handling fixes in the Azure module. Neither changes what gets provisioned on a correctly configured deployment.

## 1. An AKS zone change is currently a silent no-op

`azurerm_kubernetes_cluster` ignores changes to `default_node_pool[0].zones`, so editing `availability_zones` on a live cluster plans clean, applies clean, and does nothing. There is no output distinguishing "your zone change was applied" from "your zone change was discarded."

**The suppression is ours, not a platform limit.** Under `azurerm ~> 4.0`, `default_node_pool.0.zones` is one of the `cycleNodePoolProperties`, and its schema is `commonschema.ZonesMultipleOptional()` rather than a ForceNew variant. The provider applies a zone change by cycling the system node pool through `temporary_name_for_rotation`, which this module already sets to `defaulttmp`. The pre-existing lifecycle comment, and the first revision of this PR, both attributed the no-op to AKS. Neither was correct. Thanks @dstampfli for catching it.

The suppression stays, for the reason that actually holds: the provider's cycle does no cordon and drain, so it disrupts every pod running on the previous system node pool. Editing one line of tfvars should not do that unannounced. The lifecycle comment now says that.

So the drift gets reported instead of hidden. A `check` block names both the live and the requested zones on every plan:

```
AKS node pool zones are [1] but availability_zones requests [1,2,3]. This
module ignores zone changes on an existing node pool, so the request was
discarded and the live zones above are what you have. To make it take effect,
either revert availability_zones to the live value, or drop
default_node_pool[0].zones from the ignore_changes block in
modules/k8s-cluster/main.tf and apply during a maintenance window. That cycles
the system node pool, which does not cordon and drain and will disrupt every
pod running on it.
```

`check` rather than `postcondition`, deliberately. A failing postcondition aborts planning even when the cluster has zero planned changes, so any deployment already sitting in this state could not apply anything at all until someone reverted or rebuilt. That is the same trap as a hard-failing default on an existing deployment. A `check` reports the same drift as a warning and exits 0. Both constructs are available on the module's `>= 1.11.0` floor.

Docs updated where an operator would look: the README Multi-AZ section, and the `TEST_CYCLE.md` Multi-AZ scenario, which expected "AKS node pool zones updated" for behavior that never happened.

## 2. The networking module took an `availability_zones` input it never read

The module declared `availability_zones` and the root passed a value in, but nothing under `modules/networking/` ever referenced it. The declaration was the only occurrence of the name in the entire directory.

It could never have done anything. An Azure subnet spans every availability zone in its region, so a VNet or subnet has no zonal placement decision to make. The shape mirrors AWS, where subnets genuinely are per-AZ, and it read as a supported feature that silently did nothing. The README module table advertised it as "Multi-AZ zone pinning supported"; corrected here to say the module is not zonal.

Removing an unused variable has no state impact and no plan diff. The root `var.availability_zones` is untouched and still drives AKS node pools and the Postgres primary.

## Verification

- `terraform fmt -check -recursive modules/azure/` clean
- `terraform validate` on `modules/azure/infra` succeeds
- No `availability_zones` references remain anywhere under `modules/networking/`
- `check` block semantics confirmed on Terraform 1.14.6 against a synthetic reproduction: an unknown value at create time yields a "known after apply" warning, and drift with zero planned changes yields the message as a warning with exit code 0

Not verified against a live AKS cluster. The re-zoning claim above comes from the `azurerm` v4.0.0 source and registry docs, not from an apply.

## Context

Supersedes #107, which additionally tried to add zone pinning for Azure Managed Redis. That is not possible: ARM rejects a `zones` array on every live AMR SKU tier. Details in the closing comment on #107. This PR carries only the parts of #107 that were correct.

No overlap with #109 (AMR SKU defaults and Redis HA).
