### PR TITLE
chore: bring remaining modules and docs to the Terraform 1.11 floor

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Each provider directory is a self-contained deployment with a `Makefile`, an `in
 
 1. **Check out the latest release tag, not `main`** — see [Versioning and releases](#versioning-and-releases) for the one-line command. `main` is the development branch and may move under you.
 2. Pick the provider folder above and read its `README.md`.
-3. Install the prerequisites it lists (Terraform ≥ 1.5, `kubectl`, `helm`, and your cloud CLI).
+3. Install the prerequisites it lists (Terraform ≥ 1.11.0, `kubectl`, `helm`, and your cloud CLI).
 4. Run the interactive wizard (`make quickstart` on AWS; equivalent setup on Azure / GCP).
 5. `make apply` → `make deploy`.
 

--- a/modules/aws/README.md
+++ b/modules/aws/README.md
@@ -39,7 +39,7 @@ A [Makefile](Makefile) wraps all commands — run `make help` to see available t
 brew install awscli
 aws --version
 
-# Terraform (>= 1.5)
+# Terraform (>= 1.11.0)
 brew tap hashicorp/tap && brew install hashicorp/tap/terraform
 terraform version
 

--- a/modules/azure/BUILDING_LIGHT_LANGSMITH.md
+++ b/modules/azure/BUILDING_LIGHT_LANGSMITH.md
@@ -35,7 +35,7 @@ Before starting, verify all of the following:
 ### Tools
 ```bash
 az --version          # Azure CLI — must be installed and logged in
-terraform --version   # >= 1.5
+terraform --version   # >= 1.11.0
 kubectl version       # any recent version
 helm version          # >= 3.x
 python3 --version     # for JSON parsing in scripts

--- a/modules/azure/README.md
+++ b/modules/azure/README.md
@@ -43,7 +43,7 @@ A [Makefile](Makefile) wraps all commands — run `make help` to see available t
 brew install azure-cli
 az --version
 
-# Terraform (>= 1.5)
+# Terraform (>= 1.11.0)
 brew tap hashicorp/tap && brew install hashicorp/tap/terraform
 terraform version
 

--- a/modules/azure/TEST_CYCLE.md
+++ b/modules/azure/TEST_CYCLE.md
@@ -12,7 +12,7 @@ checklist below.
 
 **Tools required** (all must be in PATH):
 - `az` CLI >= 2.50 — authenticated to the target subscription
-- `terraform` v1.5+
+- `terraform` v1.11.0+
 - `kubectl`
 - `helm` v3.12+
 

