### PR TITLE
feat(azure): keyvault_manage_secrets to deploy without data-plane access

### DIFF
--- a/modules/azure/PERMISSIONS.md
+++ b/modules/azure/PERMISSIONS.md
@@ -66,7 +66,36 @@ The deployment creates the following assignments. Each one requires `Microsoft.A
 | `Network Contributor` | `4d97b98b-1d4f-4787-a291-c67834d212e7` | Virtual network | AGIC identity | `ingress_controller = "agic"` |
 | `Virtual Machine Administrator Login` | `1c0163c0-47e6-4577-8991-ea5c82e286e4` | Bastion VM | Operators | Bastion module is enabled |
 
-The Key Vault assignment to the deploying identity is self-granting: Terraform gives itself `Key Vault Secrets Officer` so that it can then write the application secrets through the Key Vault data plane. The vault runs in RBAC mode, so no access policy path exists as a fallback.
+The Key Vault assignment to the deploying identity is self-granting: Terraform gives itself `Key Vault Secrets Officer` so that it can then write `postgres-admin-password` and `langsmith-license-key` through the Key Vault data plane. The vault runs in RBAC mode, so no access policy path exists as a fallback. Set `keyvault_manage_secrets = false` to drop both writes and the grant they exist for, as below.
+
+## Deploy without Key Vault access
+
+Two settings take Key Vault out of the deploying identity's requirements:
+
+```hcl
+keyvault_manage_terraform_admin_assignment = false  # skip the self-grant
+keyvault_manage_secrets                    = false  # write no secrets
+```
+
+The first skips `Microsoft.Authorization/roleAssignments/write` on the vault, the second skips the data-plane writes that grant exists for. Apply then touches the vault's control plane only. `make seed-secrets` writes all nine secrets afterwards, under your own credentials rather than Terraform's, so it needs `Key Vault Secrets Officer` on the vault at that point and nothing earlier. Everything downstream is unchanged: `make k8s-secrets` still reads the vault to build `langsmith-config-secret`.
+
+This does not remove the deployment's need for `roleAssignments/write` altogether. `Storage Blob Data Contributor` on the storage account is not optional, because LangSmith pods need it at runtime, and it has no toggle. A deployer who holds no role-assignment rights at all still fails there.
+
+### Turning it off on a deployment that already applied
+
+Leaving `keyvault_manage_secrets` at its default needs no migration. Setting it to false afterwards does, because Terraform reads `count = 0` as "delete these two secrets from the vault", and every pod reading them breaks before soft delete makes that recoverable.
+
+Drop them from state first, which leaves the vault untouched. Read the addresses out of state rather than typing them, since they are un-indexed on deployments that last applied before this flag existed and indexed after:
+
+```bash
+terraform -chdir=infra state list | grep azurerm_key_vault_secret
+```
+
+```bash
+terraform -chdir=infra state rm '<address>'   # once per address listed
+```
+
+Then set the flag, and confirm `terraform plan` reports no change to the vault's secrets. `make seed-secrets` is write-once, so running it afterwards skips both and the vault keeps the values it already had.
 
 ## Restrict which roles the deployer can assign
 

--- a/modules/azure/PERMISSIONS.md
+++ b/modules/azure/PERMISSIONS.md
@@ -66,7 +66,7 @@ The deployment creates the following assignments. Each one requires `Microsoft.A
 | `Network Contributor` | `4d97b98b-1d4f-4787-a291-c67834d212e7` | Virtual network | AGIC identity | `ingress_controller = "agic"` |
 | `Virtual Machine Administrator Login` | `1c0163c0-47e6-4577-8991-ea5c82e286e4` | Bastion VM | Operators | Bastion module is enabled |
 
-The Key Vault assignment to the deploying identity is self-granting: Terraform gives itself `Key Vault Secrets Officer` so that it can then write `postgres-admin-password` and `langsmith-license-key` through the Key Vault data plane. The vault runs in RBAC mode, so no access policy path exists as a fallback. Set `keyvault_manage_secrets = false` to drop both writes and the grant they exist for, as below.
+The Key Vault assignment to the deploying identity is self-granting: Terraform gives itself `Key Vault Secrets Officer` so that it can then write `postgres-admin-password` and `langsmith-license-key` through the Key Vault data plane. The vault runs in RBAC mode, so no access policy path exists as a fallback. Set `keyvault_manage_secrets = false` to drop both writes, and `keyvault_manage_terraform_admin_assignment = false` alongside it to drop the grant they exist for, as below.
 
 ## Deploy without Key Vault access
 
@@ -83,9 +83,9 @@ This does not remove the deployment's need for `roleAssignments/write` altogethe
 
 ### Turning it off on a deployment that already applied
 
-Leaving `keyvault_manage_secrets` at its default needs no migration. Setting it to false afterwards does, because Terraform reads `count = 0` as "delete these two secrets from the vault", and every pod reading them breaks before soft delete makes that recoverable.
+Leaving `keyvault_manage_secrets` at its default needs no migration. Setting it to false afterwards does, because Terraform reads `count = 0` as "delete these two secrets from the vault". Nothing breaks at the moment of the delete, since no runtime path reads the vault — the failure surfaces later, when `make k8s-secrets` cannot read `langsmith-license-key` to build `langsmith-config-secret`. Soft delete keeps both recoverable for the vault's retention window.
 
