### PR TITLE
docs(aws,gcp): state that sandboxes need the 0.16 module line

### DIFF
--- a/modules/aws/README.md
+++ b/modules/aws/README.md
@@ -4,6 +4,8 @@ Self-hosted LangSmith on Amazon EKS, managed with Terraform.
 
 > **Deploy from a release tag, not `main`.** Check out the latest `v0.15.*` tag before deploying (don't hardcode a patch): `git fetch --tags && git checkout "$(git tag -l 'v0.15.*' --sort=-v:refname | head -1)"`. Tags pin the default LangSmith chart line (`~0.15.1` = latest `0.15.x`). Features with a higher minimum chart line require setting a compatible chart version explicitly. See [Versioning and releases](../../README.md#versioning-and-releases).
 
+> **Sandboxes need the `v0.16.*` module line.** `enable_sandboxes = true` requires LangSmith chart `0.16.0` or newer, and this line pins `~0.15.1`. `deploy.sh` refuses to run unless you name a 0.16 chart explicitly, and doing so pairs a 0.16 chart with values still on the pre-0.16 schema, which is not a supported combination. Deploy sandboxes from a `v0.16.*` tag instead.
+
 ---
 
 ## Overview

--- a/modules/gcp/README.md
+++ b/modules/gcp/README.md
@@ -4,6 +4,8 @@ Self-hosted LangSmith on Google Kubernetes Engine (GKE), managed with Terraform.
 
 > **Deploy from a release tag, not `main`.** Check out the latest `v0.15.*` tag before deploying (don't hardcode a patch): `git fetch --tags && git checkout "$(git tag -l 'v0.15.*' --sort=-v:refname | head -1)"`. Tags pin the default LangSmith chart line (`~0.15.1` = latest `0.15.x`). Features with a higher minimum chart line require setting a compatible chart version explicitly. See [Versioning and releases](../../README.md#versioning-and-releases).
 
+> **Sandboxes need the `v0.16.*` module line.** `enable_sandboxes = true` requires LangSmith chart `0.16.0` or newer, and this line pins `~0.15.1`. `deploy.sh` refuses to run unless you name a 0.16 chart explicitly, and doing so pairs a 0.16 chart with values still on the pre-0.16 schema, which is not a supported combination. Deploy sandboxes from a `v0.16.*` tag instead.
+
 ---
 
 ## Overview


### PR DESCRIPTION
Sandbox support landed on the 0.15 line in #70 and shipped as v0.15.31, but it only works against LangSmith chart 0.16.0 or newer, which this line does not pin. deploy.sh already refuses to run without an explicit 0.16 CHART_VERSION, so the failure is loud, but nothing told a reader why before they got there or what the supported path is.

Naming a 0.16 chart by hand does not rescue it either: the values on this line are still on the pre-0.16 schema, so the chart either rejects config.insights and config.polly outright or, where an existing secret is configured, quietly brings up the Insights and Polly agents with their own databases. Point people at the v0.16.* tags instead.