### PR TITLE
fix(aws): harden teardown cleanup

### DIFF
--- a/modules/aws/Makefile
+++ b/modules/aws/Makefile
@@ -64,6 +64,12 @@ apply: ## terraform apply (infra)
 
 destroy: ## terraform destroy (infra) — run make uninstall first
 	terraform -chdir=$(INFRA_DIR) destroy
+	@echo ""
+	@echo "  ✔ Infrastructure destroyed."
+	@echo ""
+	@echo "  Next step: delete this deployment's SSM secrets."
+	@echo "    make purge-secrets"
+	@echo ""
 
 purge-secrets: ## Delete SSM secrets after Terraform has no managed resources
 	$(INFRA_DIR)/scripts/purge-secrets.sh

--- a/modules/aws/QUICK_REFERENCE.md
+++ b/modules/aws/QUICK_REFERENCE.md
@@ -247,4 +247,9 @@ make destroy-app
 cd infra
 terraform apply
 terraform destroy
+
+# After destroy succeeds, remove cloud secrets explicitly, then local files.
+cd ..
+make purge-secrets
+make clean
 ```

--- a/modules/aws/README.md
+++ b/modules/aws/README.md
@@ -1059,4 +1059,9 @@ make destroy-app
 cd terraform/aws/infra
 terraform apply
 terraform destroy
+
+# After destroy succeeds, remove cloud secrets explicitly, then local files.
+cd ..
+make purge-secrets
+make clean
 ```

--- a/modules/aws/TEARDOWN.md
+++ b/modules/aws/TEARDOWN.md
@@ -365,7 +365,10 @@ aws s3 rb s3://$PREFIX-traces
 
 ## B6 — Delete SSM Parameters
 
-When Terraform state is unavailable, `make purge-secrets` refuses to run. Use this manual fallback only after confirming that the deployment has been removed.
+When Terraform reports no state file and no local state backup exists,
+`make purge-secrets` can remove the parameters after its typed-prefix confirmation.
+Use this manual fallback only when Terraform state cannot be read, and only after
+confirming that the deployment has been removed.
 
 ```bash
 set -euo pipefail

--- a/modules/aws/TEARDOWN.md
+++ b/modules/aws/TEARDOWN.md
@@ -35,7 +35,7 @@ helm list -A
 kubectl get namespaces
 ```
 
-**Data warning:** Teardown permanently deletes the RDS instance, S3 bucket contents, and SSM parameters. Export any data you need to retain before proceeding.
+**Data warning:** Teardown permanently deletes the RDS instance and S3 bucket contents. `make purge-secrets` permanently deletes this deployment's SSM parameters. Export any data you need to retain before proceeding.
 
 ---
 
@@ -213,6 +213,19 @@ aws ec2 describe-vpcs \
 
 ---
 
+## A7 — Purge SSM Parameters and Local Files
+
+After `terraform destroy` succeeds and Terraform state has no managed resources, run this from `modules/aws/`:
+
+```bash
+make purge-secrets
+make clean
+```
+
+`make purge-secrets` displays the exact SSM prefix and region, then asks for confirmation before deletion. Run it only when the state-backed teardown above is complete.
+
+---
+
 # Option B: Teardown Without Terraform State
 
 Use this when Terraform state is lost (deleted, corrupted, or never configured a remote backend). Everything must be deleted manually via AWS CLI in reverse dependency order.
@@ -352,22 +365,57 @@ aws s3 rb s3://$PREFIX-traces
 
 ## B6 — Delete SSM Parameters
 
