### PR TITLE
ci(release): cut releases from the release/* maintenance branches

### DIFF
--- a/.github/workflows/chart-line-check.yml
+++ b/.github/workflows/chart-line-check.yml
@@ -1,18 +1,19 @@
 name: Chart Line Check
 
-# Fails a PR (or push to main) if the chart line pin in any provider's deploy.sh
-# is missing or the providers disagree. This catches a bad/divergent pin before
-# it can reach the release workflow, which derives the tag MAJOR.MINOR from it.
+# Fails a PR (or push) targeting main or a release/* maintenance branch if the
+# chart line pin in any provider's deploy.sh is missing or the providers disagree.
+# This catches a bad/divergent pin before it can reach the release workflow, which
+# derives the tag MAJOR.MINOR from it.
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, 'release/*']
     paths:
       - 'modules/**/helm/scripts/deploy.sh'
       - '.github/scripts/chart-line.sh'
       - '.github/workflows/chart-line-check.yml'
   push:
-    branches: [main]
+    branches: [main, 'release/*']
     paths:
       - 'modules/**/helm/scripts/deploy.sh'
       - '.github/scripts/chart-line.sh'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release (auto-tag on merge)
 
-# Cuts a global tag on every merge to main that touches modules/**.
+# Cuts a global tag on every merge that touches modules/**, on main and on the
+# release/* maintenance branches.
 #
 # Versioning: MAJOR.MINOR is the supported LangSmith chart line (parsed from the
 # deploy.sh pins, see .github/scripts/chart-line.sh). PATCH is a module revision
@@ -8,12 +9,19 @@ name: Release (auto-tag on merge)
 # PATCH is NOT the chart version - the chart is resolved as the latest patch in
 # the pinned line (e.g. ~0.15.1).
 #
+# Because the next patch is looked up per line (v0.15.* vs v0.16.*) while tags are
+# repo-global, main and a release/* branch on a different line release in parallel
+# without colliding. The concurrency group below is deliberately global so two
+# branches can never compute the same version at once.
+#
 # Skip a release for a given merge by including "[skip release]" in the commit
 # message. Run manually with dry_run=true to preview the computed version.
 
 on:
   push:
-    branches: [main]
+    branches:
+      - main
+      - 'release/*'
     paths:
       - 'modules/**'
   workflow_dispatch:
@@ -61,6 +69,24 @@ jobs:
           line="$(.github/scripts/chart-line.sh)"
           echo "line=$line" >> "$GITHUB_OUTPUT"
           echo "Chart line: $line"
