### PR TITLE
Add AWS QuickStart support for Sandboxes

### DIFF
--- a/modules/aws/helm/scripts/deploy.sh
+++ b/modules/aws/helm/scripts/deploy.sh
@@ -60,8 +60,7 @@ _validate_sandbox_values_file() {
 
   if ! grep -Eq '^sandboxes:[[:space:]]*$' "$values_file" \
     || ! grep -Eq '^[[:space:]]{2}enabled:[[:space:]]*true[[:space:]]*$' "$values_file" \
-    || ! grep -Eq '^[[:space:]]{6}existingSecretName:[[:space:]]*"?[^"]+"?[[:space:]]*$' "$values_file" \
-    || ! grep -Eq '^[[:space:]]{2}sandboxHostImage:[[:space:]]*$' "$values_file"; then
+    || ! grep -Eq '^[[:space:]]{6}existingSecretName:[[:space:]]*"?[^"]+"?[[:space:]]*$' "$values_file"; then
     echo "ERROR: enable_sandboxes = true, but $(basename "$values_file") does not contain generated sandbox values." >&2
     echo "       Run: make init-values  (or: ./helm/scripts/init-values.sh) after applying infra." >&2
     exit 1
@@ -481,12 +480,21 @@ _helm_timeout="${HELM_TIMEOUT:-30m}"
 # Instead, we do our own readiness check below.
 # Resolve the pin to a concrete version and print it. Without this the only place
 # the installed version shows up is `helm list`, after the release is already out.
-_resolved_chart=$(helm show chart langchain/langsmith --version "$CHART_VERSION" ${_devel_flag:-} 2>/dev/null \
-  | awk '/^version:/{print $2}') || _resolved_chart=""
+_chart_metadata=$(helm show chart langchain/langsmith --version "$CHART_VERSION" ${_devel_flag:-} 2>/dev/null) || _chart_metadata=""
+_resolved_chart=$(awk '/^version:/{print $2}' <<<"$_chart_metadata")
 echo "Chart: langchain/langsmith  requested=${CHART_VERSION}  resolved=${_resolved_chart:-UNRESOLVED}"
 if [[ -z "$_resolved_chart" ]]; then
   echo "ERROR: no chart matches '$CHART_VERSION' in the langchain repo." >&2
   exit 1
+fi
+if [[ "$_enable_sandboxes" == "true" ]]; then
+  _sandbox_host_image_tag=$(awk '/^appVersion:/{print $2}' <<<"$_chart_metadata")
+  if [[ -z "$_sandbox_host_image_tag" ]]; then
+    echo "ERROR: chart $_resolved_chart does not declare an appVersion for the Sandbox image." >&2
+    exit 1
+  fi
+  VALUES_ARGS+=(--set-string "images.sandboxHostImage.tag=$_sandbox_host_image_tag")
+  echo "Sandboxes: sandbox-host image tag=$_sandbox_host_image_tag"
 fi
 
 helm upgrade --install "$RELEASE_NAME" langchain/langsmith \

--- a/modules/aws/helm/scripts/init-values.sh
+++ b/modules/aws/helm/scripts/init-values.sh
@@ -242,13 +242,8 @@ _tfvar_is_true "enable_standalone_polly"    && _enable_standalone_polly=true
 _tfvar_is_true "enable_standalone_insights" && _enable_standalone_insights=true
 _tfvar_is_true "enable_sandboxes"           && _enable_sandboxes=true
 
-_sandbox_host_image_tag=$(_parse_tfvar "sandbox_host_image_tag") || _sandbox_host_image_tag=""
 _sandbox_service_url_base_url=$(_parse_tfvar "sandbox_service_url_base_url") || _sandbox_service_url_base_url=""
 if [[ "$_enable_sandboxes" == "true" ]]; then
-  if [[ -z "$_sandbox_host_image_tag" ]]; then
-    echo "ERROR: sandbox_host_image_tag is required when enable_sandboxes = true." >&2
-    exit 1
-  fi
   SANDBOX_JUICEFS_CSI_CONFIG_SECRET_NAME=$(terraform -chdir="$INFRA_DIR" output -raw sandbox_juicefs_csi_config_secret_name 2>/dev/null) || SANDBOX_JUICEFS_CSI_CONFIG_SECRET_NAME="juicefs-csi-config"
 fi
 
@@ -683,7 +678,6 @@ insights:
 fi
 
 _sandbox_config_block=""
-_sandbox_top_level_block=""
 if [[ "$_enable_sandboxes" == "true" ]]; then
   _sandbox_service_url_block=""
   if [[ -n "$_sandbox_service_url_base_url" ]]; then
@@ -704,10 +698,6 @@ sandboxes:
     deployment:
       nodeSelector:
         sandbox.langsmith.com/host: \"true\""
-  _sandbox_top_level_block="
-images:
-  sandboxHostImage:
-    tag: \"${_sandbox_host_image_tag}\""
 fi
 
 # ── Write langsmith-values-overrides.yaml ─────────────────────────────────────
@@ -799,7 +789,6 @@ operator:
 ${_routing_block}
 ${_external_services_block}
 ${_standalone_block}
-${_sandbox_top_level_block}
 YAML
 
 echo "Written: $OUT_FILE"

--- a/modules/aws/infra/scripts/quickstart.sh
+++ b/modules/aws/infra/scripts/quickstart.sh
@@ -57,6 +57,12 @@ _ask_yn() {
   [[ "$_REPLY" =~ ^[Yy] ]]
 }
 
+_feature_prompt() {
+  local prompt="$1" enabled="$2"
+  local state="disabled"; [[ "$enabled" == "true" ]] && state="enabled"
+  printf '%s [%s]' "$prompt" "$state"
+}
+
 _ask_choice() {
   # Usage: _ask_choice [--default N] "prompt" "opt1" "opt2" ...
   local default=""
@@ -639,26 +645,37 @@ _ex_deploys=$(_existing "enable_deployments" "false")
 _ex_ab=$(_existing "enable_agent_builder" "false")
 _ex_insights=$(_existing "enable_insights" "false")
 _ex_polly=$(_existing "enable_polly" "false")
+_ex_sandboxes=$(_existing "enable_sandboxes" "false")
 
 ENABLE_DEPLOYMENTS="false"; ENABLE_AGENT_BUILDER="false"
 ENABLE_INSIGHTS="false"; ENABLE_POLLY="false"
+ENABLE_SANDBOXES="false"
 
-_ask_yn "Enable LangGraph Platform Deployments (listener + operator + host-backend)?" \
+_ask_yn "$(_feature_prompt "Enable LangGraph Platform Deployments (listener + operator + host-backend)?" "$_ex_deploys")" \
   "$([[ "$_ex_deploys" == "true" ]] && echo "y" || echo "n")" \
   && ENABLE_DEPLOYMENTS="true" || ENABLE_DEPLOYMENTS="false"
 
 if [[ "$ENABLE_DEPLOYMENTS" == "true" ]]; then
-  _ask_yn "  ↳ Enable Agent Builder (visual agent UI, requires Deployments)?" \
+  _ask_yn "$(_feature_prompt "  ↳ Enable Agent Builder (visual agent UI, requires Deployments)?" "$_ex_ab")" \
     "$([[ "$_ex_ab" == "true" ]] && echo "y" || echo "n")" \
     && ENABLE_AGENT_BUILDER="true" || ENABLE_AGENT_BUILDER="false"
-  _ask_yn "  ↳ Enable Polly (AI-powered eval, requires Deployments)?" \
+  _ask_yn "$(_feature_prompt "  ↳ Enable Polly (AI-powered eval, requires Deployments)?" "$_ex_polly")" \
     "$([[ "$_ex_polly" == "true" ]] && echo "y" || echo "n")" \
     && ENABLE_POLLY="true" || ENABLE_POLLY="false"
 fi
 
-_ask_yn "Enable Insights (ClickHouse analytics dashboard)?" \
+_ask_yn "$(_feature_prompt "Enable Insights (ClickHouse analytics dashboard)?" "$_ex_insights")" \
   "$([[ "$_ex_insights" == "true" ]] && echo "y" || echo "n")" \
   && ENABLE_INSIGHTS="true" || ENABLE_INSIGHTS="false"
+
+echo ""
+printf "  ${DIM}Sandboxes run untrusted code on dedicated EC2 nodes and create a dedicated${RESET}\n"
+printf "  ${DIM}external Redis instance for JuiceFS metadata. They also require a Linux${RESET}\n"
+printf "  ${DIM}KVM-compatible host. The matching Sandbox image is selected during deployment.${RESET}\n"
+if _ask_yn "$(_feature_prompt "Enable LangSmith Sandboxes?" "$_ex_sandboxes")" \
+  "$([[ "$_ex_sandboxes" == "true" ]] && echo "y" || echo "n")"; then
+  ENABLE_SANDBOXES="true"
+fi
 
 # ═══════════════════════════════════════════════════════════════════════════
 # Write terraform.tfvars
@@ -873,6 +890,12 @@ enable_insights      = ${ENABLE_INSIGHTS}
 enable_polly         = ${ENABLE_POLLY}
 TFVARS
 
+if [[ "$ENABLE_SANDBOXES" == "true" ]]; then
+  cat >> "$OUTPUT" << TFVARS
+enable_sandboxes = true
+TFVARS
+fi
+
 # Security add-ons
 HAS_SECURITY=false; SECURITY_BLOCK=""
 [[ "${ALB_SCHEME:-internet-facing}" != "internet-facing" ]] && { SECURITY_BLOCK+="alb_scheme          = \"${ALB_SCHEME}\"\n"; HAS_SECURITY=true; }
@@ -917,6 +940,7 @@ printf "  %-26s %s\n" "Deployments:"  "$ENABLE_DEPLOYMENTS"
 [[ "$ENABLE_AGENT_BUILDER" == "true" ]] && printf "  %-26s %s\n" "Agent Builder:" "$ENABLE_AGENT_BUILDER"
 [[ "$ENABLE_POLLY" == "true" ]]         && printf "  %-26s %s\n" "Polly:"         "$ENABLE_POLLY"
 [[ "$ENABLE_INSIGHTS" == "true" ]]      && printf "  %-26s %s\n" "Insights:"      "$ENABLE_INSIGHTS"
+printf "  %-26s %s\n" "Sandboxes:" "$ENABLE_SANDBOXES"
 
 echo ""
 printf "${BOLD}── Next Steps ──${RESET}\n"

--- a/modules/aws/infra/terraform.tfvars.example
+++ b/modules/aws/infra/terraform.tfvars.example
@@ -345,9 +345,6 @@ redis_instance_type = "cache.m6g.xlarge"
 # sandbox_host_local_nvme_bootstrap_enabled = true
 # sandbox_host_local_nvme_expected_device_count = 4
 #
-# Required by init-values.sh when enable_sandboxes = true. Use the same release
-# tag as the other LangSmith images.
-# sandbox_host_image_tag = "0.0.0"
 # Optional: enables browser/programmatic service URLs for HTTP services running inside sandboxes.
 # Requires wildcard DNS and TLS for *.<host>.
 # sandbox_service_url_base_url = "https://sandbox-services.example.com"

--- a/modules/aws/infra/variables.tf
+++ b/modules/aws/infra/variables.tf
@@ -725,12 +725,6 @@ variable "enable_usage_telemetry" {
   default     = false
 }
 
-variable "sandbox_host_image_tag" {
-  type        = string
-  description = "sandbox-host image tag. Required by init-values.sh when enable_sandboxes = true."
-  default     = ""
-}
-
 variable "sandbox_service_url_base_url" {
   type        = string
   description = "Optional base URL used by init-values.sh to generate browser/programmatic service URLs for HTTP services running inside sandboxes. Requires wildcard DNS and TLS for the host when set."


### PR DESCRIPTION
## Summary

- Add an optional Sandbox prompt to AWS QuickStart.
- Keep Sandboxes disabled unless explicitly selected.
- Show saved add-on state during QuickStart update runs.
- Set the Sandbox host image tag automatically at deploy time.
- Remove the unused manual sandbox image-tag Terraform input.

## Sandbox image versioning

The Sandbox host image tag is derived from the selected LangSmith Helm
chart's `appVersion`.

LangChain documents that the Sandbox host image must use the same release
tag as the LangSmith images. This avoids asking users to enter and maintain
a version manually.

The Helm chart is the source of truth for this tag. If a future chart has an
incorrect `appVersion` or does not publish the matching Sandbox image, that
is a Helm chart issue. If this repository reads or passes the value
incorrectly, that is a Terraform issue.

## Testing

- Ran `git diff --check`.
- Manual deployment testing was not run as part of this change.