-```bash
-# List parameters first to confirm
-aws ssm describe-parameters --region $REGION \
-  --parameter-filters "Key=Name,Option=BeginsWith,Values=/langsmith/$PREFIX" \
-  --query 'Parameters[*].Name' --output json
+When Terraform state is unavailable, `make purge-secrets` refuses to run. Use this manual fallback only after confirming that the deployment has been removed.
 
-# Delete all
-aws ssm delete-parameters --region $REGION --names \
-  "/langsmith/$PREFIX/agent-builder-encryption-key" \
-  "/langsmith/$PREFIX/insights-encryption-key" \
-  "/langsmith/$PREFIX/langsmith-admin-password" \
-  "/langsmith/$PREFIX/langsmith-api-key-salt" \
-  "/langsmith/$PREFIX/langsmith-jwt-secret" \
-  "/langsmith/$PREFIX/langsmith-license-key" \
-  "/langsmith/$PREFIX/postgres-password" \
-  "/langsmith/$PREFIX/redis-auth-token"
+```bash
+set -euo pipefail
+
+SSM_PREFIX="/langsmith/$PREFIX"
+if ! SSM_PARAMS=$(aws ssm get-parameters-by-path \
+  --region "$REGION" \
+  --path "$SSM_PREFIX/" \
+  --recursive \
+  --query 'Parameters[].Name' \
+  --output text); then
+  echo "Could not list SSM parameters under $SSM_PREFIX/" >&2
+  exit 1
+fi
+
+if [ -z "$SSM_PARAMS" ] || [ "$SSM_PARAMS" = "None" ]; then
+  echo "No SSM parameters found under $SSM_PREFIX/"
+  exit 0
+fi
+
+# AWS CLI text output can contain tabs and newlines across pages.
+PARAMETER_NAMES=()
+while IFS= read -r name; do
+  [ -n "$name" ] && PARAMETER_NAMES+=("$name")
+done < <(printf '%s\n' "$SSM_PARAMS" | tr '\t' '\n')
+
+echo "This permanently deletes ${#PARAMETER_NAMES[@]} SSM parameter(s)."
+printf "Type '%s/' in region '%s' to continue: " "$SSM_PREFIX" "$REGION"
+read -r CONFIRM
+if [ "$CONFIRM" != "$SSM_PREFIX/" ]; then
+  echo "Aborted."
+  exit 0
+fi
+
+# SSM accepts at most 10 names per delete-parameters call.
+for ((i=0; i<${#PARAMETER_NAMES[@]}; i+=10)); do
+  BATCH=("${PARAMETER_NAMES[@]:i:10}")
+  if ! INVALID_COUNT=$(aws ssm delete-parameters \
+    --region "$REGION" \
+    --names "${BATCH[@]}" \
+    --query 'length(InvalidParameters)' \
+    --output text); then
+    echo "SSM deletion failed for batch starting at parameter $i." >&2
+    exit 1
+  fi
+  if [ "$INVALID_COUNT" != "0" ]; then
+    echo "SSM reported $INVALID_COUNT invalid parameter(s); cleanup is incomplete." >&2
+    exit 1
+  fi
+done
 ```
 
 ## B7 — Delete ALBs and Target Groups

--- a/modules/aws/TEST_CYCLE.md
+++ b/modules/aws/TEST_CYCLE.md
@@ -323,6 +323,10 @@ helm uninstall cert-manager -n cert-manager 2>/dev/null || true
 
 # 2. Destroy all infrastructure
 terraform -chdir=infra destroy
+
+# 3. After destroy succeeds, remove cloud secrets, then local files.
+make purge-secrets
+make clean
 ```
 
 **Before destroy, verify:**

--- a/modules/aws/helm/scripts/uninstall.sh
+++ b/modules/aws/helm/scripts/uninstall.sh
@@ -23,6 +23,7 @@ NAMESPACE="${NAMESPACE:-langsmith}"
 # ── Resolve config from terraform.tfvars ──────────────────────────────────────
 if [[ ! -f "$INFRA_DIR/terraform.tfvars" ]]; then
   echo "ERROR: terraform.tfvars not found at $INFRA_DIR/terraform.tfvars" >&2
+  echo "       Cannot safely identify a deployment to uninstall." >&2
   exit 1
 fi
 
@@ -44,16 +45,32 @@ echo ""
 
 # ── Get cluster name from Terraform output ────────────────────────────────────
 echo "Reading cluster name from Terraform output..."
-_cluster_name=$(terraform -chdir="$INFRA_DIR" output -raw cluster_name 2>/dev/null) || {
-  echo "ERROR: Could not read cluster_name. Is 'terraform apply' complete?" >&2
+_state_output=""
+if ! _cluster_name=$(terraform -chdir="$INFRA_DIR" output -raw cluster_name 2>/dev/null); then
+  if _state_output=$(_terraform -chdir="$INFRA_DIR" state list 2>&1) && [[ -z "${_state_output//[$' \t\r\n']/}" ]]; then
+    skip "Terraform state is empty; uninstall is already complete."
+    exit 0
+  fi
+  echo "ERROR: Could not read cluster_name from Terraform state." >&2
+  printf "       %s\n" "$_state_output" >&2
   exit 1
-}
+fi
 echo "  cluster_name = $_cluster_name"
 echo ""
 
 # ── Point kubeconfig at the right cluster ─────────────────────────────────────
+if ! _cluster_status=$(_aws eks describe-cluster --name "$_cluster_name" --region "$_region" --query 'cluster.status' --output text 2>&1); then
+  if [[ "$_cluster_status" == *"ResourceNotFoundException"* ]]; then
+    skip "EKS cluster '$_cluster_name' no longer exists; uninstall is already complete."
+    exit 0
+  fi
+  fail "Could not verify EKS cluster '$_cluster_name'."
+  printf "  %s\n" "$_cluster_status" >&2
+  exit 1
+fi
+
 echo "Updating kubeconfig for cluster: $_cluster_name..."
-aws eks update-kubeconfig --name "$_cluster_name" --region "$_region"
+_aws eks update-kubeconfig --name "$_cluster_name" --region "$_region"
 echo "  Active context: $(kubectl config current-context)"
 echo ""
 
@@ -72,7 +89,13 @@ fi
 echo ""
 
 # ── Uninstall Helm release ────────────────────────────────────────────────────
-if helm list -n "$NAMESPACE" --filter "^${RELEASE_NAME}$" --output json 2>/dev/null | grep -q '"name"'; then
+if ! _helm_releases=$(_helm list -n "$NAMESPACE" --filter "^${RELEASE_NAME}$" --output json 2>&1); then
+  fail "Could not list Helm releases in namespace '$NAMESPACE'."
+  printf "  %s\n" "$_helm_releases" >&2
+  exit 1
+fi
+
+if grep -q '"name"' <<<"$_helm_releases"; then
   echo "Uninstalling Helm release '$RELEASE_NAME'..."
   helm uninstall "$RELEASE_NAME" -n "$NAMESPACE"
 else
@@ -97,7 +120,10 @@ kubectl delete deployments,services,pods,jobs,statefulsets,replicasets \
 # Operator-spawned agent deployment pods use a different label pattern
 kubectl delete deployments,pods \
   -l "langsmith.dev/managed-by=operator" \
-  -n "$NAMESPACE" --ignore-not-found 2>/dev/null || true
+  -n "$NAMESPACE" --ignore-not-found
 echo ""
 
 echo "Uninstall complete."
+echo ""
+echo "Next step: destroy this deployment's infrastructure."
+echo "  make destroy"

--- a/modules/aws/infra/scripts/clean.sh
+++ b/modules/aws/infra/scripts/clean.sh
@@ -30,6 +30,16 @@ HELM_VALUES_DIR="$AWS_DIR/helm/values"
 
 source "$SCRIPT_DIR/_common.sh"
 
+_local_state_backups=()
+
+_collect_local_state_backups() {
+  _local_state_backups=()
+  local _backup
+  for _backup in "$INFRA_DIR/terraform.tfstate.backup" "$INFRA_DIR"/terraform.tfstate.*.backup; do
+    [[ -f "$_backup" ]] && _local_state_backups+=("$_backup")
+  done
+}
+
 _has_local_artifacts() {
   [[ -f "$INFRA_DIR/terraform.tfvars" ]] && return 0
   [[ -f "$INFRA_DIR/terraform.tfstate" ]] && return 0
@@ -68,10 +78,15 @@ if [[ ! -f "$INFRA_DIR/terraform.tfvars" ]]; then
   exit 1
 fi
 
+_backup_confirmation_required=false
 if ! _state_output=$(_terraform -chdir="$INFRA_DIR" state list 2>&1); then
   # A local backend with no state file has no resources to protect. Terraform
   # reports it as an error, unlike an initialized empty or remote state.
   if [[ "$_state_output" == *"No state file was found"* ]]; then
+    _collect_local_state_backups
+    if (( ${#_local_state_backups[@]} > 0 )); then
+      _backup_confirmation_required=true
+    fi
     _state_output=""
   else
     fail "Could not read Terraform state; refusing to remove local configuration."
@@ -104,6 +119,16 @@ fi
 if [[ -n "$_ssm_params" && "$_ssm_params" != "None" ]]; then
   fail "SSM parameters remain under ${SSM_PREFIX}/; run 'make purge-secrets' first."
   exit 1
+fi
+
+if [[ "$_backup_confirmation_required" == true ]]; then
+  warn "Terraform state is missing, but local state backup(s) remain:"
+  printf "  %s\n" "${_local_state_backups[@]#$AWS_DIR/}"
+  warn "Deleting them removes the only local recovery record for this deployment."
+  printf "  Type DELETE BACKUPS to continue: "
+  read -r _backup_confirm
+  [[ "$_backup_confirm" == "DELETE BACKUPS" ]] || { echo "  Aborted."; exit 0; }
+  echo ""
 fi
 
 printf "  Continue? [y/N] "

--- a/modules/aws/infra/scripts/clean.sh
+++ b/modules/aws/infra/scripts/clean.sh
@@ -30,33 +30,80 @@ HELM_VALUES_DIR="$AWS_DIR/helm/values"
 
 source "$SCRIPT_DIR/_common.sh"
 
+_has_local_artifacts() {
+  [[ -f "$INFRA_DIR/terraform.tfvars" ]] && return 0
+  [[ -f "$INFRA_DIR/terraform.tfstate" ]] && return 0
+  [[ -f "$INFRA_DIR/terraform.tfstate.backup" ]] && return 0
+
+  for f in "$INFRA_DIR"/terraform.tfstate.*.backup "$HELM_VALUES_DIR"/langsmith-values*.yaml; do
+    [[ -f "$f" ]] && return 0
+  done
+
+  [[ -d "$INFRA_DIR/logs" ]] && find "$INFRA_DIR/logs" -mindepth 1 -maxdepth 1 -print -quit | grep -q . && return 0
+  return 1
+}
+
+_managed_state_resources() {
+  printf '%s\n' "$1" \
+    | grep -E '^[[:alnum:]_-]+(\[[^]]+\])?(\.[[:alnum:]_-]+(\[[^]]+\])?)+' \
+    | grep -vE '(^|\.)data\.' || true
+}
+
 echo ""
 echo "══════════════════════════════════════════════════════"
 echo "  LangSmith AWS — Clean local files"
 echo "══════════════════════════════════════════════════════"
 echo ""
 warn "This removes local generated files only; it does not delete AWS resources or SSM parameters."
-warn "Run AFTER: make uninstall && make destroy && make purge-secrets"
-info "To delete SSM parameters after Terraform has no managed resources, run: make purge-secrets"
+info "It removes terraform.tfvars, local Terraform state/backups, logs, and generated Helm values."
 echo ""
 
-# Guard: if tfstate exists with tracked resources, abort unless forced.
-if [[ -f "$INFRA_DIR/terraform.tfstate" ]]; then
-  _state_resources=$(grep -c '"type":' "$INFRA_DIR/terraform.tfstate" 2>/dev/null || true)
-  if [[ "$_state_resources" -gt 0 ]]; then
-    echo ""
-    fail "terraform.tfstate exists with ${_state_resources} tracked resource(s)."
-    warn "Run 'terraform destroy' BEFORE 'make clean' — otherwise Terraform loses track"
-    warn "of your AWS resources and you'll have to delete them manually."
-    warn "  make uninstall                     # remove Helm release first"
-    warn "  cd infra && terraform destroy      # terraform destroy"
-    warn "  make clean                         # then clean local files"
-    echo ""
-    printf "  Force clean anyway? [y/N] "
-    read -r _force
-    [[ "$_force" =~ ^[Yy]$ ]] || { echo "  Aborted."; exit 0; }
-    echo ""
+if ! _has_local_artifacts; then
+  skip "No local generated files to clean. Cleanup skipped."
+  exit 0
+fi
+
+if [[ ! -f "$INFRA_DIR/terraform.tfvars" ]]; then
+  fail "terraform.tfvars not found; cannot verify Terraform and SSM cleanup."
+  exit 1
+fi
+
+if ! _state_output=$(_terraform -chdir="$INFRA_DIR" state list 2>&1); then
+  # A local backend with no state file has no resources to protect. Terraform
+  # reports it as an error, unlike an initialized empty or remote state.
+  if [[ "$_state_output" == *"No state file was found"* ]]; then
+    _state_output=""
+  else
+    fail "Could not read Terraform state; refusing to remove local configuration."
+    printf "  %s\n" "$_state_output" >&2
+    exit 1
   fi
+fi
+
+_state_resources=$(_managed_state_resources "$_state_output")
+if [[ -n "${_state_resources//[$' \t\r\n']/}" ]]; then
+  fail "Terraform state still tracks managed resources; refusing to clean."
+  printf "  %s\n" "$_state_resources" >&2
+  exit 1
+fi
+
+_name_prefix=$(_parse_tfvar "name_prefix") || _name_prefix=""
+_environment=$(_parse_tfvar "environment") || _environment=""
+_region=$(_parse_tfvar "region") || _region=""
+if [[ -z "$_name_prefix" || -z "$_environment" || -z "$_region" ]]; then
+  fail "name_prefix, environment, and region are required to verify SSM cleanup."
+  exit 1
+fi
+
+SSM_PREFIX="/langsmith/${_name_prefix}-${_environment}"
+if ! _ssm_params=$(_aws ssm get-parameters-by-path --region "$_region" --path "${SSM_PREFIX}/" --recursive --query 'Parameters[].Name' --output text 2>&1); then
+  fail "Could not verify SSM cleanup; refusing to remove local configuration."
+  printf "  %s\n" "$_ssm_params" >&2
+  exit 1
+fi
+if [[ -n "$_ssm_params" && "$_ssm_params" != "None" ]]; then
+  fail "SSM parameters remain under ${SSM_PREFIX}/; run 'make purge-secrets' first."
+  exit 1
 fi
 
 printf "  Continue? [y/N] "

--- a/modules/aws/infra/scripts/purge-secrets.sh
+++ b/modules/aws/infra/scripts/purge-secrets.sh
@@ -33,6 +33,15 @@ _managed_state_resources() {
     | grep -vE '(^|\.)data\.' || true
 }
 
+_has_local_state_backups() {
+  local _backup
+  [[ -f "$INFRA_DIR/terraform.tfstate.backup" ]] && return 0
+  for _backup in "$INFRA_DIR"/terraform.tfstate.*.backup; do
+    [[ -f "$_backup" ]] && return 0
+  done
+  return 1
+}
+
 SSM_PREFIX="/langsmith/${_name_prefix}-${_environment}"
 
 echo ""
@@ -41,9 +50,13 @@ info "SSM prefix: ${SSM_PREFIX}/"
 info "AWS region: $_region"
 
 if ! _state_output=$(_terraform -chdir="$INFRA_DIR" state list 2>&1); then
-  fail "Could not read Terraform state; refusing to delete SSM parameters."
-  printf "  %s\n" "$_state_output" >&2
-  exit 1
+  if [[ "$_state_output" == *"No state file was found"* ]] && ! _has_local_state_backups; then
+    _state_output=""
+  else
+    fail "Could not read Terraform state; refusing to delete SSM parameters."
+    printf "  %s\n" "$_state_output" >&2
+    exit 1
+  fi
 fi
 
 _state_resources=$(_managed_state_resources "$_state_output")

--- a/modules/aws/infra/scripts/purge-secrets.sh
+++ b/modules/aws/infra/scripts/purge-secrets.sh
@@ -17,6 +17,11 @@ _name_prefix=$(_parse_tfvar "name_prefix") || _name_prefix=""
 _environment=$(_parse_tfvar "environment") || _environment=""
 _region=$(_parse_tfvar "region") || _region=""
 
+if [[ ! -f "$INFRA_DIR/terraform.tfvars" ]]; then
+  fail "terraform.tfvars not found; cannot safely identify an SSM prefix to purge."
+  exit 1
+fi
+
 if [[ -z "$_name_prefix" || -z "$_environment" || -z "$_region" ]]; then
   fail "name_prefix, environment, and region are required in $INFRA_DIR/terraform.tfvars."
   exit 1
@@ -61,6 +66,9 @@ fi
 
 if [[ -z "$_ssm_params" || "$_ssm_params" == "None" ]]; then
   skip "No SSM parameters found under ${SSM_PREFIX}/"
+  echo ""
+  info "Next step: remove local generated files."
+  info "  make clean"
   exit 0
 fi
 
@@ -71,7 +79,12 @@ done < <(printf '%s\n' "$_ssm_params" | tr '\t' '\n')
 _ssm_count=${#_ssm_array[@]}
 
 warn "This permanently deletes $_ssm_count SSM parameter(s)."
-printf "  Type '%s/' in region '%s' to continue: " "$SSM_PREFIX" "$_region"
+echo ""
+info "Target:"
+printf "  Prefix: %s/\n" "$SSM_PREFIX"
+printf "  Region: %s\n" "$_region"
+echo ""
+printf "  Type the prefix shown above to confirm:\n  > "
 read -r _confirm
 if [[ "$_confirm" != "${SSM_PREFIX}/" ]]; then
   echo "  Aborted."
@@ -96,3 +109,6 @@ for (( _i=0; _i<_ssm_count; _i+=10 )); do
 done
 
 pass "Deleted $_ssm_count SSM parameter(s) under ${SSM_PREFIX}/ in $_region."
+echo ""
+info "Next step: remove local generated files."
+info "  make clean"


### PR DESCRIPTION
## What this PR changes

This PR makes the AWS teardown flow safer, clearer, and easier to complete.

### 1. Documents the full teardown order

The documentation now shows the required order:

1. `make uninstall`
2. `make destroy`
3. `make purge-secrets`
4. `make clean`

It explains that SSM parameters are deleted separately from Terraform resources. It also provides a safer manual fallback when Terraform state cannot be read.

### 2. Makes uninstall safe to rerun

`make uninstall` now:

- Stops when it cannot safely identify the deployment.
- Skips cleanly when Terraform state is already empty.
- Skips cleanly when the EKS cluster no longer exists.
- Reports real AWS and Helm errors instead of hiding them.
- Does not ignore failures while removing operator-managed resources.

### 3. Guides users through teardown

After a successful uninstall, destroy, or SSM purge, the command shows the next teardown step. This helps users complete the cleanup in the right order.

### 4. Protects cleanup from deleting live deployment information

`make clean` now checks Terraform’s configured state, including remote state, before deleting generated files.

It refuses cleanup when:

- Terraform still tracks deployed resources.
- Terraform state cannot be read.
- SSM parameters for the deployment still exist.

It exits early when there is nothing local to remove.

### 5. Handles cancelled setup safely

Users can now stop before the first Terraform deployment:

- If Terraform has not created state and no local backup exists, `make clean` can remove the generated configuration.
- If `setup-env.sh` created SSM parameters first, `make purge-secrets` can remove them after the existing typed-prefix confirmation.
- If the main local state file is missing but backups remain, `make clean` shows those backups and requires the user to type `DELETE BACKUPS` before removing them.

This prevents accidental loss of the only local recovery record while still letting users intentionally remove it.

## Validation

- Shell syntax checks passed for changed scripts.
- `git diff --check` passed.
- Terraform validation requires `terraform init`; modules are not installed in this checkout.