--- a/modules/azure/infra/versions.tf
+++ b/modules/azure/infra/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.5"
+  required_version = ">= 1.11.0"
 
   required_providers {
     azurerm = {

--- a/modules/byoc/aws/langsmith-byoc-role/README.md
+++ b/modules/byoc/aws/langsmith-byoc-role/README.md
@@ -12,7 +12,7 @@ This module creates two roles:
 ## Prerequisites
 
 1. An AWS account where the LangSmith data plane will live, and AWS credentials with permission to create IAM roles and policies in it.
-2. Terraform `>= 1.5` and the AWS provider `~> 6.0`.
+2. Terraform `>= 1.11.0` and the AWS provider `~> 6.0`.
 3. The `control_plane_reconcile_role_arn` provided by LangChain.
 4. An `external_id` value that you generate and provide to LangChain at data plane creation time. It is used in the trust policy `sts:ExternalId` condition.
 5. For break-glass access, the LangChain engineer Identity Store user IDs and LangChain email addresses provided by LangChain.

--- a/modules/byoc/aws/langsmith-byoc-role/versions.tf
+++ b/modules/byoc/aws/langsmith-byoc-role/versions.tf
@@ -1,4 +1,6 @@
 terraform {
+  required_version = ">= 1.11.0"
+
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/modules/gcp/README.md
+++ b/modules/gcp/README.md
@@ -38,7 +38,7 @@ This directory contains the Terraform configuration to deploy LangSmith on GCP. 
 brew install --cask google-cloud-sdk
 gcloud version
 
-# Terraform (>= 1.5)
+# Terraform (>= 1.11.0)
 brew tap hashicorp/tap && brew install hashicorp/tap/terraform
 terraform version
 

--- a/modules/gcp/TEST_CYCLE.md
+++ b/modules/gcp/TEST_CYCLE.md
@@ -12,7 +12,7 @@ checklist below.
 
 **Tools required** (all must be in PATH):
 - `gcloud` CLI — authenticated to the target project
-- `terraform` v1.5+
+- `terraform` v1.11.0+
 - `kubectl`
 - `helm` v3+
 

--- a/modules/ocp/README.md
+++ b/modules/ocp/README.md
@@ -33,7 +33,7 @@ Pass 3 — LangSmith Deployments (LangGraph Platform)
 - OpenShift 4.12+ or ROSA cluster
 - `oc` CLI authenticated (`oc login`)
 - Helm 3.12+
-- Terraform 1.5+
+- Terraform 1.11.0+
 - Cluster admin role for initial setup
 
 ## Reference

--- a/modules/ocp/infra/main.tf
+++ b/modules/ocp/infra/main.tf
@@ -1,4 +1,6 @@
 terraform {
+  required_version = ">= 1.11.0"
+
   required_providers {
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
## Change

Finishes the Terraform 1.11 floor that `c87398c` started in #70.

That commit raised `aws/infra` and `gcp/infra` to `>= 1.11.0` because the sandbox JuiceFS CSI secret uses write-only arguments (`data_wo` / `data_wo_revision`). Three modules and every doc reference were left behind.

- Three modules: `required_version` in `modules/azure/infra/versions.tf`, `modules/ocp/infra/main.tf`, and `modules/byoc/aws/langsmith-byoc-role/versions.tf`. The last two carried no `required_version` at all, so their READMEs claimed a floor nothing enforced.
- Nine doc references: the prerequisite lines in the root README, the per-cloud READMEs, the Azure and GCP `TEST_CYCLE.md` runbooks, `modules/azure/BUILDING_LIGHT_LANGSMITH.md`, `modules/ocp/README.md`, and the BYOC role module README

All five modules that declare a `terraform` block now read `>= 1.11.0`.

Rebased onto `main` after #118 removed the Terraform app module. The original commit also bumped `modules/{aws,azure,gcp}/app/versions.tf`; those files no longer exist, so the bumps went with them.

## Why 1.11.0 and not a later patch

Write-only arguments landed in Terraform 1.11.0, so that is the version the code actually requires. 1.11.1 and 1.11.2 are bug-fix releases with no language changes, and a higher floor would exclude 1.11.0 and 1.11.1 users without buying anything. It also matches the number already on `main`.

The constraint stays a floor rather than an exact pin, matching how it already worked. These are reusable modules, so `= 1.11.0` would break any consumer on a later release.

## Breaking change

A consumer pinned below 1.11 fails at `terraform init` with a version-constraint error once this lands in a tagged release. Two modules already reject 1.5 as of #70, so the docs are currently wrong for anyone reading them. Worth a line in the release notes for the next tag.

## Follow-up, not in this PR

`modules/azure/infra` pins `kubernetes ~> 2.0`. Write-only support for `kubernetes_secret_v1` (`data_wo`, `binary_data_wo`) arrived in the kubernetes provider 2.36.0, so that constraint permits versions where the argument does not exist. A fresh `terraform init` resolves to a recent 2.x and works, but a consumer with an older lock file gets an "unsupported argument" error. Every other module already pins `~> 2.37`. That bump belongs with the Azure write-only secrets change rather than here.

## Verification

- `terraform fmt -check -recursive` is clean across `modules/`.
- No CI change needed. `.github/workflows/tf_format.yaml` uses `hashicorp/setup-terraform@v2` with no `terraform_version` input, so it already installs a Terraform newer than the floor.
- No `.terraform.lock.hcl` is tracked in the repo and `required_version` constrains the CLI only, so no provider resolution changes.
- Two sets of `1.5` matches are intentionally untouched, since neither is a version constraint: the "Pass 1.5" and "Step 1.5" workflow-stage labels, and the `1.5Gi` memory values in the Helm sizing docs.
