### PR TITLE
fix(aws): stop uninstall hanging on JuiceFS sandbox volumes

### DIFF
--- a/modules/aws/TEARDOWN.md
+++ b/modules/aws/TEARDOWN.md
@@ -75,6 +75,14 @@ cd aws/helm
 ./scripts/uninstall.sh
 ```
 
+**Sandboxes / JuiceFS:** the JuiceFS CSI driver is part of the LangSmith Helm release. Uninstalling the release before the JuiceFS PVCs leaves mount pods holding `juicefs.com/finalizer` with no controller left to clear it, so `kubectl delete` blocks past the grace period and never returns. `uninstall.sh` therefore deletes the sandbox-host workload and the JuiceFS claims first, while the driver is still running, and force-clears any pod still in `Terminating` afterwards.
+
+**In-cluster ClickHouse volumes:** `data-langsmith-clickhouse-*` is provisioned by the EBS CSI driver, so Terraform has no record of the volume. `uninstall.sh` keeps the claim by default, because uninstall is also the path to a clean Helm reinstall. When the cluster is going away, delete the claim during uninstall so the driver reclaims the volume — after `terraform destroy` the driver is gone and the EBS volume is orphaned:
+
+```bash
+DELETE_DATA_PVCS=true ./scripts/uninstall.sh
+```
+
 After the script completes:
 
 ```bash

--- a/modules/aws/helm/scripts/uninstall.sh
+++ b/modules/aws/helm/scripts/uninstall.sh
@@ -9,6 +9,12 @@
 # Resolves cluster name and region from terraform.tfvars + terraform output,
 # updates kubeconfig to target the right cluster, then removes the Helm release
 # and ESO resources.
+#
+# Phase 10 / sandboxes: JuiceFS CSI lives in the same Helm release as
+# sandbox-host. Deleting the release first leaves mount pods holding
+# juicefs.com/finalizer with no controller left to clear it, so kubectl
+# delete hangs forever. Tear down JuiceFS volumes while CSI is still up,
+# then force-clear any leftover finalizers after helm uninstall.
 set -euo pipefail
 export AWS_PAGER=""
 
@@ -19,6 +25,47 @@ source "$INFRA_DIR/scripts/_common.sh"
 
 RELEASE_NAME="${RELEASE_NAME:-langsmith}"
 NAMESPACE="${NAMESPACE:-langsmith}"
+DELETE_TIMEOUT="${DELETE_TIMEOUT:-120s}"
+# In-cluster ClickHouse holds trace data, so its claim is kept by default:
+# uninstall is also the path to a clean Helm reinstall on the same cluster.
+# Set to true when the cluster is going away, so the EBS CSI driver reclaims
+# the volume before terraform destroy removes the driver.
+DELETE_DATA_PVCS="${DELETE_DATA_PVCS:-false}"
+
+# Names of resources of type $1 whose name matches extended regex $2.
+# Resource names rather than labels: the sandbox-host workload is named
+# "sandbox-host" on some chart versions and "<release>-sandbox-host" on
+# others, and JuiceFS mount pods carry no chart labels at all.
+_names_matching() {
+  local _type="$1" _pattern="$2"
+  kubectl get "$_type" -n "$NAMESPACE" \
+    -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null \
+    | grep -Ei -- "$_pattern" || true
+}
+
+# Force-delete pods stuck in Terminating and strip the JuiceFS finalizer that
+# only the (now-removed) CSI controller would clear. Without this, kubectl
+# delete blocks past terminationGracePeriodSeconds with no way to finish.
+_force_clear_stuck_pods() {
+  local _pod
+  while IFS= read -r _pod; do
+    [[ -z "$_pod" ]] && continue
+    echo "  force-deleting pod $_pod"
+    kubectl patch pod "$_pod" -n "$NAMESPACE" \
+      --type=merge -p '{"metadata":{"finalizers":null}}' >/dev/null || true
+    kubectl delete pod "$_pod" -n "$NAMESPACE" \
+      --grace-period=0 --force --wait=false --ignore-not-found || true
+  done < <(
+    {
+      # Pods the API server has accepted a delete for but that never finish.
+      kubectl get pods -n "$NAMESPACE" \
+        -o jsonpath='{range .items[?(@.metadata.deletionTimestamp)]}{.metadata.name}{"\n"}{end}' \
+        2>/dev/null || true
+      # JuiceFS mount pods, which hold juicefs.com/finalizer.
+      _names_matching pods 'juicefs'
+    } | sort -u
+  )
+}
 
 # ── Resolve config from terraform.tfvars ──────────────────────────────────────
 if [[ ! -f "$INFRA_DIR/terraform.tfvars" ]]; then
