### PR TITLE
fix(azure): drop the dns01 ClusterIssuer that broke terraform plan

### DIFF
--- a/modules/azure/BUILDING_LIGHT_LANGSMITH.md
+++ b/modules/azure/BUILDING_LIGHT_LANGSMITH.md
@@ -270,8 +270,8 @@ cd terraform/azure
 make init
 
 # Apply — creates all Azure resources
-# Note: make plan fails on a fresh deploy (no cluster yet for kubernetes_manifest).
-# Run apply directly — it handles the ordering in three targeted stages automatically.
+# Note: make apply runs three targeted stages so the Kubernetes resources land
+# after the cluster they connect to.
 # Light deploy takes 8–12 minutes (dominated by AKS cluster provisioning).
 make apply
 ```

--- a/modules/azure/Makefile
+++ b/modules/azure/Makefile
@@ -51,7 +51,7 @@ plan: ## terraform plan (infra) — runs setup-env.sh first to ensure secrets.au
 	@if [ ! -f $(INFRA_DIR)/secrets.auto.tfvars ]; then cd $(INFRA_DIR) && bash scripts/setup-env.sh; fi
 	terraform -chdir=$(INFRA_DIR) plan
 
-apply: ## terraform apply (infra) — two-stage: Azure infra first, then k8s bootstrap + ClusterIssuer
+apply: ## terraform apply (infra) — three stages: Azure infra, then k8s bootstrap, then the rest
 	@if [ ! -f $(INFRA_DIR)/secrets.auto.tfvars ]; then cd $(INFRA_DIR) && bash scripts/setup-env.sh; fi
 	@echo "→ Stage 1: Azure infrastructure (RG, VNet, AKS, Postgres, Redis, Blob, KeyVault)..."
 	terraform -chdir=$(INFRA_DIR) apply -auto-approve \
@@ -74,7 +74,7 @@ apply: ## terraform apply (infra) — two-stage: Azure infra first, then k8s boo
 		-target=module.k8s_bootstrap.kubernetes_secret_v1.license \
 		-target=module.k8s_bootstrap.helm_release.cert_manager \
 		-target=module.k8s_bootstrap.helm_release.keda
-	@echo "→ Stage 3: ClusterIssuer + remaining resources (cert-manager CRDs now ready)..."
+	@echo "→ Stage 3: remaining resources (DNS zone, WAF, anything left in k8s bootstrap)..."
 	terraform -chdir=$(INFRA_DIR) apply -auto-approve
 
 destroy: ## terraform destroy (infra) — prompts for confirmation

--- a/modules/azure/QUICK_REFERENCE.md
+++ b/modules/azure/QUICK_REFERENCE.md
@@ -29,8 +29,8 @@ make setup-env
 make preflight
 
 # 4. Deploy infrastructure (~15–20 min)
-# Note: make plan fails on a fresh deploy (no cluster yet for kubernetes_manifest).
-# Skip plan and run apply directly — it runs three targeted stages automatically.
+# Note: make apply runs three targeted stages so the Kubernetes resources land
+# after the cluster they connect to.
 make init
 make apply
 

--- a/modules/azure/README.md
+++ b/modules/azure/README.md
@@ -100,8 +100,8 @@ make setup-env
 make preflight
 
 # 4. Deploy infrastructure (~15–20 min)
-# Note: make plan will fail on a fresh deploy (no cluster yet for kubernetes_manifest).
-# Skip plan and run apply directly — it handles the ordering in three stages.
+# Note: make apply runs three targeted stages so the Kubernetes resources land
+# after the cluster they connect to.
 make init
 make apply
 

--- a/modules/azure/TEST_CYCLE.md
+++ b/modules/azure/TEST_CYCLE.md
@@ -286,8 +286,7 @@ postgres_geo_redundant_backup        = true
 
 | Issue | Symptom | Fix |
 |-------|---------|-----|
-| `make plan` fails on fresh deploy | `cannot create REST client: no client config` on `kubernetes_manifest.cluster_issuer_http01` | Expected — the Kubernetes provider can't connect during plan because the cluster doesn't exist yet. Skip `make plan` on a fresh deploy and run `make apply` directly. `make apply` handles this with a three-stage apply. |
-| `kubernetes_manifest` ClusterIssuer fails during apply | `API did not recognize GroupVersionKind: no matches for kind "ClusterIssuer"` | cert-manager CRDs not registered yet. Fixed by `make apply` Stage 2 (installs cert-manager first) before Stage 3 applies the ClusterIssuer. If you ran a plain `terraform apply`, run `make apply` again — it will pick up from the correct stage. |
+| `letsencrypt-prod` ClusterIssuer missing after apply | `clusterissuers.cert-manager.io "letsencrypt-prod" not found` on the langsmith-tls certificate | Terraform does not create the issuer. `make deploy` applies it, so run Pass 2 before checking the certificate. See TROUBLESHOOTING.md. |
 | vCPU quota exceeded | `ErrCode_InsufficientVCPUQuota: Insufficient vcpu quota... remaining 2 for standardDSv3Family` | Request quota increase: Portal → Subscriptions → Usage + Quotas → DSv3 → Request 32. Or: `az quota update --resource-name standardDSv3Family ...` See TROUBLESHOOTING.md. |
 | `max_pods` too low — autoscaler backoff | `pod didn't trigger scale-up: in backoff after failed scale-up` | Set `default_node_pool_max_pods = 60` **before** first apply — this field is immutable. With 30 pods/node, Pass 2's ~37 pods trigger autoscaler which hits quota. |
 | `default_node_pool_min_count = 1` causes pod pending | All 14+ vCPU of Pass 2 must schedule but only 1 node starts | Set `default_node_pool_min_count = 3` — autoscaler waits for pending pods before adding nodes, causing initial deploy to stall. |