+
+      - name: Assert branch matches chart line
+        # A release/<line> branch exists to keep releasing its own line. If a pin from
+        # another line is merged or backported into it, the line resolved above would
+        # be wrong for the branch and the tag would land in the other line's series.
+        # Refuse instead. main is unconstrained: it is where the line moves.
+        if: steps.skipcheck.outputs.skip != 'true' && startsWith(github.ref_name, 'release/')
+        env:
+          LINE: ${{ steps.line.outputs.line }}
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          # Branch name is untrusted input; read it from the env, never interpolated.
+          expected="${BRANCH#release/}"
+          if [[ "$expected" != "$LINE" ]]; then
+            echo "::error::branch ${BRANCH} pins chart line ${LINE}, refusing to tag" >&2
+            exit 1
+          fi
+          echo "Branch ${BRANCH} matches chart line ${LINE}."
 
       - name: Compute next tag
         if: steps.skipcheck.outputs.skip != 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 The per-release history lives in
 **[GitHub Releases](https://github.com/langchain-ai/terraform/releases)**, which
-are created automatically on every merge to `main` by
-[`.github/workflows/release.yml`](.github/workflows/release.yml). This file is not
-maintained by hand.
+are created automatically by
+[`.github/workflows/release.yml`](.github/workflows/release.yml) on every merge to
+`main` and to the `release/*` maintenance branches. This file is not maintained by
+hand.
 
 ## Versioning
 
@@ -17,4 +18,4 @@ Releases are global tags `vMAJOR.MINOR.PATCH`:
   repo, regardless of provider, and is **not** the chart version (`v0.15.4`
   does not mean chart `0.15.4`).
 
-Deploy from a tag (`git checkout v0.15.0`), never from `main`.
+Deploy from a tag (`git checkout v0.15.0`), never from a branch.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ Terraform modules for deploying **LangSmith Self-Hosted** on AWS, Azure, GCP, an
 
 LangSmith is LangChain's observability, evaluation, and prompt-engineering platform. This repository packages the cloud foundation (network / cluster / database / cache / object storage / secrets / DNS) and the Helm deployment of the LangSmith application as reusable, production-ready Terraform.
 
+> **This is the `0.15` maintenance branch.** Chart line `0.15` is superseded by `0.16`, which ships as `v0.16.*` tags. This branch keeps shipping `v0.15.*` releases for installs staying on chart `0.15.x`, so staying here is supported — but deploy from a `v0.15.*` tag, never from the branch itself. See [Versioning and releases](#versioning-and-releases). Read `MIGRATION-0.15-to-0.16.md` on the `0.16` line before moving across; the values schema changed in ways chart `0.15` ignores silently rather than rejecting.
+
 ## Who this is for
 
 Enterprise customers running LangSmith in their own cloud account or OpenShift cluster. If you are evaluating Self-Hosted or standing up a production deployment, start here.


### PR DESCRIPTION
## What this does

This branch is now the home of the `0.15` line. Until now, only `main` could create
releases. This PR lets `release/0.15` create its own `v0.15.*` releases, and adds a
check so it can never tag into the wrong version series.

No module code changes. Two workflow files and two docs.

## Why

`main` is about to move to chart line `0.16`. Customers who stay on chart `0.15.x`
still need fixes, and those fixes now land here — so this branch has to be able to
release on its own.

Without this change, a merge into `release/0.15` would produce no release at all,
because the release workflow only listens to `main`. That failure is quiet: the merge
succeeds, and no tag ever appears.

## What changed

**`.github/workflows/release.yml`**
- Now also runs on `release/*` branches, not just `main`.
- New step, "Assert branch matches chart line". It compares the branch name against
  the chart version pinned in the provider deploy scripts. If a `0.16` pin ever gets
  merged or backported onto `release/0.15`, the workflow stops instead of tagging a
  `v0.16.*` release from the wrong branch.

**`.github/workflows/chart-line-check.yml`**
- Now also checks pull requests and pushes on `release/*`, so a bad or inconsistent
  pin is caught before it can reach the release workflow.

**`CHANGELOG.md`**
- Says releases are created from `main` *and* from the `release/*` maintenance
  branches, instead of `main` only.
- "never from `main`" becomes "never from a branch", since there are two release
  branches now.

**`README.md`**
- Adds a note at the top: this is the `0.15` maintenance branch, `0.16` is the current
  line, `v0.15.*` releases continue here, and you should deploy from a tag rather than
  from the branch itself.

## Why the change has to be on this branch

For a `push` event, GitHub reads the workflow file from the branch that was pushed.
Adding this to `main` alone would do nothing for `release/0.15`. That is why it lands
here first.

## How to verify

This merge should create **no** release, because the release workflow only tags when
files under `modules/` change, and this PR touches none:

```bash
git fetch origin --tags
git tag -l 'v0.15.*' --sort=-v:refname | head -1   # expect: still v0.15.32
```

The final `0.15` release is then cut deliberately, dry run first:

```bash
gh workflow run release.yml --ref release/0.15 -f dry_run=true   # expect: line 0.15, tag v0.15.33
gh workflow run release.yml --ref release/0.15
```

## Not in this PR

- The release-notes wording fix (the hardcoded `~0.15.1` in the notes). It happens to
  be correct for the `0.15` line, so changing it here would only add noise. It is
  fixed on the `0.16` side.
- The same workflow change for `main`. That lands as its own PR after the cutover.

## Risk

Low. No Terraform or Helm code is touched. The only behaviour changes are that this
branch can now create releases, and that a release will stop if the branch name and
the pinned chart line disagree.