### PR TITLE
fix(aws): expire completed standalone database jobs

### DIFF
--- a/modules/aws/infra/main.tf
+++ b/modules/aws/infra/main.tf
@@ -737,6 +737,9 @@ resource "kubernetes_job_v1" "standalone_db" {
 
   spec {
     backoff_limit = 6
+    # Keep the result available briefly, then let Kubernetes remove this
+    # Terraform-managed, idempotent database bootstrap Job.
+    ttl_seconds_after_finished = 3600
     template {
       metadata {
         labels = {


### PR DESCRIPTION
## Summary

- Retain completed standalone database bootstrap Jobs for one hour.
- Let Kubernetes remove each one-shot Job after that retention period.

## Why

The database bootstrap Jobs are idempotent and only create a logical database
when it does not already exist. Keeping completed Jobs indefinitely adds
unneeded cluster objects, while a one-hour TTL preserves short-term debugging
evidence and allows later Terraform applies to recreate the Job safely.

## Testing

- Passed `terraform -chdir=modules/aws/infra fmt -check main.tf`.
- Passed `git diff --check upstream/main...HEAD`.
- Attempted `terraform -chdir=modules/aws/infra validate -no-color`; local
  provider plugins could not load schemas, so validation remains unverified.