### PR TITLE
fix(gcp): add missing fleet.apiServer/fleet.queue resource blocks

### DIFF
--- a/modules/gcp/helm/values/examples/langsmith-values-fleet.yaml
+++ b/modules/gcp/helm/values/examples/langsmith-values-fleet.yaml
@@ -43,3 +43,32 @@ fleet:
       # Secret created by Terraform (infra/main.tf: kubernetes_secret.fleet_redis).
       # Contains key: redis_connection_url = redis://<host>:<port>
       existingSecretName: "langsmith-fleet-redis"
+
+  # Explicit resources — a strict ResourceQuota (regulated/production namespaces)
+  # rejects any pod that doesn't specify cpu/memory requests and limits. The
+  # chart defaults these standalone blocks to {}.
+  apiServer:
+    deployment:
+      resources:
+        requests:
+          cpu: "500m"
+          memory: 1Gi
+        limits:
+          cpu: "2"
+          memory: 4Gi
+    autoscaling:
+      enabled: true
+      minReplicas: 1
+      maxReplicas: 5
+      targetCPUUtilizationPercentage: 70
+
+  queue:
+    enabled: true
+    deployment:
+      resources:
+        requests:
+          cpu: "500m"
+          memory: 1Gi
+        limits:
+          cpu: "2"
+          memory: 4Gi


### PR DESCRIPTION
## Summary
- GCP's standalone Fleet reference template (`langsmith-values-fleet.yaml`) was missing `fleet.apiServer` and `fleet.queue` entirely — no resources, no autoscaling, no `enabled` flag for queue — while AWS's equivalent template already has them.
- Chart 0.15.1 defaults these standalone blocks to `{}` when unset; the `langsmith-quota` ResourceQuota (present in regulated/production namespaces) rejects any pod without explicit `requests`/`limits`, so this silently blocks Fleet's `apiServer`/`queue` pods from ever being admitted.
- Brings GCP's template to parity with AWS's for these two blocks (same structure, same values).

## Test plan
- [x] Confirmed via `git grep` that no other tracked GCP values file already defines `fleet.apiServer`/`fleet.queue` — no redundancy/conflicting source of truth introduced.
- [x] Confirmed indentation nests correctly under the existing `fleet:` block (sibling to `postgres`/`redis`), not as new top-level keys.
- [ ] Validate via `helm template` with `enable_fleet=true` that both blocks render into the expected Deployment/HPA manifests before merging.