--- a/modules/azure/TROUBLESHOOTING.md
+++ b/modules/azure/TROUBLESHOOTING.md
@@ -451,7 +451,7 @@ kubectl describe certificate langsmith-tls -n langsmith
 # Events: ... clusterissuers.cert-manager.io "letsencrypt-prod" not found
 ```
 
-**Cause:** When `tls_certificate_source = "letsencrypt"` is set, the `k8s-bootstrap` module creates a `letsencrypt-prod` ClusterIssuer via `kubernetes_manifest`. If you deployed from an older version of the module (before `cluster_issuer_http01` was added), the ClusterIssuer was never created.
+**Cause:** `deploy.sh` applies the `letsencrypt-prod` ClusterIssuer when `tls_certificate_source` is `letsencrypt` or `dns01`. Terraform never creates it. You hit this when `make deploy` has not run yet, when `tls_certificate_source` was unset in tfvars at the time it ran, or when the `dns01` branch skipped the issuer because `langsmith_domain` was empty (`make deploy` prints a warning in that case).
 
 **Fix — apply it manually:**
 ```bash

--- a/modules/azure/infra/main.tf
+++ b/modules/azure/infra/main.tf
@@ -280,8 +280,8 @@ module "keyvault" {
 #
 # LangSmith application deployment is handled outside Terraform:
 #   Pass 1.5: bash helm/scripts/get-kubeconfig.sh <cluster> <rg>
-#   Pass 1.6: ACME_EMAIL=... bash helm/scripts/apply-cluster-issuers.sh
 #   Pass 2:   bash helm/scripts/generate-secrets.sh && bash helm/scripts/deploy.sh
+#             (deploy.sh also applies the letsencrypt-prod ClusterIssuer)
 #   Pass 3+:  bash helm/scripts/deploy.sh --overlay overlays/<feature>.yaml
 #
 # Note: This module configures its own kubernetes/helm providers internally,
@@ -328,13 +328,24 @@ module "k8s_bootstrap" {
   # helm/scripts/generate-secrets.sh from Azure Key Vault.
   langsmith_license_key = var.langsmith_license_key
 
-  # TLS / cert-manager
+  # TLS / cert-manager. The ClusterIssuers themselves are applied by
+  # helm/scripts/deploy.sh, which reads letsencrypt_email, langsmith_domain and
+  # subscription_id straight from terraform.tfvars.
   tls_certificate_source          = var.tls_certificate_source
-  letsencrypt_email               = var.letsencrypt_email
   cert_manager_identity_client_id = module.aks.cert_manager_identity_client_id
-  subscription_id                 = var.subscription_id
-  dns_zone_name                   = var.create_dns_zone ? var.langsmith_domain : ""
-  dns_resource_group_name         = azurerm_resource_group.resource_group.name
+}
+
+# The DNS-01 ClusterIssuer used to be a kubernetes_manifest in k8s-bootstrap, which
+# broke terraform plan on a fresh deploy: kubernetes_manifest opens an API connection
+# during plan and there is no cluster yet. deploy.sh already applied an identical
+# issuer, so the Terraform copy was dropped. Existing deployments keep the live
+# object; only the state entry goes.
+removed {
+  from = module.k8s_bootstrap.kubernetes_manifest.cluster_issuer_dns01
+
+  lifecycle {
+    destroy = false
+  }
 }
 
 # ── WAF (optional) ────────────────────────────────────────────────────────────

--- a/modules/azure/infra/modules/k8s-bootstrap/main.tf
+++ b/modules/azure/infra/modules/k8s-bootstrap/main.tf
@@ -256,8 +256,7 @@ resource "kubernetes_secret_v1" "license" {
 
 # ── cert-manager ──────────────────────────────────────────────────────────────
 # TLS automation infrastructure. Manages Let's Encrypt certificates.
-# ClusterIssuers are applied separately via:
-#   bash helm/scripts/apply-cluster-issuers.sh
+# ClusterIssuers are applied separately by helm/scripts/deploy.sh.
 
 resource "helm_release" "cert_manager" {
   name             = "cert-manager"
@@ -311,50 +310,11 @@ resource "helm_release" "cert_manager" {
   }
 }
 
-# HTTP-01 ClusterIssuer is NOT created here.
+# No ClusterIssuer is created here, for either HTTP-01 or DNS-01.
 # kubernetes_manifest requires a live API connection during plan, which fails on fresh
-# deploy (no cluster exists yet). It is applied by helm/scripts/deploy.sh instead,
-# after the cluster is up, via kubectl apply.
-
-# DNS-01 ClusterIssuer — created by Terraform when tls_certificate_source = "dns01".
-# Uses Azure DNS + Workload Identity: no static service principal needed.
-# cert-manager controller calls the Azure DNS API to create/delete TXT records
-# for ACME challenge verification.
-resource "kubernetes_manifest" "cluster_issuer_dns01" {
-  count = var.tls_certificate_source == "dns01" ? 1 : 0
-
-  manifest = {
-    apiVersion = "cert-manager.io/v1"
-    kind       = "ClusterIssuer"
-    metadata = {
-      name = "letsencrypt-prod"
-    }
-    spec = {
-      acme = {
-        server = "https://acme-v02.api.letsencrypt.org/directory"
-        email  = var.letsencrypt_email
-        privateKeySecretRef = {
-          name = "letsencrypt-prod-account-key"
-        }
-        solvers = [{
-          dns01 = {
-            azureDNS = {
-              subscriptionID    = var.subscription_id
-              resourceGroupName = var.dns_resource_group_name
-              hostedZoneName    = var.dns_zone_name
-              environment       = "AzurePublicCloud"
-              managedIdentity = {
-                clientID = var.cert_manager_identity_client_id
-              }
-            }
-          }
-        }]
-      }
-    }
-  }
-
-  depends_on = [helm_release.cert_manager]
-}
+# deploy (no cluster exists yet). Both issuers are applied by helm/scripts/deploy.sh
+# after the cluster is up, via kubectl apply. The DNS-01 issuer needs the pod labels
+# and service account annotation set on the cert-manager release above.
 
 # ── KEDA ──────────────────────────────────────────────────────────────────────
 # Kubernetes Event-Driven Autoscaling. Scales LangSmith queue workers

--- a/modules/azure/infra/modules/k8s-bootstrap/variables.tf
+++ b/modules/azure/infra/modules/k8s-bootstrap/variables.tf
@@ -115,7 +115,7 @@ variable "ingress_controller" {
 
 variable "tls_certificate_source" {
   type        = string
-  description = "TLS certificate source. 'letsencrypt' = HTTP-01 via cert-manager (ClusterIssuer created by apply-cluster-issuers.sh). 'dns01' = DNS-01 via Azure DNS + Workload Identity (ClusterIssuer created by Terraform). 'none' = skip."
+  description = "TLS certificate source. 'letsencrypt' = HTTP-01 via cert-manager. 'dns01' = DNS-01 via Azure DNS + Workload Identity. 'none' = skip. Both ClusterIssuers are created by helm/scripts/deploy.sh; this module only sets up cert-manager to support them."
   default     = "letsencrypt"
 
   validation {
@@ -124,33 +124,9 @@ variable "tls_certificate_source" {
   }
 }
 
-variable "letsencrypt_email" {
-  type        = string
-  description = "Email for Let's Encrypt certificate notifications. Required when tls_certificate_source = 'dns01'."
-  default     = ""
-}
-
 variable "cert_manager_identity_client_id" {
   type        = string
   description = "Client ID of the cert-manager Managed Identity. Required when tls_certificate_source = 'dns01'."
-  default     = ""
-}
-
-variable "dns_zone_name" {
-  type        = string
-  description = "Azure DNS zone name (e.g. langsmith.mycompany.com). Required when tls_certificate_source = 'dns01'."
-  default     = ""
-}
-
-variable "dns_resource_group_name" {
-  type        = string
-  description = "Resource group containing the Azure DNS zone. Required when tls_certificate_source = 'dns01'."
-  default     = ""
-}
-
-variable "subscription_id" {
-  type        = string
-  description = "Azure subscription ID. Required when tls_certificate_source = 'dns01' for the ClusterIssuer azureDNS config."
   default     = ""
 }
 

--- a/modules/azure/infra/variables.tf
+++ b/modules/azure/infra/variables.tf
@@ -350,15 +350,6 @@ variable "tls_certificate_source" {
     condition     = contains(["none", "letsencrypt", "dns01", "existing"], var.tls_certificate_source)
     error_message = "tls_certificate_source must be 'none', 'letsencrypt', 'dns01', or 'existing'."
   }
-
-  # DNS-01 has no dns_label equivalent: cert-manager writes TXT records under a
-  # zone it has to be told by name. Left empty, langsmith_domain reaches the dns
-  # module as an empty zone name, and the deployment applies its way to a
-  # certificate that can never be issued.
-  validation {
-    condition     = var.tls_certificate_source != "dns01" || var.langsmith_domain != ""
-    error_message = "tls_certificate_source = \"dns01\" requires langsmith_domain. DNS-01 validates a real hostname, so there is no Azure public-IP DNS label equivalent. Set langsmith_domain, or use \"letsencrypt\" for HTTP-01."
-  }
 }
 
 variable "postgres_admin_username" {

--- a/modules/azure/infra/variables.tf
+++ b/modules/azure/infra/variables.tf
@@ -350,6 +350,15 @@ variable "tls_certificate_source" {
     condition     = contains(["none", "letsencrypt", "dns01", "existing"], var.tls_certificate_source)
     error_message = "tls_certificate_source must be 'none', 'letsencrypt', 'dns01', or 'existing'."
   }
+
+  # DNS-01 has no dns_label equivalent: cert-manager writes TXT records under a
+  # zone it has to be told by name. Left empty, langsmith_domain reaches the dns
+  # module as an empty zone name, and the deployment applies its way to a
+  # certificate that can never be issued.
+  validation {
+    condition     = var.tls_certificate_source != "dns01" || var.langsmith_domain != ""
+    error_message = "tls_certificate_source = \"dns01\" requires langsmith_domain. DNS-01 validates a real hostname, so there is no Azure public-IP DNS label equivalent. Set langsmith_domain, or use \"letsencrypt\" for HTTP-01."
+  }
 }
 
 variable "postgres_admin_username" {

--- a/modules/azure/infra/variables.tf
+++ b/modules/azure/infra/variables.tf
@@ -321,9 +321,11 @@ variable "istio_addon_revision" {
   default     = "asm-1-27"
 }
 
+# No Terraform resource reads this. helm/scripts/deploy.sh parses it out of
+# terraform.tfvars for the ClusterIssuer it applies, so the declaration has to stay.
 variable "letsencrypt_email" {
   type        = string
-  description = "Email address for Let's Encrypt certificate notifications. Required when tls_certificate_source = 'letsencrypt'."
+  description = "Email address for Let's Encrypt certificate notifications. Required when tls_certificate_source is 'letsencrypt' or 'dns01'."
   default     = ""
 }
 


### PR DESCRIPTION
Fixes the plan-time failure described in #130. Leaves #130 open, because a second blocker lives in #106. See the last section.

## The problem

`kubernetes_manifest.cluster_issuer_dns01` in `k8s-bootstrap` could not be planned before its cluster existed. `kubernetes_manifest` opens a Kubernetes API connection during plan, to fetch the OpenAPI schema for the manifest's kind, and on a fresh deploy there is no cluster to ask. Every dns01 config hit it.

`helm/scripts/deploy.sh` already applies a `letsencrypt-prod` issuer once the cluster is up, and it matches the one Terraform was creating field for field: same name, same `dns01.azureDNS` solver, same `subscriptionID` / `resourceGroupName` / `hostedZoneName` / `environment` / `managedIdentity.clientID`. The Terraform copy was duplication.

## What changed

- Deleted the resource. It was the last `kubernetes_manifest` anywhere in the Azure module.
- Dropped `letsencrypt_email`, `dns_zone_name`, `dns_resource_group_name` and `subscription_id` from `k8s-bootstrap`. Each had exactly one reference and it was inside the deleted resource.
- Kept `cert_manager_identity_client_id`. It still annotates the cert-manager service account for Workload Identity, which is how the issuer `deploy.sh` applies reaches the Azure DNS API.
- Added a `removed` block with `destroy = false`, so an existing dns01 deployment drops the state entry instead of destroying a live issuer and sitting unrenewed until the next `make deploy`.
- Root `letsencrypt_email` stays, now with a comment saying why. No Terraform resource reads it, but `deploy.sh` parses it out of `terraform.tfvars`. It joins nine other tfvars-only variables that tflint already flags the same way.
- Docs. Three files pointed at `apply-cluster-issuers.sh`, which does not exist. `TROUBLESHOOTING.md` and both ClusterIssuer rows of the `TEST_CYCLE.md` table described `cluster_issuer_http01`, deleted a while back, and the troubleshooting cause contradicted its own Note 30 lines below it. The "`make plan` fails on a fresh deploy" caveat is out of README, QUICK_REFERENCE and BUILDING_LIGHT_LANGSMITH. The `Makefile` help said "two-stage" while running three.

## Verification

`bash agents/check.sh modules/azure` passes: `terraform validate` returns `Success! The configuration is valid.`, `terraform fmt -check -recursive` is clean, tflint reports no errors (10 pre-existing `terraform_unused_declarations` warnings, advisory at the gate's severity).

Nothing here was run against a live Azure subscription. The `deploy.sh` path is verified by reading it and confirming both `terraform output` calls it makes exist in `infra/outputs.tf`.

## Why #130 stays open

A dns01 `terraform plan` still exits 1, now on `azurerm_role_assignment.cert_manager_dns` in `infra/modules/dns/main.tf`, whose `count` reads `module.aks.cert_manager_identity_principal_id` and cannot know that value until apply. #106 fixes exactly that, with a plan-known `grant_cert_manager_dns` bool. Two separate blockers, one per PR, so neither closes the issue alone. Close #130 by hand once both are in and a dns01 plan exits 0.

The two merge cleanly in either order. Six files overlap and no hunks do; I test-merged this branch against `pull/106/head` with `git merge-tree` and it came back clean.
