### PR TITLE
fix(gcp): fleet-tool-server CrashLoopBackOff — bump CPU limit and relax startup probe across all sizing profiles

### DIFF
--- a/modules/gcp/helm/values/examples/langsmith-values-sizing-dev.yaml
+++ b/modules/gcp/helm/values/examples/langsmith-values-sizing-dev.yaml
@@ -146,11 +146,18 @@ fleetToolServer:
     replicas: 1
     resources:
       requests:
-        cpu: "100m"
-        memory: "256Mi"
+        cpu: "1"
+        memory: "1Gi"
       limits:
-        cpu: "500m"
-        memory: "512Mi"
+        cpu: "2500m"
+        memory: "3Gi"
+    startupProbe:
+      httpGet:
+        path: /health
+        port: 1989
+      failureThreshold: 30
+      periodSeconds: 5
+      timeoutSeconds: 5
 
 fleetTriggerServer:
   deployment:

--- a/modules/gcp/helm/values/examples/langsmith-values-sizing-minimum.yaml
+++ b/modules/gcp/helm/values/examples/langsmith-values-sizing-minimum.yaml
@@ -139,11 +139,18 @@ fleetToolServer:
     replicas: 1
     resources:
       requests:
-        cpu: "100m"
+        cpu: "1"
         memory: "1Gi"
       limits:
-        cpu: "1"
-        memory: "2Gi"
+        cpu: "2500m"
+        memory: "3Gi"
+    startupProbe:
+      httpGet:
+        path: /health
+        port: 1989
+      failureThreshold: 30
+      periodSeconds: 5
+      timeoutSeconds: 5
 
 fleetTriggerServer:
   deployment:

--- a/modules/gcp/helm/values/examples/langsmith-values-sizing-production-large.yaml
+++ b/modules/gcp/helm/values/examples/langsmith-values-sizing-production-large.yaml
@@ -188,11 +188,18 @@ fleetToolServer:
   deployment:
     resources:
       requests:
-        cpu: "500m"
+        cpu: "1"
         memory: "1Gi"
       limits:
-        cpu: "2"
-        memory: "4Gi"
+        cpu: "2500m"
+        memory: "3Gi"
+    startupProbe:
+      httpGet:
+        path: /health
+        port: 1989
+      failureThreshold: 30
+      periodSeconds: 5
+      timeoutSeconds: 5
 
 fleetTriggerServer:
   deployment:

--- a/modules/gcp/helm/values/examples/langsmith-values-sizing-production.yaml
+++ b/modules/gcp/helm/values/examples/langsmith-values-sizing-production.yaml
@@ -185,11 +185,18 @@ fleetToolServer:
   deployment:
     resources:
       requests:
-        cpu: "500m"
+        cpu: "1"
         memory: "1Gi"
       limits:
-        cpu: "1"
-        memory: "2Gi"
+        cpu: "2500m"
+        memory: "3Gi"
+    startupProbe:
+      httpGet:
+        path: /health
+        port: 1989
+      failureThreshold: 30
+      periodSeconds: 5
+      timeoutSeconds: 5
 
 fleetTriggerServer:
   deployment:


### PR DESCRIPTION
## Summary
- `fleetToolServer`'s CPU limit was at or below the threshold that causes a startup crash loop in 3 of 4 sizing profiles (`dev`: `500m`, `minimum`/`production`: `1`). The Fleet tool-server image is CPU-intensive during startup while it syncs with `standalone-fleet-api-server` via `LANGGRAPH_DEPLOYMENT_URL`; at a limit of `1` CPU or below, throttling prevents the process from binding its port before the startup probe's deadline, causing `CrashLoopBackOff`.
- None of the four sizing profiles had a `startupProbe` override, relying on the chart's default timing, which is too tight for this component's startup behavior.
- The required CPU limit does not scale down with profile size — all four profiles use the same `fleetToolServer` values below.

## Changes
`fleetToolServer.deployment.resources` and `startupProbe` updated in:
- `langsmith-values-sizing-dev.yaml`
- `langsmith-values-sizing-minimum.yaml`
- `langsmith-values-sizing-production.yaml`
- `langsmith-values-sizing-production-large.yaml`

Each file: `requests: {cpu: "1", memory: "1Gi"}`, `limits: {cpu: "2500m", memory: "3Gi"}`, plus a `startupProbe` (`httpGet: /health:1989`, `failureThreshold: 30`, `periodSeconds: 5`, `timeoutSeconds: 5`).

`fleetTriggerServer` is unchanged in all four files — this fix is specific to `fleetToolServer`.

## Test plan
- [x] Verified no conflicting resource definition for `fleetToolServer` in `langsmith-values-fleet.yaml` (see #126) — single source of truth maintained.
- [ ] Validate via `helm template` for each `sizing_profile` value that resources and probe render as expected.
- [ ] Confirm stable pod restarts across a full deploy cycle per profile.