@@ -62,6 +109,12 @@ echo "This will remove:"
 echo "  - Helm release '$RELEASE_NAME' from namespace '$NAMESPACE'"
 echo "  - ExternalSecret 'langsmith-config' from namespace '$NAMESPACE'"
 echo "  - ClusterSecretStore 'langsmith-ssm'"
+echo "  - JuiceFS / sandbox volumes (while CSI is still present)"
+if [[ "$DELETE_DATA_PVCS" == "true" ]]; then
+  echo "  - ClickHouse data PVCs — TRACE DATA IS DELETED (DELETE_DATA_PVCS=true)"
+else
+  echo "  - Keeps ClickHouse data PVCs (set DELETE_DATA_PVCS=true to delete)"
+fi
 echo ""
 printf "Proceed? [y/N] "
 read -r _confirm
@@ -69,6 +122,34 @@ if [[ "$_confirm" != "y" && "$_confirm" != "Y" ]]; then
   echo "Aborted."
   exit 0
 fi
+echo ""
+
+# ── Pre-Helm: tear down JuiceFS while CSI can still unmount ───────────────────
+# helm uninstall removes the JuiceFS CSI driver along with the release. A PVC
+# that mounts through that driver can then never be unmounted, because the
+# controller that clears juicefs.com/finalizer is gone. Drop the consumer and
+# the volume first, while the driver is still running.
+echo "Removing JuiceFS / sandbox volumes while CSI is still present..."
+_workload=""
+while IFS= read -r _workload; do
+  [[ -z "$_workload" ]] && continue
+  echo "  deleting $_workload"
+  kubectl delete "$_workload" -n "$NAMESPACE" \
+    --ignore-not-found --timeout="$DELETE_TIMEOUT" || true
+done < <(
+  {
+    _names_matching deployments 'sandbox-host' | sed 's|^|deployment/|'
+    _names_matching statefulsets 'sandbox-host' | sed 's|^|statefulset/|'
+  }
+)
+
+_pvc=""
+while IFS= read -r _pvc; do
+  [[ -z "$_pvc" ]] && continue
+  echo "  deleting PVC $_pvc"
+  kubectl delete pvc "$_pvc" -n "$NAMESPACE" \
+    --ignore-not-found --timeout="$DELETE_TIMEOUT" || true
+done < <(_names_matching pvc 'juicefs|smithbox')
 echo ""
 
 # ── Uninstall Helm release ────────────────────────────────────────────────────
@@ -90,14 +171,46 @@ echo ""
 # platform-backend creates agent-builder and LangGraph resources at runtime with
 # no Helm owner reference. Target only LangSmith resources by label so workloads
 # from other teams sharing this namespace are not affected.
+# Bounded by --timeout so a pod that cannot terminate does not block the run
+# indefinitely; anything left over is force-cleared below.
 echo "Removing operator-managed LangSmith resources from namespace '$NAMESPACE'..."
 kubectl delete deployments,services,pods,jobs,statefulsets,replicasets \
   -l "app.kubernetes.io/instance=${RELEASE_NAME}" \
-  -n "$NAMESPACE" --ignore-not-found
+  -n "$NAMESPACE" --ignore-not-found --timeout="$DELETE_TIMEOUT" || true
 # Operator-spawned agent deployment pods use a different label pattern
 kubectl delete deployments,pods \
   -l "langsmith.dev/managed-by=operator" \
-  -n "$NAMESPACE" --ignore-not-found 2>/dev/null || true
+  -n "$NAMESPACE" --ignore-not-found --timeout="$DELETE_TIMEOUT" 2>/dev/null || true
 echo ""