-Drop them from state first, which leaves the vault untouched. Read the addresses out of state rather than typing them, since they are un-indexed on deployments that last applied before this flag existed and indexed after:
+Drop them from state first, which leaves the vault untouched. Read the addresses out of state rather than typing them: `postgres_admin_password` is un-indexed on deployments that last applied before this flag existed and `[0]` after, while `langsmith_license_key` carried a `count` already and is `[0]` either way:
 
 ```bash
 terraform -chdir=infra state list | grep azurerm_key_vault_secret

--- a/modules/azure/README.md
+++ b/modules/azure/README.md
@@ -110,7 +110,7 @@ Expect `Reader` on the gateway's resource group, `Contributor` on the Applicatio
 
 ### Deploying against an existing Key Vault
 
-Set `create_keyvault = false` to write LangSmith's secrets into a Key Vault the customer already owns. Terraform reads the vault, writes its nine secrets, and changes nothing else about it: the auth mode, network rules, retention, and purge protection stay as the vault's owner configured them, and `keyvault_default_action`, `keyvault_allowed_ips`, and `keyvault_purge_protection` are ignored.
+Set `create_keyvault = false` to write LangSmith's secrets into a Key Vault the customer already owns. Terraform reads the vault, writes the two secrets it manages, and changes nothing else about it: the auth mode, network rules, retention, and purge protection stay as the vault's owner configured them, and `keyvault_default_action`, `keyvault_allowed_ips`, and `keyvault_purge_protection` are ignored.
 
 ```hcl
 create_keyvault                       = false
@@ -130,7 +130,7 @@ az keyvault show --name <vault> --query "{rbac:properties.enableRbacAuthorizatio
 | Requirement | Why | Fix |
 |---|---|---|
 | Azure RBAC authorization, not access policies | Terraform grants access with `azurerm_role_assignment`, which grants nothing on an access-policy vault while the apply still reports success | Migrate the vault to RBAC or pick a different one. The plan fails naming this rather than applying |
-| Deployer already holds Key Vault Secrets Officer | Terraform writes the nine secrets through the data plane, and it does not create its own grant on a vault it doesn't own | Have the vault's owner grant it on the vault or its resource group before apply, or set `keyvault_manage_terraform_admin_assignment = true` if the deployer has `roleAssignments/write` on the vault |
+| Deployer already holds Key Vault Secrets Officer | Terraform writes `postgres-admin-password` and `langsmith-license-key` through the data plane, and it does not create its own grant on a vault it doesn't own | Have the vault's owner grant it on the vault or its resource group before apply, or set `keyvault_manage_terraform_admin_assignment = true` if the deployer has `roleAssignments/write` on the vault. Failing both, set `keyvault_manage_secrets = false`: apply then writes nothing to the vault, and whoever runs `make seed-secrets` afterwards needs the role instead of the apply identity |
 | Apply host's IP allowlisted, if the vault firewall is on | A vault with `default_action = Deny` accepts the role assignment and then rejects the secret writes partway through apply, with an error that reads nothing like a permissions error | Add the apply host's egress IP to the vault firewall, or add the AKS subnet with the `Microsoft.KeyVault` service endpoint |
 | Purge protection off, on any vault you intend to tear down | Destroying the deployment soft-deletes the nine secrets, reserving their names for the vault's retention window. Purging early needs a permission the deployer won't have on a vault someone else owns, so the next apply blocks until the window passes | Leave purge protection off on dev vaults |
 
@@ -448,7 +448,7 @@ Only two secrets reach Terraform, because Terraform needs them to build somethin
 
 Writes the LangSmith application secrets directly into Key Vault via `az`, after `make apply` has created the vault. These never pass through Terraform, so they never land in Terraform state — the same split the AWS module uses with SSM and the GCP module uses with Secret Manager.
 
-Seeds seven secrets:
+Seeds the seven secrets Terraform never sees:
 
 | Secret | Source |
 |---|---|
@@ -459,6 +459,8 @@ Seeds seven secrets:
 | `langsmith-agent-builder-encryption-key` | Generated (Fernet) |
 | `langsmith-insights-encryption-key` | Generated (Fernet) |
 | `langsmith-polly-encryption-key` | Generated (Fernet) |
+
+It also seeds `postgres-admin-password` and `langsmith-license-key`, from `secrets.auto.tfvars` or the environment, when the vault does not already hold them. That is what `keyvault_manage_secrets = false` relies on. On the default path Terraform wrote both and the script skips them.
 
 - **Write-once.** An existing secret is never overwritten, so the script is safe to re-run and seeds only what is missing. Rotating any of these breaks a running deployment: a new API key salt invalidates every API key, a new JWT secret drops every session, a new Fernet key makes existing encrypted data unreadable. Rotate deliberately with `make keyvault` instead.
 - **Validates the admin password before storing it:** min 12 characters, with a lowercase letter, an uppercase letter, and a symbol from ``!#$%()+,-./:?@[\]^_{~}``. The Helm chart's auth-bootstrap job rejects a password without a symbol, and it fails ~10 minutes into the release rather than at the point you typed it.

--- a/modules/azure/TROUBLESHOOTING.md
+++ b/modules/azure/TROUBLESHOOTING.md
@@ -414,7 +414,7 @@ Failure responding to request: StatusCode=403 -- Original Error: autorest/azure:
 Service returned an error. Status=403 Code="Forbidden"
 ```
 
-`make seed-secrets` fails the same way and for the same reasons, reported by `az` as `(Forbidden) Caller is not authorized`. It writes the seven app secrets over the data plane too.
+`make seed-secrets` fails the same way and for the same reasons, reported by `az` as `(Forbidden) Caller is not authorized`. It writes all nine secrets over the data plane too.
 
 **Cause:** one of three, and the 403 looks the same for all of them. Read the message body: a network denial names `ForbiddenByFirewall` or client address, an authorization denial names the caller and action.
 
@@ -444,12 +444,12 @@ az role assignment create --role "Key Vault Secrets Officer" \
 az keyvault secret list --vault-name <vault> --query "length(@)"
 ```
 
-**Fix, or take Terraform out of the data plane entirely:**
+**Fix for causes 2 and 3 — take Terraform out of the data plane entirely:**
 ```hcl
 keyvault_manage_secrets = false
 ```
 
