### PR TITLE
fix(azure): optionally add the service endpoints a BYO AKS subnet needs

### DIFF
--- a/modules/azure/infra/main.tf
+++ b/modules/azure/infra/main.tf
@@ -43,6 +43,19 @@ locals {
   redis_subnet_id    = var.create_vnet ? module.vnet.subnet_redis_id : var.redis_subnet_id
   agic_subnet_id     = var.create_vnet ? module.vnet.subnet_agic_id : ""
 
+  # ── Service endpoints on a bring-your-own AKS subnet ────────────────────────
+  # Both the blob storage and Key Vault firewalls allowlist the AKS subnet by ID,
+  # and Azure rejects a subnet rule whose subnet lacks the matching endpoint.
+  # Terraform puts both on the subnets it creates (see modules/networking), so
+  # this only ever applies to a subnet the operator supplied.
+  required_aks_service_endpoints = ["Microsoft.Storage", "Microsoft.KeyVault"]
+
+  manage_aks_subnet_endpoints = !var.create_vnet && var.aks_subnet_id != "" && var.manage_byo_subnet_service_endpoints
+
+  # The endpoints the supplied subnet already carries, exactly as Azure returned
+  # them, so the patch below can append without disturbing them.
+  byo_aks_subnet_service_endpoints = try(data.azapi_resource.byo_aks_subnet_endpoints[0].output.properties.serviceEndpoints, [])
+
   # ── Common tags ─────────────────────────────────────────────────────────────
   # Applied to every Azure resource in every sub-module.
   # Sub-modules merge their own { module = "..." } tag on top.
@@ -221,6 +234,58 @@ module "blob" {
   allowed_ips        = var.storage_allowed_ips
 
   tags = local.common_tags
+
+  # The subnet rule above is rejected until the endpoint is on the subnet. The ID
+  # is a plain string, so nothing orders these two without saying so.
+  depends_on = [azapi_update_resource.byo_aks_subnet_endpoints]
+}
+
+# ── Service endpoints on a supplied AKS subnet (opt-in) ───────────────────────
+# Reads the subnet's service endpoints in full so the patch below can add the two
+# LangSmith needs without dropping any the network team put there. azurerm_subnet
+# exposes only the service names, not the locations an endpoint can be scoped to,
+# so building the new list from it would quietly reset that scope.
+data "azapi_resource" "byo_aks_subnet_endpoints" {
+  count                  = local.manage_aks_subnet_endpoints ? 1 : 0
+  type                   = "Microsoft.Network/virtualNetworks/subnets@2023-11-01"
+  resource_id            = var.aks_subnet_id
+  response_export_values = ["properties.serviceEndpoints"]
+}
+
+# Adds the endpoints rather than requiring the operator to add them first. azurerm
+# has no standalone service-endpoint resource — service_endpoints is a property of
+# azurerm_subnet — so doing this in azurerm would mean importing the operator's
+# subnet and owning its prefixes, delegations and associations along with it.
+# azapi_update_resource patches the one property and leaves the rest alone.
+#
+# Off by default: this needs write access on a subnet that usually belongs to a
+# network team, and it rewrites the property on every apply, which fights their
+# tooling if they manage it too.
+resource "azapi_update_resource" "byo_aks_subnet_endpoints" {
+  count       = local.manage_aks_subnet_endpoints ? 1 : 0
+  type        = "Microsoft.Network/virtualNetworks/subnets@2023-11-01"
+  resource_id = var.aks_subnet_id
+
+  body = {
+    properties = {
+      # Azure replaces the whole list on write, so the existing entries are passed
+      # back verbatim and only the missing ones appended. Removing an endpoint the
+      # subnet's other workloads depend on would be its own outage.
+      serviceEndpoints = concat(
+        local.byo_aks_subnet_service_endpoints,
+        [
+          for service in local.required_aks_service_endpoints : { service = service }
+          if !contains([for e in local.byo_aks_subnet_service_endpoints : try(e.service, "")], service)
+        ]
+      )
+    }
+  }
+
+  # Azure serializes writes per VNet and fails the loser with
+  # AnotherOperationInProgress. azurerm holds its own lock across the subnets it
+  # creates, but azapi does not share it, so this waits for those instead of
+  # racing them.
+  depends_on = [module.vnet]
 }
 
 # ── Key Vault ─────────────────────────────────────────────────────────────────
@@ -268,7 +333,9 @@ module "keyvault" {
 
   tags = local.common_tags
 
-  depends_on = [module.blob]
+  # module.blob for the managed identity principal ID; the subnet patch for the
+  # same reason the storage account waits on it.
+  depends_on = [module.blob, azapi_update_resource.byo_aks_subnet_endpoints]
 }
 
 # ── Kubernetes Bootstrap ───────────────────────────────────────────────────────

--- a/modules/azure/infra/terraform.tfvars.example
+++ b/modules/azure/infra/terraform.tfvars.example
@@ -178,6 +178,14 @@ sizing_profile = "production"
 # ── Networking (optional — override only if reusing existing VNet) ─────────────
 # create_vnet          = false
 # vnet_id              = "/subscriptions/.../virtualNetworks/my-vnet"
+# An existing AKS subnet must carry the Microsoft.Storage and Microsoft.KeyVault
+# service endpoints — the storage and Key Vault firewalls allowlist it by ID and
+# Azure rejects a subnet rule without the matching endpoint. Add them yourself
+# (az network vnet subnet update --ids <id> --service-endpoints Microsoft.Storage
+# Microsoft.KeyVault, repeating any already there, since the flag replaces the
+# list), or have Terraform add them. Terraform patches only that property, and
+# needs write access on the subnet to do it.
+# manage_byo_subnet_service_endpoints = true
 # aks_subnet_id        = "/subscriptions/.../subnets/aks"
 # postgres_subnet_id   = "/subscriptions/.../subnets/postgres"
 # redis_subnet_id      = "/subscriptions/.../subnets/redis"

--- a/modules/azure/infra/variables.tf
+++ b/modules/azure/infra/variables.tf
@@ -101,8 +101,14 @@ variable "vnet_id" {
 
 variable "aks_subnet_id" {
   type        = string
-  description = "The id of the existing subnet to use for the AKS cluster. If create_vnet is false, this is required."
+  description = "The id of the existing subnet to use for the AKS cluster. If create_vnet is false, this is required. The subnet must carry the Microsoft.Storage and Microsoft.KeyVault service endpoints: the blob storage firewall is always default-deny and allowlists this subnet by ID, and Azure rejects a subnet rule when the matching endpoint is absent. Add them yourself, or set manage_byo_subnet_service_endpoints = true to have Terraform add them."
   default     = ""
+}
+
+variable "manage_byo_subnet_service_endpoints" {
+  type        = bool
+  description = "Add the Microsoft.Storage and Microsoft.KeyVault service endpoints to the subnet given as aks_subnet_id. Terraform patches only that one property and leaves the rest of the subnet — address prefixes, delegations, NSG and route table associations — to whoever owns it. Needs Microsoft.Network/virtualNetworks/subnets/write on the subnet, so leave this false when it belongs to a network team that only granted read, or when their own tooling manages its endpoints and both would rewrite the property on every run."
+  default     = false
 }
 
 variable "postgres_subnet_id" {


### PR DESCRIPTION
## What this fixes

A subnet supplied via `aks_subnet_id` has to carry the `Microsoft.Storage` and `Microsoft.KeyVault` service endpoints. The blob storage firewall is hardcoded default-deny and both it and Key Vault allowlist that subnet by ID ([`main.tf`](../blob/main/modules/azure/infra/main.tf) `allowed_subnet_ids`), and Azure rejects a subnet rule whose subnet lacks the matching endpoint. Terraform adds both to the subnets it creates, so `create_vnet = false` is the only path that hits this, and today it hits it as an opaque Azure error partway through an apply that has already built resources.

`manage_byo_subnet_service_endpoints = true` has Terraform add them.

## Why azapi

`azurerm` has no standalone service-endpoint resource: `service_endpoints` is a property of `azurerm_subnet`. Doing this in `azurerm` would mean importing the operator's subnet and owning its address prefixes, delegations, NSG and route table associations along with it — the wrong ownership boundary, and it would fight their own IaC. `azapi_update_resource` patches the one property and leaves the rest of the subnet alone. `azapi` is already a required provider here (the Redis module uses it for AMR), so this adds no dependency.

## Why off by default

It needs `Microsoft.Network/virtualNetworks/subnets/write` on a subnet that usually belongs to a network team. It also rewrites the property on every apply, so it fights their tooling if they manage the endpoints too. With the flag off, behaviour is unchanged.

## Notes for the reviewer

- The patch body is built from an `azapi` read of the live subnet, so existing entries pass back verbatim with the `locations` scope `azurerm_subnet` doesn't expose, and only missing services are appended. Azure replaces the whole list on write, so dropping an endpoint the subnet's other workloads rely on would be its own outage.
- Reading live also makes the body self-stabilizing: after the apply the read returns the added endpoint, the `contains` guard excludes it, and the next plan is empty rather than perpetually diffing.
- Ordering is explicit in three places, because a subnet ID is a plain string that creates no dependency. `module.blob` and `module.keyvault` wait on the patch before their firewall rules; the patch waits on `module.vnet`, because Azure serializes writes per VNet and `azapi` does not share `azurerm`'s subnet lock.
- `azapi_update_resource` performs no operation on delete (the provider documents this), so the endpoints stay on the subnet after `terraform destroy`. That is deliberate — Terraform owned one property, not the subnet.

## Scope

Deliberately narrow. This does not add a plan-time check that the endpoints are present when the flag is off, and does not touch the quickstart wizard, because both of those exist in #99 and #98 and would conflict on merge. The follow-up that wires the flag into the wizard prompt and the `create_vnet = false` preconditions is on `feat/azure-byo-subnet-service-endpoints` and waits for those PRs.

Also worth knowing: `create_vnet = false` has other gaps on `main` that #99 fixes — `agic_subnet_id` collapses to `""`, the bastion is hard-wired to `module.vnet.subnet_bastion_id`, and the networking module is not gated so a VNet is created regardless. This fixes the endpoint blocker only.

## Verification

- `terraform validate` and `terraform fmt -check` pass
- The endpoint-union expression was checked in `terraform console`: a subnet carrying `Microsoft.Sql` (scoped to two locations) and `Microsoft.Storage` comes back with both untouched and only `Microsoft.KeyVault` appended; a subnet with no endpoints gets both
- Not applied against live Azure — exercising the patch path needs a subnet in a resource group Terraform doesn't own