+
+echo "Clearing pods stuck in Terminating (JuiceFS finalizers)..."
+_force_clear_stuck_pods
+echo ""
+
+# ── Reclaim dynamically provisioned EBS before terraform destroy ──────────────
+# data-langsmith-clickhouse-* is provisioned by the EBS CSI driver, so Terraform
+# has no record of the volume. Destroying the cluster first leaves it billing
+# with nothing attached, because the driver that would reclaim it goes with the
+# cluster. Deleting the claim here is the only point where reclaim still works.
+_data_pvcs=$(_names_matching pvc 'clickhouse')
+if [[ -n "$_data_pvcs" ]]; then
+  if [[ "$DELETE_DATA_PVCS" == "true" ]]; then
+    echo "Deleting ClickHouse data PVCs (reclaims EBS while the CSI driver is alive)..."
+    while IFS= read -r _pvc; do
+      [[ -z "$_pvc" ]] && continue
+      echo "  deleting PVC $_pvc"
+      kubectl delete pvc "$_pvc" -n "$NAMESPACE" \
+        --ignore-not-found --timeout="$DELETE_TIMEOUT" || true
+    done <<< "$_data_pvcs"
+  else
+    echo "Keeping ClickHouse data PVCs (DELETE_DATA_PVCS is not true):"
+    echo "$_data_pvcs" | sed 's|^|  |'
+    echo "  These are dynamically provisioned EBS volumes that Terraform does not"
+    echo "  track. Before 'terraform destroy', delete them so the volumes are"
+    echo "  reclaimed instead of orphaned:"
+    echo "    DELETE_DATA_PVCS=true $0"
+  fi
+  echo ""
+fi
 
 echo "Uninstall complete."


### PR DESCRIPTION
## Problem
The JuiceFS CSI driver ships inside the LangSmith Helm release. `uninstall.sh`
ran `helm uninstall` first, which removed the controller that clears
`juicefs.com/finalizer` while `sandbox-host` still mounted a JuiceFS volume.
The kubelet could never finish the unmount, the pod stayed `Terminating` past
its 300s grace period, and the unbounded `kubectl delete pods` that followed
never returned. Observed on a v0.16 AWS end-to-end run with sandboxes enabled
(Phase 10); the events showed:
```
AttachVolume.Attach failed for volume "smithbox-juicefs-csi-host": timed 
out waiting for external-attacher of csi.juicefs.com CSI driver
```


Recovery needed manual `kubectl patch` to strip the finalizer plus a force
delete, otherwise teardown could not proceed and a bare-metal `m5d.metal` node
kept billing.

## Changes

1) Delete the `sandbox-host` workload and the JuiceFS / smithbox PVCs before
   `helm uninstall`, while the CSI driver can still unmount.
2) Bound the post-uninstall deletes with `--timeout` (`DELETE_TIMEOUT`,
   default `120s`) so a pod that cannot terminate no longer blocks the run.
3) Force-clear pods left in `Terminating`, stripping `juicefs.com/finalizer`
   when the controller is already gone.
4) Match workloads by name rather than by label, because the sandbox-host
   Deployment is `sandbox-host` on some chart versions and
   `<release>-sandbox-host` on others, and JuiceFS mount pods carry no chart
   labels.
5) Surface the in-cluster ClickHouse claim. `data-langsmith-clickhouse-*` is
   dynamically provisioned, so Terraform never sees the EBS volume and
   `destroy` orphans it. Deletion is opt-in via `DELETE_DATA_PVCS=true`
   because uninstall is also the path to a clean Helm reinstall; by default the
   script names the claims and prints how to reclaim them.
6) Document both traps in `modules/aws/TEARDOWN.md`.

No `jq` dependency was added: the repo treats `jq` as optional
(`setup-env.sh` has a pure-bash fallback), so this uses `kubectl` jsonpath.

## Test plan

- [x] `shellcheck -S warning` clean; `bash agents/check.sh --scripts` passes
      (61 scripts)
- [x] Verified against the live test EKS cluster: force-clearing the
      finalizer released the stuck pod, and the PV/PVC then cleared on their own
- [x] Deleting the ClickHouse PVC while the EBS CSI driver was alive reclaimed
      `vol-…` instead of orphaning it; `terraform destroy` then completed with
      125 resources removed and no orphaned ALB, volume, metal node or Redis