-Terraform then writes no secrets, so none of the three causes above can stop an apply. `make seed-secrets` writes all nine afterwards under your own credentials, which is a step you can retry in seconds instead of 10 minutes into an apply. On a deployment that already applied, drop the two secrets from state first or Terraform deletes them from the vault. See [PERMISSIONS.md](PERMISSIONS.md#deploy-without-key-vault-access).
+Terraform then writes no secrets, so neither a missing grant nor an unpropagated one can stop an apply. `make seed-secrets` writes all nine afterwards under your own credentials, which is a step you can retry in seconds instead of 10 minutes into an apply. This does nothing for cause 1: the script reaches the same data plane from the same host, so a firewall that denies the apply host denies the script too, and the allowlisting above is still the fix. On a deployment that already applied, drop the two secrets from state first or Terraform deletes them from the vault. See [PERMISSIONS.md](PERMISSIONS.md#deploy-without-key-vault-access).
 
 **Prevention:** run through the prerequisites table in the README's "Deploying against an existing Key Vault" section before applying. All three of these are checkable in advance, and the apply is 10+ minutes in by the time the secret writes run.
 

--- a/modules/azure/TROUBLESHOOTING.md
+++ b/modules/azure/TROUBLESHOOTING.md
@@ -388,6 +388,18 @@ terraform -chdir=infra import \
   'module.keyvault.azurerm_role_assignment.terraform_kv_admin' "$RA_ID"
 ```
 
+Or take Terraform out of the vault's data plane, which removes the reason that grant exists:
+
+```hcl
+# terraform.tfvars
+keyvault_manage_terraform_admin_assignment = false
+keyvault_manage_secrets                    = false
+```
+
+Apply then touches only the vault's control plane, and `make seed-secrets` writes all nine secrets afterwards under your own credentials. This is the one route that needs no Key Vault role on the deployer, inherited or otherwise. Both flags are required together: the first is what stops the request the condition rejects, and the second is what makes the role that request was asking for unnecessary. See [PERMISSIONS.md](PERMISSIONS.md#deploy-without-key-vault-access).
+
+It does not reduce the deployment's need for `roleAssignments/write`. The other seven assignments still run, so a subscription that delegates none of them fails at `Storage Blob Data Contributor` in the storage module instead.
+
 **Note:** on versions predating the `principal_type` declarations, the first failure came earlier, on `module.blob.azurerm_role_assignment.blob_data_contributor`. Every role assignment in the module was affected.
 
 ---

--- a/modules/azure/TROUBLESHOOTING.md
+++ b/modules/azure/TROUBLESHOOTING.md
@@ -327,6 +327,8 @@ already exists - to be managed via Terraform this resource needs to be imported 
 
 **Cause:** Something wrote the secret to Key Vault outside Terraform, or the state file lost the resource. This can only happen for the two secrets Terraform still manages — `postgres-admin-password` and `langsmith-license-key`. The seven LangSmith app secrets are written by `make seed-secrets` and have no Terraform resource, so they never produce this error.
 
+Seeding is the usual way in: `make seed-secrets` writes both of these too, so running it against a deployment that has not applied yet leaves Terraform to collide with what the script wrote. Setting `keyvault_manage_secrets = false` is the other resolution, and it makes the collision impossible rather than importing past it.
+
 **Fix:** Import the conflicting secret, then re-run apply:
 ```bash
 terraform -chdir=infra import \
@@ -429,6 +431,13 @@ az role assignment create --role "Key Vault Secrets Officer" \
 # 3. Propagation — confirm data-plane access directly, then re-run apply
 az keyvault secret list --vault-name <vault> --query "length(@)"
 ```
+
+**Fix, or take Terraform out of the data plane entirely:**
+```hcl
+keyvault_manage_secrets = false
+```
+
+Terraform then writes no secrets, so none of the three causes above can stop an apply. `make seed-secrets` writes all nine afterwards under your own credentials, which is a step you can retry in seconds instead of 10 minutes into an apply. On a deployment that already applied, drop the two secrets from state first or Terraform deletes them from the vault. See [PERMISSIONS.md](PERMISSIONS.md#deploy-without-key-vault-access).
 
 **Prevention:** run through the prerequisites table in the README's "Deploying against an existing Key Vault" section before applying. All three of these are checkable in advance, and the apply is 10+ minutes in by the time the secret writes run.
 

--- a/modules/azure/infra/main.tf
+++ b/modules/azure/infra/main.tf
@@ -808,10 +808,8 @@ module "keyvault" {
   # Only the two Terraform already holds in state for another reason. The
   # LangSmith app secrets are written to the vault post-apply by
   # scripts/seed-keyvault-secrets.sh and never pass through Terraform.
-  #
-  # keyvault_manage_secrets = false drops those two as well, leaving apply with
-  # no Key Vault data-plane access to need at all. The seed script writes all
-  # nine, so nothing downstream changes.
+  # keyvault_manage_secrets = false drops those two too; the seed script then
+  # writes all nine.
   manage_secrets          = var.keyvault_manage_secrets
   postgres_admin_password = var.postgres_admin_password
   langsmith_license_key   = var.langsmith_license_key

--- a/modules/azure/infra/main.tf
+++ b/modules/azure/infra/main.tf
@@ -808,6 +808,11 @@ module "keyvault" {
   # Only the two Terraform already holds in state for another reason. The
   # LangSmith app secrets are written to the vault post-apply by
   # scripts/seed-keyvault-secrets.sh and never pass through Terraform.
+  #
+  # keyvault_manage_secrets = false drops those two as well, leaving apply with
+  # no Key Vault data-plane access to need at all. The seed script writes all
+  # nine, so nothing downstream changes.
+  manage_secrets          = var.keyvault_manage_secrets
   postgres_admin_password = var.postgres_admin_password
   langsmith_license_key   = var.langsmith_license_key
 

--- a/modules/azure/infra/modules/keyvault/main.tf
+++ b/modules/azure/infra/modules/keyvault/main.tf
@@ -173,8 +173,8 @@ resource "azurerm_role_assignment" "managed_identity_kv_reader" {
 # Only the deployer's grant is worth waiting on, because the secret writes below
 # are what would 403 without it. The managed-identity grant is read at runtime by
 # pods that start long after this apply, and an access grant that came from
-# outside this apply propagated long ago. With manage_secrets = false there are
-# no writes to wait for either way.
+# outside this apply propagated long ago. manage_secrets = false leaves no
+# writes to wait for either way.
 
 resource "time_sleep" "wait_for_rbac" {
   count = var.manage_terraform_admin_assignment && var.manage_secrets ? 1 : 0
@@ -197,12 +197,10 @@ resource "time_sleep" "wait_for_rbac" {
 # vault by infra/scripts/seed-keyvault-secrets.sh after apply — matching how the
 # AWS module writes SSM and the GCP module writes Secret Manager.
 #
-# var.manage_secrets = false writes neither, which is what gets a deployment
-# through where the deployer holds no Key Vault data-plane access. Apply then
-# touches only the vault's control plane, and seed-keyvault-secrets.sh writes all
-# nine secrets afterwards. Flipping it on a deployment that already applied
-# deletes both secrets from the vault: drop them from state with
-# `terraform state rm` first. See PERMISSIONS.md.
+# var.manage_secrets = false writes neither, for a deployer with no Key Vault
+# data-plane access; seed-keyvault-secrets.sh writes all nine afterwards.
+# Flipping it on a live deployment deletes both from the vault — `terraform
+# state rm` them first. See PERMISSIONS.md.
 #
 # Naming convention: kebab-case, matching the TF variable names.
 # Scripts read these by name: az keyvault secret show --name <name>

--- a/modules/azure/infra/modules/keyvault/main.tf
+++ b/modules/azure/infra/modules/keyvault/main.tf
@@ -173,10 +173,11 @@ resource "azurerm_role_assignment" "managed_identity_kv_reader" {
 # Only the deployer's grant is worth waiting on, because the secret writes below
 # are what would 403 without it. The managed-identity grant is read at runtime by
 # pods that start long after this apply, and an access grant that came from
-# outside this apply propagated long ago.
+# outside this apply propagated long ago. With manage_secrets = false there are
+# no writes to wait for either way.
 
 resource "time_sleep" "wait_for_rbac" {
-  count = var.manage_terraform_admin_assignment ? 1 : 0
+  count = var.manage_terraform_admin_assignment && var.manage_secrets ? 1 : 0
 
   create_duration = "30s"
   depends_on      = [azurerm_role_assignment.terraform_kv_admin]
@@ -196,10 +197,19 @@ resource "time_sleep" "wait_for_rbac" {
 # vault by infra/scripts/seed-keyvault-secrets.sh after apply — matching how the
 # AWS module writes SSM and the GCP module writes Secret Manager.
 #
+# var.manage_secrets = false writes neither, which is what gets a deployment
+# through where the deployer holds no Key Vault data-plane access. Apply then
+# touches only the vault's control plane, and seed-keyvault-secrets.sh writes all
+# nine secrets afterwards. Flipping it on a deployment that already applied
+# deletes both secrets from the vault: drop them from state with
+# `terraform state rm` first. See PERMISSIONS.md.
+#
 # Naming convention: kebab-case, matching the TF variable names.
 # Scripts read these by name: az keyvault secret show --name <name>
 
 resource "azurerm_key_vault_secret" "postgres_admin_password" {
+  count = var.manage_secrets ? 1 : 0
+
   name         = "postgres-admin-password"
   value        = var.postgres_admin_password
   key_vault_id = local.vault_id
@@ -210,7 +220,7 @@ resource "azurerm_key_vault_secret" "postgres_admin_password" {
 }
 
 resource "azurerm_key_vault_secret" "langsmith_license_key" {
-  count        = var.langsmith_license_key != "" ? 1 : 0
+  count        = var.manage_secrets && var.langsmith_license_key != "" ? 1 : 0
   name         = "langsmith-license-key"
   value        = var.langsmith_license_key
   key_vault_id = local.vault_id

--- a/modules/azure/infra/modules/keyvault/removed.tf
+++ b/modules/azure/infra/modules/keyvault/removed.tf
@@ -72,3 +72,26 @@ removed {
     destroy = false
   }
 }
+
+# ══════════════════════════════════════════════════════════════════════════════
+# State migration: both remaining secrets gained `count`
+#
+# postgres_admin_password and langsmith_license_key are now gated by
+# var.manage_secrets, which makes their state addresses indexed. Deployments that
+# applied before this change hold them at the un-indexed address, and without
+# these `moved` blocks Terraform plans a destroy-then-create against the vault on
+# the next apply — on the default path, where nothing about the deployment has
+# changed at all.
+#
+# Safe to delete once every deployment has applied once on this version.
+# ══════════════════════════════════════════════════════════════════════════════
+
+moved {
+  from = azurerm_key_vault_secret.postgres_admin_password
+  to   = azurerm_key_vault_secret.postgres_admin_password[0]
+}
+
+moved {
+  from = azurerm_key_vault_secret.langsmith_license_key
+  to   = azurerm_key_vault_secret.langsmith_license_key[0]
+}

--- a/modules/azure/infra/modules/keyvault/removed.tf
+++ b/modules/azure/infra/modules/keyvault/removed.tf
@@ -74,14 +74,16 @@ removed {
 }
 
 # ══════════════════════════════════════════════════════════════════════════════
-# State migration: both remaining secrets gained `count`
+# State migration: postgres_admin_password gained `count`
 #
-# postgres_admin_password and langsmith_license_key are now gated by
-# var.manage_secrets, which makes their state addresses indexed. Deployments that
-# applied before this change hold them at the un-indexed address, and without
-# these `moved` blocks Terraform plans a destroy-then-create against the vault on
-# the next apply — on the default path, where nothing about the deployment has
-# changed at all.
+# The secret is now gated by var.manage_secrets, which makes its state address
+# indexed. Deployments that applied before this change hold it at the un-indexed
+# address, and without this `moved` block Terraform plans a destroy-then-create
+# against the vault on the next apply — on the default path, where nothing about
+# the deployment has changed at all.
+#
+# langsmith_license_key needs no equivalent: it carried a `count` already, so it
+# has always been stored at [0] and only the count expression changed.
 #
 # Safe to delete once every deployment has applied once on this version.
 # ══════════════════════════════════════════════════════════════════════════════
@@ -89,9 +91,4 @@ removed {
 moved {
   from = azurerm_key_vault_secret.postgres_admin_password
   to   = azurerm_key_vault_secret.postgres_admin_password[0]
-}
-
-moved {
-  from = azurerm_key_vault_secret.langsmith_license_key
-  to   = azurerm_key_vault_secret.langsmith_license_key[0]
 }

--- a/modules/azure/infra/modules/keyvault/removed.tf
+++ b/modules/azure/infra/modules/keyvault/removed.tf
@@ -76,14 +76,10 @@ removed {
 # ══════════════════════════════════════════════════════════════════════════════
 # State migration: postgres_admin_password gained `count`
 #
-# The secret is now gated by var.manage_secrets, which makes its state address
-# indexed. Deployments that applied before this change hold it at the un-indexed
-# address, and without this `moved` block Terraform plans a destroy-then-create
-# against the vault on the next apply — on the default path, where nothing about
-# the deployment has changed at all.
-#
-# langsmith_license_key needs no equivalent: it carried a `count` already, so it
-# has always been stored at [0] and only the count expression changed.
+# var.manage_secrets makes its state address indexed. Without this `moved` block,
+# deployments that applied earlier plan a destroy-then-create on an upgrade that
+# changes nothing else. langsmith_license_key had a `count` already, so it needs
+# no equivalent.
 #
 # Safe to delete once every deployment has applied once on this version.
 # ══════════════════════════════════════════════════════════════════════════════

--- a/modules/azure/infra/modules/keyvault/variables.tf
+++ b/modules/azure/infra/modules/keyvault/variables.tf
@@ -84,7 +84,7 @@ variable "purge_protection_enabled" {
 
 variable "network_default_action" {
   type        = string
-  description = "Default action for the Key Vault data-plane firewall. \"Allow\" (default) keeps the starter UX working — Terraform's first apply creates ~10 secrets via the data plane and \"Deny\" without operator IP allowlisting blocks that. Production deployments set \"Deny\" and populate allowed_ips / allowed_subnet_ids."
+  description = "Default action for the Key Vault data-plane firewall. \"Allow\" (default) keeps the starter UX working — apply and seed-keyvault-secrets.sh write nine secrets via the data plane, and \"Deny\" without operator IP allowlisting blocks that. Production deployments set \"Deny\" and populate allowed_ips / allowed_subnet_ids."
   default     = "Allow"
 
   validation {
@@ -109,6 +109,12 @@ variable "allowed_subnet_ids" {
 # Only secrets Terraform already holds for another reason. The LangSmith app
 # secrets are seeded post-apply by infra/scripts/seed-keyvault-secrets.sh so
 # they never land in Terraform state.
+
+variable "manage_secrets" {
+  type        = bool
+  description = "Whether this module writes its two secrets into the vault. False writes neither, so apply touches only the vault's control plane and needs no Key Vault data-plane access at all: seed-keyvault-secrets.sh writes all nine secrets afterwards under the operator's own credentials. Set it where the deployer cannot hold Key Vault Secrets Officer, or where the vault firewall denies the machine running apply. Flipping it to false on a deployment that already applied deletes both secrets from the vault, so drop them from state with `terraform state rm` first."
+  default     = true
+}
 
 variable "postgres_admin_password" {
   type        = string

--- a/modules/azure/infra/scripts/seed-keyvault-secrets.sh
+++ b/modules/azure/infra/scripts/seed-keyvault-secrets.sh
@@ -34,13 +34,10 @@ set -euo pipefail
 # and the GCP module (writes Secret Manager). Terraform owns only the vault and
 # its RBAC.
 #
-# postgres-admin-password and langsmith-license-key are Terraform's, and it
-# writes them itself on the default path. They are seeded here for
-# keyvault_manage_secrets = false, where the deployer holds no Key Vault
-# data-plane access and apply left them out. Write-once means the default path
-# just skips them, so both paths end with the same nine secrets in the vault.
-# They are seeded last, after the seven above, so a value this script cannot
-# resolve never costs the seven that nothing else writes.
+# postgres-admin-password and langsmith-license-key are Terraform's on the
+# default path, and seeded here for keyvault_manage_secrets = false, where apply
+# left them out. Write-once means both paths end with the same nine. They go
+# last, so a value this script cannot resolve never costs the seven above.
 #
 # WRITE-ONCE: an existing secret is never overwritten. Rotating any of these
 # breaks running deployments — a new API key salt invalidates every API key, a
@@ -204,15 +201,12 @@ _seed "langsmith-polly-encryption-key" "$(_gen_fernet)" \
   "component=polly stability=critical module=seed-script"
 
 # ── Terraform's two secrets ───────────────────────────────────────────────────
-# Present already on the default path, so these are skips. On the
-# keyvault_manage_secrets = false path they are missing and get written here from
-# the same values that fed terraform apply, so the vault ends up with identical
-# contents either way. langsmith-license-key matters most: create-k8s-secrets.sh
-# reads it out of the vault to build langsmith-config-secret.
+# Skips on the default path; written here when keyvault_manage_secrets = false
+# left them out. create-k8s-secrets.sh needs langsmith-license-key to build
+# langsmith-config-secret.
 #
-# Seeded last on purpose. Resolving either value can fail — secrets.auto.tfvars
-# is gitignored and does not survive a tag checkout — and this script is the only
-# writer of the seven secrets above, so a failure here must not cost them.
+# Last on purpose: resolving either value can fail (secrets.auto.tfvars is
+# gitignored), and nothing else writes the seven above.
 
 _pg_password="${LANGSMITH_PG_PASSWORD:-${TF_VAR_postgres_admin_password:-}}"
 if [[ -z "$_pg_password" ]]; then
@@ -224,9 +218,8 @@ if [[ -z "$_license_key" ]]; then
   _license_key=$(_parse_tfvar_quoted langsmith_license_key "secrets.auto.tfvars") || _license_key=""
 fi
 
-# No license key is a configuration the module supports — the Terraform resource
-# carries the same guard, and k8s-bootstrap skips its langsmith-license secret to
-# match — so an empty value skips here rather than failing the run.
+# No license key is supported: the Terraform resource and k8s-bootstrap carry the
+# same guard. Skip rather than fail.
 if _kv_exists "langsmith-license-key"; then
   echo -e "  ${DIM}skip${NC}  langsmith-license-key ${DIM}(already set)${NC}"
 elif [[ -n "$_license_key" ]]; then

--- a/modules/azure/infra/scripts/seed-keyvault-secrets.sh
+++ b/modules/azure/infra/scripts/seed-keyvault-secrets.sh
@@ -19,8 +19,8 @@ set -euo pipefail
 #     granted it out of band instead)
 #
 # What this seeds:
-#   postgres-admin-password                  — from secrets.auto.tfvars
-#   langsmith-license-key                    — from secrets.auto.tfvars
+#   postgres-admin-password                  — from secrets.auto.tfvars or the env
+#   langsmith-license-key                    — same, and skipped when unset
 #   langsmith-admin-password                 — prompted, or $LANGSMITH_ADMIN_PASSWORD
 #   langsmith-api-key-salt                   — generated
 #   langsmith-jwt-secret                     — generated
@@ -34,11 +34,13 @@ set -euo pipefail
 # and the GCP module (writes Secret Manager). Terraform owns only the vault and
 # its RBAC.
 #
-# The first two are Terraform's, and it writes them itself on the default path.
-# They are seeded here for keyvault_manage_secrets = false, where the deployer
-# holds no Key Vault data-plane access and apply left them out. Write-once means
-# the default path just skips them, so both paths end with the same nine secrets
-# in the vault.
+# postgres-admin-password and langsmith-license-key are Terraform's, and it
+# writes them itself on the default path. They are seeded here for
+# keyvault_manage_secrets = false, where the deployer holds no Key Vault
+# data-plane access and apply left them out. Write-once means the default path
+# just skips them, so both paths end with the same nine secrets in the vault.
+# They are seeded last, after the seven above, so a value this script cannot
+# resolve never costs the seven that nothing else writes.
 #
 # WRITE-ONCE: an existing secret is never overwritten. Rotating any of these
 # breaks running deployments — a new API key salt invalidates every API key, a
@@ -150,33 +152,6 @@ _gen_b64() {
 
 echo "  Seeding..."
 
-# ── Terraform's two secrets ───────────────────────────────────────────────────
-# Present already on the default path, so these are skips. On the
-# keyvault_manage_secrets = false path they are missing and get written here from
-# the same secrets.auto.tfvars that fed terraform apply, so the vault ends up
-# with identical contents either way. langsmith-license-key matters most:
-# create-k8s-secrets.sh reads it out of the vault to build
-# langsmith-config-secret.
-
-_pg_password="${LANGSMITH_PG_PASSWORD:-}"
-if [[ -z "$_pg_password" ]]; then
-  _pg_password=$(_parse_tfvar_quoted postgres_admin_password "secrets.auto.tfvars") || _pg_password=""
-fi
-
-_license_key="${LANGSMITH_LICENSE_KEY:-}"
-if [[ -z "$_license_key" ]]; then
-  _license_key=$(_parse_tfvar_quoted langsmith_license_key "secrets.auto.tfvars") || _license_key=""
-fi
-
-_seed "postgres-admin-password" "$_pg_password" \
-  "component=postgres module=seed-script" \
-  "Set LANGSMITH_PG_PASSWORD, or re-run ./setup-env.sh to write secrets.auto.tfvars."
-_seed "langsmith-license-key" "$_license_key" \
-  "component=langsmith module=seed-script" \
-  "Set LANGSMITH_LICENSE_KEY, or re-run ./setup-env.sh to write secrets.auto.tfvars."
-
-unset _pg_password _license_key
-
 # ── LangSmith admin password ──────────────────────────────────────────────────
 
 if _kv_exists "langsmith-admin-password"; then
@@ -227,6 +202,45 @@ _seed "langsmith-insights-encryption-key" "$(_gen_fernet)" \
   "component=insights stability=critical module=seed-script"
 _seed "langsmith-polly-encryption-key" "$(_gen_fernet)" \
   "component=polly stability=critical module=seed-script"
+
+# ── Terraform's two secrets ───────────────────────────────────────────────────
+# Present already on the default path, so these are skips. On the
+# keyvault_manage_secrets = false path they are missing and get written here from
+# the same values that fed terraform apply, so the vault ends up with identical
+# contents either way. langsmith-license-key matters most: create-k8s-secrets.sh
+# reads it out of the vault to build langsmith-config-secret.
+#
+# Seeded last on purpose. Resolving either value can fail — secrets.auto.tfvars
+# is gitignored and does not survive a tag checkout — and this script is the only
+# writer of the seven secrets above, so a failure here must not cost them.
+
+_pg_password="${LANGSMITH_PG_PASSWORD:-${TF_VAR_postgres_admin_password:-}}"
+if [[ -z "$_pg_password" ]]; then
+  _pg_password=$(_parse_tfvar_quoted postgres_admin_password "secrets.auto.tfvars") || _pg_password=""
+fi
+
+_license_key="${LANGSMITH_LICENSE_KEY:-${TF_VAR_langsmith_license_key:-}}"
+if [[ -z "$_license_key" ]]; then
+  _license_key=$(_parse_tfvar_quoted langsmith_license_key "secrets.auto.tfvars") || _license_key=""
+fi
+
+# No license key is a configuration the module supports — the Terraform resource
+# carries the same guard, and k8s-bootstrap skips its langsmith-license secret to
+# match — so an empty value skips here rather than failing the run.
+if _kv_exists "langsmith-license-key"; then
+  echo -e "  ${DIM}skip${NC}  langsmith-license-key ${DIM}(already set)${NC}"
+elif [[ -n "$_license_key" ]]; then
+  _seed "langsmith-license-key" "$_license_key" \
+    "component=langsmith module=seed-script"
+else
+  echo -e "  ${DIM}skip${NC}  langsmith-license-key ${DIM}(no value configured)${NC}"
+fi
+
+_seed "postgres-admin-password" "$_pg_password" \
+  "component=postgres module=seed-script" \
+  "Set LANGSMITH_PG_PASSWORD, or re-run ./setup-env.sh to write secrets.auto.tfvars."
+
+unset _pg_password _license_key
 
 echo ""
 echo "  Done."

--- a/modules/azure/infra/scripts/seed-keyvault-secrets.sh
+++ b/modules/azure/infra/scripts/seed-keyvault-secrets.sh
@@ -14,9 +14,13 @@ set -euo pipefail
 # Prerequisites:
 #   - terraform apply complete (the Key Vault exists)
 #   - az login with a principal holding "Key Vault Secrets Officer" on the vault
-#     (terraform apply grants this to the deployer identity)
+#     (terraform apply grants this to the deployer identity, unless
+#     keyvault_manage_terraform_admin_assignment = false, where a tenant admin
+#     granted it out of band instead)
 #
 # What this seeds:
+#   postgres-admin-password                  — from secrets.auto.tfvars
+#   langsmith-license-key                    — from secrets.auto.tfvars
 #   langsmith-admin-password                 — prompted, or $LANGSMITH_ADMIN_PASSWORD
 #   langsmith-api-key-salt                   — generated
 #   langsmith-jwt-secret                     — generated
@@ -25,9 +29,16 @@ set -euo pipefail
 #   langsmith-insights-encryption-key        — generated (Fernet)
 #   langsmith-polly-encryption-key           — generated (Fernet)
 #
-# These are deliberately NOT Terraform-managed: Terraform would persist their
-# plaintext in state. This mirrors the AWS module (writes SSM) and the GCP
-# module (writes Secret Manager). Terraform owns only the vault and its RBAC.
+# The seven LangSmith secrets are deliberately NOT Terraform-managed: Terraform
+# would persist their plaintext in state. This mirrors the AWS module (writes SSM)
+# and the GCP module (writes Secret Manager). Terraform owns only the vault and
+# its RBAC.
+#
+# The first two are Terraform's, and it writes them itself on the default path.
+# They are seeded here for keyvault_manage_secrets = false, where the deployer
+# holds no Key Vault data-plane access and apply left them out. Write-once means
+# the default path just skips them, so both paths end with the same nine secrets
+# in the vault.
 #
 # WRITE-ONCE: an existing secret is never overwritten. Rotating any of these
 # breaks running deployments — a new API key salt invalidates every API key, a
@@ -102,10 +113,11 @@ _kv_set() {
   trap - EXIT INT TERM
 }
 
-# _seed <secret-name> <value> <tags>
-# Skips if the secret already exists. Never overwrites.
+# _seed <secret-name> <value> <tags> [hint]
+# Skips if the secret already exists. Never overwrites. <hint> is printed when
+# the value is empty, for the secrets this script does not generate itself.
 _seed() {
-  local secret_name="$1" secret_value="$2" tags="$3"
+  local secret_name="$1" secret_value="$2" tags="$3" hint="${4:-}"
 
   if _kv_exists "$secret_name"; then
     echo -e "  ${DIM}skip${NC}  $secret_name ${DIM}(already set)${NC}"
@@ -114,6 +126,9 @@ _seed() {
 
   if [[ -z "$secret_value" ]]; then
     echo -e "  ${RED}fail${NC}  $secret_name (empty value)" >&2
+    if [[ -n "$hint" ]]; then
+      echo "        $hint" >&2
+    fi
     return 1
   fi
 
@@ -134,6 +149,35 @@ _gen_b64() {
 # ── Seed ───────────────────────────────────────────────────────────────────────
 
 echo "  Seeding..."
+
+# ── Terraform's two secrets ───────────────────────────────────────────────────
+# Present already on the default path, so these are skips. On the
+# keyvault_manage_secrets = false path they are missing and get written here from
+# the same secrets.auto.tfvars that fed terraform apply, so the vault ends up
+# with identical contents either way. langsmith-license-key matters most:
+# create-k8s-secrets.sh reads it out of the vault to build
+# langsmith-config-secret.
+
+_pg_password="${LANGSMITH_PG_PASSWORD:-}"
+if [[ -z "$_pg_password" ]]; then
+  _pg_password=$(_parse_tfvar_quoted postgres_admin_password "secrets.auto.tfvars") || _pg_password=""
+fi
+
+_license_key="${LANGSMITH_LICENSE_KEY:-}"
+if [[ -z "$_license_key" ]]; then
+  _license_key=$(_parse_tfvar_quoted langsmith_license_key "secrets.auto.tfvars") || _license_key=""
+fi
+
+_seed "postgres-admin-password" "$_pg_password" \
+  "component=postgres module=seed-script" \
+  "Set LANGSMITH_PG_PASSWORD, or re-run ./setup-env.sh to write secrets.auto.tfvars."
+_seed "langsmith-license-key" "$_license_key" \
+  "component=langsmith module=seed-script" \
+  "Set LANGSMITH_LICENSE_KEY, or re-run ./setup-env.sh to write secrets.auto.tfvars."
+
+unset _pg_password _license_key
+
+# ── LangSmith admin password ──────────────────────────────────────────────────
 
 if _kv_exists "langsmith-admin-password"; then
   echo -e "  ${DIM}skip${NC}  langsmith-admin-password ${DIM}(already set)${NC}"

--- a/modules/azure/infra/variables.tf
+++ b/modules/azure/infra/variables.tf
@@ -131,6 +131,12 @@ variable "keyvault_manage_managed_identity_assignment" {
   default     = null
 }
 
+variable "keyvault_manage_secrets" {
+  type        = bool
+  description = "Whether Terraform writes postgres-admin-password and langsmith-license-key into the vault. False writes neither, so apply needs no Key Vault data-plane access at all and `make seed-secrets` writes all nine secrets afterwards under your own credentials. Set it where the deployer cannot hold Key Vault Secrets Officer, or where keyvault_default_action = \"Deny\" blocks the machine running apply. Flipping it to false on a deployment that already applied deletes both secrets from the vault, so drop them from state first. See PERMISSIONS.md."
+  default     = true
+}
+
 variable "keyvault_purge_protection" {
   type        = bool
   description = "Enable purge protection on Key Vault. Set false for dev environments where you need to destroy and recreate. Always true for production."
@@ -139,7 +145,7 @@ variable "keyvault_purge_protection" {
 
 variable "keyvault_default_action" {
   type        = string
-  description = "Default action for the Key Vault data-plane firewall. \"Allow\" (default) keeps the starter UX working — first apply creates ~10 secrets via the data plane and \"Deny\" without operator IP allowlisting blocks that. Production deployments set \"Deny\" and populate keyvault_allowed_ips."
+  description = "Default action for the Key Vault data-plane firewall. \"Allow\" (default) keeps the starter UX working — apply and `make seed-secrets` write nine secrets via the data plane, and \"Deny\" without operator IP allowlisting blocks that. Production deployments set \"Deny\" and populate keyvault_allowed_ips."
   default     = "Allow"
 
   validation {


### PR DESCRIPTION
## Problem

Terraform wrote two of the vault's nine secrets, `postgres-admin-password` and `langsmith-license-key`, which made `Key Vault Secrets Officer` on the vault a hard requirement of `terraform apply`. A deployer whose subscription will not delegate that role, or whose vault firewall denies the host running apply, had no way through. This came out of a live customer deployment that could create the vault and could create secrets by hand in the portal, but could not get apply past the data plane.

## Change

`keyvault_manage_secrets = false` gates both writes with `count`, leaving apply on the vault's control plane only.

`seed-keyvault-secrets.sh` now seeds those two as well, write-once from `secrets.auto.tfvars`, `LANGSMITH_*`, or `TF_VAR_*`, so both paths leave the vault holding the same nine secrets and the default path is a no-op set of skips. Both run after the seven app secrets, and an empty license key skips rather than fails, so a value the script cannot resolve never costs the secrets nothing else writes. That part is required rather than a convenience: `create-k8s-secrets.sh` reads `langsmith-license-key` out of the vault to build `langsmith-config-secret`, and `status.sh` lists it as required.

`time_sleep.wait_for_rbac` now also depends on `manage_secrets`, since the 30s RBAC-propagation wait exists only so those writes don't 403.

## State migration

`postgres_admin_password` gains `count`, which changes its state address, so **without intervention every existing deployment would plan a destroy-then-create against that secret on an upgrade that changes nothing else**. One `moved` block in `modules/keyvault/removed.tf` handles it, alongside the seven `removed` blocks already there from the earlier app-secret migration. `langsmith_license_key` carried a `count` already, so it has always been stored at `[0]` and needs no migration. Upgrading on the default is a no-op.

Turning the flag off on a deployment that already applied is the one case that still needs manual work, because `count = 0` reads as "delete these from the vault". PERMISSIONS.md documents reading the addresses out of `terraform state list` (`postgres_admin_password` is un-indexed before this change and `[0]` after; `langsmith_license_key` is `[0]` either way) and dropping them with `terraform state rm` before flipping the flag.

## Scope

This does not remove the deployment's need for `roleAssignments/write`. `keyvault_manage_terraform_admin_assignment = false` is what skips the vault role assignment; this flag removes the data-plane requirement that grant exists to satisfy. `Storage Blob Data Contributor` in the storage module is still ungated, because LangSmith pods need it at runtime, so a deployer holding no role-assignment rights at all relocates the failure there rather than clearing it.

Follow-up worth doing in whichever lands second: #180's preflight hard-fails when the deployer lacks `roleAssignments/write`, and that message should point at this flag as the remedy.

## Verification

`terraform validate`, `terraform fmt -recursive -check`, `bash -n`, and `shellcheck -S warning` all pass. Functionally tested the tfvars resolution (file present including a value with spaces, env override, file absent under `set -e`) and all four `_seed` paths with stubs. Seed ordering is covered by four more stub runs: an empty license key writes eight secrets and exits 0, both values unresolvable writes the seven and exits 1, both values set writes nine, and a re-run against a populated vault skips all nine. No plan or apply against Azure.

