### PR TITLE
fix(azure): delegate the AGIC subnet, and ignore service-managed subnet endpoints

### DIFF
--- a/modules/azure/INGRESS_CONTROLLERS.md
+++ b/modules/azure/INGRESS_CONTROLLERS.md
@@ -157,7 +157,9 @@ create_dns_zone        = true
 ```
 
 **How it works:**
-- Terraform creates Application Gateway v2 + dedicated `/24` subnet
+- Terraform creates Application Gateway v2 + dedicated `/24` subnet, delegated to
+  `Microsoft.Network/applicationGateways` — Azure rejects a network-isolated gateway in an
+  undelegated subnet, so a subnet supplied through `agic_subnet_id` needs the same delegation
 - AKS provisions `IngressClass` named `azure-application-gateway`
 - AGIC watches `Ingress` resources and programs AGW routing rules
 - cert-manager issues TLS via DNS-01 (HTTP-01 incompatible with AGW path rewriting)

--- a/modules/azure/infra/main.tf
+++ b/modules/azure/infra/main.tf
@@ -391,6 +391,15 @@ data "azurerm_subnet" "byo_agic_subnet" {
   resource_group_name  = local.byo_agic_subnet_parts[4]
 }
 
+# Reads the same subnet again for its delegations, which azurerm_subnet does not
+# expose. Feeds the agic_subnet_delegation check below.
+data "azapi_resource" "byo_agic_subnet_delegations" {
+  count                  = local.byo_agic_subnet && var.ingress_controller == "agic" ? 1 : 0
+  type                   = "Microsoft.Network/virtualNetworks/subnets@2023-11-01"
+  resource_id            = var.agic_subnet_id
+  response_export_values = ["properties.delegations"]
+}
+
 # ── Service endpoints on a supplied AKS subnet ────────────────────────────────
 # Only when manage_byo_subnet_service_endpoints is on. Reads the endpoints
 # already on the subnet so the patch below appends to them instead of replacing
@@ -564,6 +573,25 @@ resource "terraform_data" "validate_network" {
       condition     = length(data.azurerm_virtual_network.byo_vnet) == 0 || length(local.uncontained_prefixes) == 0
       error_message = "These subnet prefixes fall outside the address space of vnet_id (${join(", ", local.vnet_address_space)}): ${join(", ", local.uncontained_prefixes)}. Point each at a free range inside your VNet, or supply that subnet's ID to reuse a subnet that already exists."
     }
+  }
+}
+
+# Azure rejects a network-isolated Application Gateway in a subnet that carries no
+# delegation, with ApplicationGatewayNetworkIsolationRequiresSubnetDelegation. The
+# subnet Terraform creates is delegated (modules/networking/main.tf); a supplied
+# one belongs to the operator, so this reports rather than fixes.
+#
+# A check block, not a precondition: gateways created before Azure applied network
+# isolation keep running in an undelegated subnet, and a later apply does not
+# recreate them. Blocking the plan there would strand a deployment that works over
+# a requirement its gateway never had to meet.
+check "agic_subnet_delegation" {
+  assert {
+    condition = length(data.azapi_resource.byo_agic_subnet_delegations) == 0 || contains([
+      for d in try(data.azapi_resource.byo_agic_subnet_delegations[0].output.properties.delegations, []) :
+      try(d.properties.serviceName, "")
+    ], "Microsoft.Network/applicationGateways")
+    error_message = "The subnet given as agic_subnet_id is not delegated to Microsoft.Network/applicationGateways. Creating an Application Gateway there fails with ApplicationGatewayNetworkIsolationRequiresSubnetDelegation, partway through the apply. Have the subnet's owner add the delegation (action Microsoft.Network/virtualNetworks/subnets/join/action) before applying: `az network vnet subnet update --ids ${var.agic_subnet_id} --delegations Microsoft.Network/applicationGateways`. Ignore this if the gateway already exists and runs — an existing one is not revalidated."
   }
 }
 

--- a/modules/azure/infra/main.tf
+++ b/modules/azure/infra/main.tf
@@ -391,8 +391,7 @@ data "azurerm_subnet" "byo_agic_subnet" {
   resource_group_name  = local.byo_agic_subnet_parts[4]
 }
 
-# Reads the same subnet again for its delegations, which azurerm_subnet does not
-# expose. Feeds the agic_subnet_delegation check below.
+# azurerm_subnet does not expose delegations. Feeds the check below.
 data "azapi_resource" "byo_agic_subnet_delegations" {
   count                  = local.byo_agic_subnet && var.ingress_controller == "agic" ? 1 : 0
   type                   = "Microsoft.Network/virtualNetworks/subnets@2023-11-01"
@@ -576,15 +575,9 @@ resource "terraform_data" "validate_network" {
   }
 }
 
-# Azure rejects a network-isolated Application Gateway in a subnet that carries no
-# delegation, with ApplicationGatewayNetworkIsolationRequiresSubnetDelegation. The
-# subnet Terraform creates is delegated (modules/networking/main.tf); a supplied
-# one belongs to the operator, so this reports rather than fixes.
-#
-# A check block, not a precondition: gateways created before Azure applied network
-# isolation keep running in an undelegated subnet, and a later apply does not
-# recreate them. Blocking the plan there would strand a deployment that works over
-# a requirement its gateway never had to meet.
+# A supplied subnet belongs to the operator, so report rather than fix. A check
+# and not a precondition, because a gateway created before Azure applied network
+# isolation keeps running undelegated and is never revalidated.
 check "agic_subnet_delegation" {
   assert {
     condition = length(data.azapi_resource.byo_agic_subnet_delegations) == 0 || contains([

--- a/modules/azure/infra/modules/networking/main.tf
+++ b/modules/azure/infra/modules/networking/main.tf
@@ -121,10 +121,32 @@ resource "azurerm_subnet" "subnet_bastion" {
 # Application Gateway subnet — required when ingress_controller = "agic".
 # Azure Application Gateway v2 requires an exclusive subnet of at least /24.
 # No other resources (pods, VMs) may be placed in this subnet.
+#
+# Delegated to Microsoft.Network/applicationGateways. Azure applies network
+# isolation to new v2 gateways, and an isolated gateway is rejected outright in a
+# subnet that carries no delegation:
+#
+#   ApplicationGatewayNetworkIsolationRequiresSubnetDelegation: Application
+#   Gateway <id> with NetworkIsolation requires subnet delegation.
+#
+# The gateway is the only thing this module puts in the subnet, so delegating it
+# to the service costs nothing that was available before.
 resource "azurerm_subnet" "subnet_agic" {
   count                = var.enable_agic ? 1 : 0
   name                 = "${var.network_name}-subnet-agic"
   resource_group_name  = local.subnet_resource_group_name
   virtual_network_name = local.subnet_vnet_name
   address_prefixes     = var.agic_subnet_address_prefix
+
+  delegation {
+    name = "appgw-delegation"
+
+    service_delegation {
+      name = "Microsoft.Network/applicationGateways"
+
+      actions = [
+        "Microsoft.Network/virtualNetworks/subnets/join/action",
+      ]
+    }
+  }
 }

--- a/modules/azure/infra/modules/networking/main.tf
+++ b/modules/azure/infra/modules/networking/main.tf
@@ -93,6 +93,13 @@ resource "azurerm_subnet" "subnet_postgres" {
       ]
     }
   }
+
+  # The Postgres network-integration principal adds Microsoft.Storage here
+  # itself once the server is injected. service_endpoints is Optional and not
+  # Computed, so declaring nothing plans to strip it on every run.
+  lifecycle {
+    ignore_changes = [service_endpoints]
+  }
 }
 
 # Redis subnet — created only when create_redis_subnet = true.
@@ -142,5 +149,11 @@ resource "azurerm_subnet" "subnet_agic" {
         "Microsoft.Network/virtualNetworks/subnets/join/action",
       ]
     }
+  }
+
+  # Same precaution as subnet_postgres above, though Application Gateway has
+  # not been seen adding an endpoint.
+  lifecycle {
+    ignore_changes = [service_endpoints]
   }
 }

--- a/modules/azure/infra/modules/networking/main.tf
+++ b/modules/azure/infra/modules/networking/main.tf
@@ -122,15 +122,9 @@ resource "azurerm_subnet" "subnet_bastion" {
 # Azure Application Gateway v2 requires an exclusive subnet of at least /24.
 # No other resources (pods, VMs) may be placed in this subnet.
 #
-# Delegated to Microsoft.Network/applicationGateways. Azure applies network
-# isolation to new v2 gateways, and an isolated gateway is rejected outright in a
-# subnet that carries no delegation:
-#
-#   ApplicationGatewayNetworkIsolationRequiresSubnetDelegation: Application
-#   Gateway <id> with NetworkIsolation requires subnet delegation.
-#
-# The gateway is the only thing this module puts in the subnet, so delegating it
-# to the service costs nothing that was available before.
+# The delegation is required: Azure applies network isolation to new v2 gateways
+# and rejects an isolated gateway in an undelegated subnet with
+# ApplicationGatewayNetworkIsolationRequiresSubnetDelegation.
 resource "azurerm_subnet" "subnet_agic" {
   count                = var.enable_agic ? 1 : 0
   name                 = "${var.network_name}-subnet-agic"

--- a/modules/azure/infra/variables.tf
+++ b/modules/azure/infra/variables.tf
@@ -19,6 +19,7 @@ variable "name_prefix" {
 # terraform.tfvars fails the plan with an explanation, rather than being
 # ignored as an undeclared variable — which would drop name_prefix to its
 # empty default and rename (destroy and recreate) every resource.
+# tflint-ignore: terraform_unused_declarations
 variable "identifier" {
   type        = string
   description = "Removed — use name_prefix instead."

--- a/modules/azure/infra/variables.tf
+++ b/modules/azure/infra/variables.tf
@@ -287,7 +287,7 @@ variable "redis_subnet_id" {
 
 variable "agic_subnet_id" {
   type        = string
-  description = "The id of an existing subnet for the Application Gateway, required when ingress_controller = \"agic\" and create_vnet = false. Unlike the three above there is no carve path: Terraform will not create an Application Gateway subnet inside a VNet it does not own. Application Gateway v2 needs the subnet to itself, and Azure recommends a /24."
+  description = "The id of an existing subnet for the Application Gateway, required when ingress_controller = \"agic\" and create_vnet = false. Unlike the three above there is no carve path: Terraform will not create an Application Gateway subnet inside a VNet it does not own. Application Gateway v2 needs the subnet to itself, and Azure recommends a /24. It must also be delegated to Microsoft.Network/applicationGateways, or Azure rejects the gateway during apply; Terraform reads the delegation at plan time and warns when it is missing."
   default     = ""
 
   validation {

--- a/modules/azure/infra/versions.tf
+++ b/modules/azure/infra/versions.tf
@@ -2,9 +2,12 @@ terraform {
   required_version = ">= 1.11.0"
 
   required_providers {
+    # 4.27 is the release that accepts Microsoft.Network/applicationGateways as a
+    # subnet service_delegation name, which the AGIC subnet needs. Older 4.x rejects
+    # it during validation, before any API call.
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 4.0"
+      version = ">= 4.27.0, < 5.0.0"
     }
     # Azure Managed Redis (Microsoft.Cache/redisEnterprise) Balanced SKUs aren't
     # reliably exposed by azurerm yet — the redis module provisions AMR via azapi.


### PR DESCRIPTION
## Problem

Azure applies network isolation to new Application Gateway v2 deployments and rejects a gateway whose subnet carries no delegation. Every AGIC apply fails at gateway creation:

```
Error: creating Application Gateway ...: unexpected status 400 (400 Bad Request) with error:
ApplicationGatewayNetworkIsolationRequiresSubnetDelegation: Application Gateway
/subscriptions/.../applicationGateways/ls-aks-<x>-agw with NetworkIsolation requires subnet
delegation. Please delegate subnet /subscriptions/.../subnets/ls-vnet-<x>-subnet-agic to
Microsoft.Network/applicationGateways.
```

Hit on a live customer deployment.

## Change

`modules/networking` delegates the AGIC subnet it creates to `Microsoft.Network/applicationGateways` with `Microsoft.Network/virtualNetworks/subnets/join/action`, the only action Azure exposes for that service (`az network vnet subnet list-available-delegations`). The gateway is the only resource the module places in that subnet, so the delegation costs nothing that was available before.

A subnet supplied through `agic_subnet_id` belongs to the operator, so that path gets a `check` block: a plan-time warning naming the `az` command to add the delegation. Deliberately not a precondition, because a gateway created before Azure applied network isolation keeps running in an undelegated subnet and is not revalidated on later applies; failing the plan there would block unrelated work on a deployment that works.

Also updates the `agic_subnet_id` description and the AGIC section of `INGRESS_CONTROLLERS.md`.

## Also: service-managed endpoints on delegated subnets

Separate defect, folded in here because it lands on the same resources.

Azure's first-party principal `Azure Database for PostgreSQL Flexible Server Private Network Integration` (appId `93efed00-6552-4119-833a-422b297199f9`) performs a `subnets/write` on a delegated Postgres subnet a couple of minutes after the flexible server is injected, and adds a `Microsoft.Storage` service endpoint. Timeline from the `azzone-enqjj2-rg` activity log on 2026-08-20 (eastus2):

| 16:39:51 | subnet created |
| 16:41:06 | service association link written |
| 16:42:45 | `subnets/write` by the RP principal |

`azurerm_subnet.service_endpoints` is `Optional` and **not** `Computed` (provider v4.81.0), so a subnet that declares nothing asserts "no endpoints" rather than "don't care". Every subsequent plan therefore offers to strip the endpoint:

```
~ resource "azurerm_subnet" "subnet_postgres" {
    ~ service_endpoints = [
        - "Microsoft.Storage",
      ]
```

The provider sends the config value whenever `d.HasChange("service_endpoints")` fires, so an apply of that plan really does remove it, and the operator carries a permanent pending change in the meantime.

Fixed with `lifecycle { ignore_changes = [service_endpoints] }` on `subnet_postgres`, and the same on the newly delegated `subnet_agic`.

**Why not declare `service_endpoints = ["Microsoft.Storage"]`.** Declaring it makes Terraform *write* the endpoint onto every deployment that predates this behavior, which is a live subnet write against a delegated subnet holding a running server, to fix a cosmetic diff. `ignore_changes` is inert on those. It also states the truth: the property belongs to the service. Same pattern as `ignore_changes = [zone]` on the flexible server in `modules/postgres`.

**Rollout is uneven.** Across the eight VNets in the subscription, three older module-created `*-subnet-postgres` subnets with live `Ready` servers report `[]` (westus, eastus x2) while newer ones report `["Microsoft.Storage"]`. Region is not the variable; both eastus cases exist. Treat `[]` as pre-rollout, not as evidence the behavior is gone.

**The AGIC half is precautionary, not observed.** No delegated Application Gateway subnet exists live to inspect, and a subscription-wide activity-log sweep over the preceding six days showed only the two Postgres RP writes, nothing from an Application Gateway principal. The guard is there because the reasoning is identical (a delegated subnet's endpoints belong to the delegated service, and the gateway holds the subnet exclusively), not because the write has been seen. Worth confirming on the next live AGIC apply.

Other subnets were checked and are not exposed: `subnet_main` declares its endpoints and is undelegated, with live values matching config exactly; `subnet_redis` and `subnet_bastion` are undelegated, and every undelegated subnet in the sweep reported exactly what its config declared. A BYO Postgres subnet is read through `azapi` and never managed as an `azurerm_subnet`, so it cannot drift.

## Upgrade note

For an existing AGIC deployment this plans an in-place update of the subnet. Adding a delegation under a live gateway may be rejected by Azure, in which case the apply errors without destroying anything.

Do not add the delegation by hand as a workaround without this change: `azurerm_subnet` owns the delegation list, so the next plan removes it again.

The `ignore_changes` additions plan no changes on their own. On a deployment currently showing the `Microsoft.Storage` diff, that diff disappears.

## Verification

`terraform fmt -check -recursive` and `terraform validate` pass. Not yet exercised against a live AGIC apply.
