### PR TITLE
chore(aws): remove stale trigger endpoint workaround

### DIFF
--- a/modules/aws/helm/scripts/init-values.sh
+++ b/modules/aws/helm/scripts/init-values.sh
@@ -599,21 +599,6 @@ _insights_key="${TF_VAR_langsmith_insights_encryption_key:-}"
 
 _standalone_block=""
 
-# platformBackend extras merged into the single platformBackend block below (the
-# heredoc already sets platformBackend.serviceAccount; appending here keeps it one key).
-_platform_backend_fleet_block=""
-if [[ "$_enable_fleet" == "true" ]]; then
-  # Workaround for chart <= 0.15.x: the chart config-map wires MCP_SERVER_URL (tool
-  # server) but NOT TRIGGER_SERVER_ENDPOINT, so the platform-backend trigger proxy
-  # returns 502 for Fleet cron/Slack/Gmail triggers. Inject it here pointing at the
-  # in-cluster trigger server (port 1990). Remove once the chart sets it natively.
-  _platform_backend_fleet_block="
-  deployment:
-    extraEnv:
-      - name: TRIGGER_SERVER_ENDPOINT
-        value: \"http://langsmith-fleet-trigger-server.${NAMESPACE:-langsmith}.svc.cluster.local:1990\""
-fi
-
 if [[ "$_enable_fleet" == "true" ]]; then
   if [[ -z "$_agent_builder_key" ]]; then
     echo "ERROR: enable_fleet = true but TF_VAR_langsmith_agent_builder_encryption_key is not set." >&2
@@ -766,7 +751,7 @@ TELEMETRY
 platformBackend:
   serviceAccount:
     annotations:
-      eks.amazonaws.com/role-arn: "${IRSA_ROLE_ARN}"${_platform_backend_fleet_block}
+      eks.amazonaws.com/role-arn: "${IRSA_ROLE_ARN}"
 
 backend:
   serviceAccount:


### PR DESCRIPTION
## Summary

- Stop injecting `TRIGGER_SERVER_ENDPOINT` from `init-values.sh`.
- Rely on the native configuration provided by LangSmith chart 0.16.
- Avoid hardcoding the Fleet service name, which breaks renamed releases.

## Testing

- `bash -n modules/aws/helm/scripts/init-values.sh`
- `git diff --check upstream/main...HEAD`
- `bash agents/check.sh --scripts` (shellcheck unavailable, so lint was skipped)
