### PR TITLE
fix(azure): expose AKS Kubernetes version

### DIFF
--- a/modules/azure/infra/main.tf
+++ b/modules/azure/infra/main.tf
@@ -559,6 +559,7 @@ module "aks" {
   subnet_id           = local.aks_subnet_id
   service_cidr        = local.aks_service_cidr   # K8s ClusterIP range (must not overlap VNet)
   dns_service_ip      = local.aks_dns_service_ip # CoreDNS IP (derived from service_cidr)
+  kubernetes_version  = var.aks_kubernetes_version
 
   default_node_pool_vm_size   = var.default_node_pool_vm_size
   default_node_pool_min_count = var.default_node_pool_min_count

--- a/modules/azure/infra/variables.tf
+++ b/modules/azure/infra/variables.tf
@@ -344,6 +344,12 @@ variable "storage_allowed_ips" {
 # Official LangSmith minimum: 16 vCPU / 64 GiB cluster-wide.
 # See: https://docs.langchain.com/langsmith/kubernetes
 
+variable "aks_kubernetes_version" {
+  type        = string
+  description = "Kubernetes version for the AKS cluster"
+  default     = "1.35"
+}
+
 variable "default_node_pool_vm_size" {
   type        = string
   description = "VM size for the default AKS node pool. Standard_D8s_v3 (8 vCPU / 32 GiB) is the recommended baseline for Pass 2+ (external Postgres + Redis). Use Standard_D4s_v3 (4 vCPU / 16 GiB) only for light/demo deployments (in-cluster DBs). See sizing comment above."


### PR DESCRIPTION
## Summary

- Expose the AKS Kubernetes version as a root Terraform input
- Pass the version through to the AKS cluster submodule
- Preserve the existing `1.35` default

## Why

The AKS submodule defaults to Kubernetes `1.35`, but the root Azure module
does not expose that setting. Operators therefore cannot select or pin the
version through `terraform.tfvars`.

This change makes the version configurable without changing existing default
behavior.

## Testing

- `terraform -chdir=modules/azure/infra fmt -check`
- `terraform -chdir=modules/azure/infra validate`
- `git diff --check`

Closes #139
