### PR TITLE
fix(azure): default availability_zones to [] and make Postgres HA its own switch

### DIFF
--- a/modules/azure/README.md
+++ b/modules/azure/README.md
@@ -1026,38 +1026,57 @@ plan checks the name, and Azure enforces the size at apply.
 
 ## Multi-AZ Support
 
-```hcl
-# Spread AKS nodes across zones 1, 2, 3
-availability_zones = ["1", "2", "3"]
-
-# PostgreSQL HA standby in a different zone
-postgres_high_availability_mode = "ZoneRedundant"
-```
-
-Zone-redundant PostgreSQL requires `GeneralPurpose` or `MemoryOptimized` SKU.
-
-Set `availability_zones = []` when a SKU you need is not offered in every zone
-of the region. Azure then places the AKS node pool and the PostgreSQL server
-itself, which is the only way to get a partially-zoned VM or database size to
-deploy. The failure without it names the zone rather than the SKU, so it reads
-as a capacity problem:
+`availability_zones` defaults to `[]`, which leaves placement to Azure: the AKS
+node pool is non-zonal and the PostgreSQL server lands where the region has
+room. That default is the only setting that deploys a VM or database size Azure
+does not offer in every zone. Pinning a zone that lacks the size fails with an
+error that names the zone rather than the size, so it reads as a capacity
+problem:
 
 ```
 The requested VM size <size> is not available in the requested zone.
 ```
 
-Availability differs per SKU and per region, so check before pinning:
+Zone-redundant PostgreSQL is a switch of its own and needs no zone numbers:
+
+```hcl
+postgres_high_availability = true
+```
+
+Azure puts the standby in a zone other than the primary's, so HA works under the
+`[]` default and does not force you to pin anything.
+
+Pin zones when you want to choose the placement yourself:
+
+```hcl
+# Spread AKS nodes across zones 1, 2, 3
+availability_zones = ["1", "2", "3"]
+
+# Pin the Postgres standby as well — optional, Azure picks one otherwise
+postgres_standby_availability_zone = "2"
+```
+
+Coverage differs per SKU and per region, so check the VM and database sizes you
+picked before pinning:
 
 ```bash
 az vm list-skus --location <region> --size <vm-size> --query "[].locationInfo[].zones" -o tsv
 ```
+
+Zone-redundant PostgreSQL requires a `GeneralPurpose` or `MemoryOptimized` SKU.
+Pin `postgres_standby_availability_zone` only alongside a pinned
+`availability_zones`. Under the `[]` default the primary is Azure's choice and
+can be the zone you pinned for the standby, which `ZoneRedundant` does not
+allow. Setting the standby zone still enables HA on its own, so a configuration
+written before `postgres_high_availability` keeps its standby.
 
 Set `availability_zones` before the first apply. The AKS node pool keeps the
 zones it was created with: `azurerm` re-zones a default node pool by cycling the
 system node pool, and that cycle does not cordon and drain, so the module ignores
 zone changes rather than disrupt running pods on a tfvars edit. Plan reports a
 mismatch as a `Check block assertion failed` warning naming both the live and the
-requested zones. To re-zone an existing cluster on purpose, remove
+requested zones. The `[]` default is exempt: it requests no zone, so there is
+nothing to be out of sync with. To re-zone an existing cluster on purpose, remove
 `default_node_pool[0].zones` from the `ignore_changes` block in
 `infra/modules/k8s-cluster/main.tf` and apply during a maintenance window.
 

--- a/modules/azure/README.md
+++ b/modules/azure/README.md
@@ -84,7 +84,7 @@ These variables shape the cluster itself, so Terraform reads and ignores them on
 - `default_node_pool_vm_size`, `default_node_pool_min_count`, `default_node_pool_max_count`, `default_node_pool_max_pods`
 - `aks_service_cidr`, `aks_dns_service_ip`
 - `aks_authorized_ip_ranges`
-- `availability_zones`, for the cluster only — PostgreSQL and the bastion still use it
+- `availability_zones`, for the cluster only — PostgreSQL still uses it
 
 `istio-addon` requires `create_cluster = true`. Azure Service Mesh is configured through `service_mesh_profile` on the cluster resource, so Terraform cannot enable it on a cluster it only reads. Use `istio` for the self-managed Helm install instead.
 
@@ -1035,6 +1035,22 @@ postgres_high_availability_mode = "ZoneRedundant"
 ```
 
 Zone-redundant PostgreSQL requires `GeneralPurpose` or `MemoryOptimized` SKU.
+
+Set `availability_zones = []` when a SKU you need is not offered in every zone
+of the region. Azure then places the AKS node pool and the PostgreSQL server
+itself, which is the only way to get a partially-zoned VM or database size to
+deploy. The failure without it names the zone rather than the SKU, so it reads
+as a capacity problem:
+
+```
+The requested VM size <size> is not available in the requested zone.
+```
+
+Availability differs per SKU and per region, so check before pinning:
+
+```bash
+az vm list-skus --location <region> --size <vm-size> --query "[].locationInfo[].zones" -o tsv
+```
 
 Set `availability_zones` before the first apply. The AKS node pool keeps the
 zones it was created with: `azurerm` re-zones a default node pool by cycling the

--- a/modules/azure/TEST_CYCLE.md
+++ b/modules/azure/TEST_CYCLE.md
@@ -287,12 +287,15 @@ az vm list -g <resource-group> --query '[].name'
 
 ```hcl
 # terraform.tfvars
+postgres_high_availability           = true
 availability_zones                   = ["1", "2", "3"]
 postgres_standby_availability_zone   = "2"
 postgres_geo_redundant_backup        = true
 ```
 
-**Expected plan**: PostgreSQL HA mode set to `ZoneRedundant`.
+**Expected plan**: PostgreSQL HA mode set to `ZoneRedundant`, standby in zone 2.
+Dropping `postgres_standby_availability_zone` keeps HA and leaves the standby
+zone to Azure.
 
 > Zone-redundant PostgreSQL requires `GeneralPurpose` or `MemoryOptimized` SKU.
 
@@ -301,7 +304,8 @@ postgres_geo_redundant_backup        = true
 > changes so the provider cannot cycle the system node pool out from under
 > running pods. Plan reports the mismatch as a `Check block assertion failed`
 > warning naming both the live and the requested zones, and exits 0. Expect that
-> warning here rather than a node pool change.
+> warning here rather than a node pool change. The `[]` default requests no zone
+> and never warns.
 
 ---
 

--- a/modules/azure/infra/main.tf
+++ b/modules/azure/infra/main.tf
@@ -670,7 +670,12 @@ module "postgres" {
   storage_tier          = var.postgres_storage_tier
   backup_retention_days = var.postgres_backup_retention_days
 
-  availability_zone            = var.availability_zones[0]
+  # availability_zones = [] means "let Azure place this", which is the only way
+  # to deploy a VM or database SKU that is not offered in every zone of the
+  # region. Indexing an empty list is an error, so this is a ternary rather than
+  # a length() guard joined with &&, which evaluates both sides below Terraform
+  # 1.14 and would error on the very input it is meant to handle.
+  availability_zone            = length(var.availability_zones) > 0 ? var.availability_zones[0] : ""
   standby_availability_zone    = var.postgres_standby_availability_zone
   geo_redundant_backup_enabled = var.postgres_geo_redundant_backup
 

--- a/modules/azure/infra/main.tf
+++ b/modules/azure/infra/main.tf
@@ -676,6 +676,7 @@ module "postgres" {
   # a length() guard joined with &&, which evaluates both sides below Terraform
   # 1.14 and would error on the very input it is meant to handle.
   availability_zone            = length(var.availability_zones) > 0 ? var.availability_zones[0] : ""
+  high_availability            = var.postgres_high_availability
   standby_availability_zone    = var.postgres_standby_availability_zone
   geo_redundant_backup_enabled = var.postgres_geo_redundant_backup
 

--- a/modules/azure/infra/modules/k8s-cluster/main.tf
+++ b/modules/azure/infra/modules/k8s-cluster/main.tf
@@ -361,12 +361,19 @@ resource "azurerm_kubernetes_cluster" "main" {
 # already sitting in this state cannot apply anything at all until it is
 # resolved. The drift is worth reporting, not worth blocking unrelated work.
 #
+# An empty availability_zones is exempt. [] is the default and asks Azure to
+# place the pool, so whatever zones a pool already reports are not drift from a
+# request nobody made. Without the exemption every cluster created under the
+# earlier ["1"] default would warn on every plan.
+#
 # The condition is a ternary, not a length() guard joined with &&, because &&
 # evaluates both sides below Terraform 1.14 and the indexed reference errors
-# under create_cluster = false, where the resource has no instances.
+# under create_cluster = false, where the resource has no instances. The || is
+# safe by the same rule: both of its operands are length() calls, and only the
+# ternary's false branch indexes.
 check "aks_node_pool_zone_drift" {
   assert {
-    condition = length(azurerm_kubernetes_cluster.main) == 0 ? true : toset(azurerm_kubernetes_cluster.main[0].default_node_pool[0].zones) == toset(var.availability_zones)
+    condition = length(var.availability_zones) == 0 || length(azurerm_kubernetes_cluster.main) == 0 ? true : toset(azurerm_kubernetes_cluster.main[0].default_node_pool[0].zones) == toset(var.availability_zones)
     error_message = join("", [
       "AKS node pool zones are [",
       join(",", sort(tolist(azurerm_kubernetes_cluster.main[0].default_node_pool[0].zones))),

--- a/modules/azure/infra/modules/k8s-cluster/main.tf
+++ b/modules/azure/infra/modules/k8s-cluster/main.tf
@@ -21,6 +21,15 @@
 # ══════════════════════════════════════════════════════════════════════════════
 
 locals {
+  # azurerm reports an unzoned default node pool as null, not [], so the drift
+  # check below has to normalize before toset() and sort() ever see it. one()
+  # also folds away the count, returning null when create_cluster = false.
+  live_node_pool_zones = (
+    one(azurerm_kubernetes_cluster.main[*].default_node_pool[0].zones) == null
+    ? toset([])
+    : toset(one(azurerm_kubernetes_cluster.main[*].default_node_pool[0].zones))
+  )
+
   service_accounts_for_workload_identity = [
     "${var.langsmith_release_name}-backend",
     "${var.langsmith_release_name}-platform-backend",
@@ -366,17 +375,15 @@ resource "azurerm_kubernetes_cluster" "main" {
 # request nobody made. Without the exemption every cluster created under the
 # earlier ["1"] default would warn on every plan.
 #
-# The condition is a ternary, not a length() guard joined with &&, because &&
-# evaluates both sides below Terraform 1.14 and the indexed reference errors
-# under create_cluster = false, where the resource has no instances. The || is
-# safe by the same rule: both of its operands are length() calls, and only the
-# ternary's false branch indexes.
+# create_cluster = false is exempt too. local.live_node_pool_zones folds the
+# count away to an empty set there, which would otherwise read as drift against
+# any requested zones on a cluster this module does not manage.
 check "aks_node_pool_zone_drift" {
   assert {
-    condition = length(var.availability_zones) == 0 || length(azurerm_kubernetes_cluster.main) == 0 ? true : toset(azurerm_kubernetes_cluster.main[0].default_node_pool[0].zones) == toset(var.availability_zones)
+    condition = length(var.availability_zones) == 0 || length(azurerm_kubernetes_cluster.main) == 0 ? true : local.live_node_pool_zones == toset(var.availability_zones)
     error_message = join("", [
       "AKS node pool zones are [",
-      join(",", sort(tolist(azurerm_kubernetes_cluster.main[0].default_node_pool[0].zones))),
+      join(",", sort(tolist(local.live_node_pool_zones))),
       "] but availability_zones requests [",
       join(",", sort(var.availability_zones)),
       "]. This module ignores zone changes on an existing node pool, so the ",

--- a/modules/azure/infra/modules/k8s-cluster/variables.tf
+++ b/modules/azure/infra/modules/k8s-cluster/variables.tf
@@ -161,8 +161,8 @@ variable "workload_identity_name" {
 
 variable "availability_zones" {
   type        = list(string)
-  description = "Availability zones for the default node pool. Use [\"1\",\"2\",\"3\"] for zone-redundant HA. Use [] for a non-zonal pool, which is required when the node VM size is not offered in every zone of the region."
-  default     = ["1"]
+  description = "Availability zones for the default node pool. The default [] creates a non-zonal pool, which is required when the node VM size is not offered in every zone of the region. Use [\"1\",\"2\",\"3\"] for zone-redundant HA."
+  default     = []
 }
 
 variable "dns_label" {

--- a/modules/azure/infra/modules/k8s-cluster/variables.tf
+++ b/modules/azure/infra/modules/k8s-cluster/variables.tf
@@ -161,7 +161,7 @@ variable "workload_identity_name" {
 
 variable "availability_zones" {
   type        = list(string)
-  description = "Availability zones for the default node pool. Use [\"1\",\"2\",\"3\"] for zone-redundant HA."
+  description = "Availability zones for the default node pool. Use [\"1\",\"2\",\"3\"] for zone-redundant HA. Use [] for a non-zonal pool, which is required when the node VM size is not offered in every zone of the region."
   default     = ["1"]
 }
 

--- a/modules/azure/infra/modules/postgres/main.tf
+++ b/modules/azure/infra/modules/postgres/main.tf
@@ -62,7 +62,16 @@ resource "azurerm_postgresql_flexible_server" "db" {
   lifecycle {
     # Azure may move the server to a different availability zone during
     # maintenance. Ignore zone drift to prevent unnecessary plan noise.
-    ignore_changes = [zone]
+    #
+    # The standby zone is ignored for a second reason: leaving
+    # standby_availability_zone unset is the supported way to let Azure place
+    # the standby, and Azure then reports the zone it picked. Without this the
+    # config's null reads as a request to unset a zone the server genuinely
+    # has, so every later plan on an HA deployment offers to change it and
+    # every apply pushes an update at a healthy HA pair. The cost is that
+    # editing an explicit pin is ignored too, which is how zone above already
+    # behaves.
+    ignore_changes = [zone, high_availability[0].standby_availability_zone]
   }
 }
 

--- a/modules/azure/infra/modules/postgres/main.tf
+++ b/modules/azure/infra/modules/postgres/main.tf
@@ -41,7 +41,7 @@ resource "azurerm_postgresql_flexible_server" "db" {
   delegated_subnet_id           = var.subnet_id
   private_dns_zone_id           = azurerm_private_dns_zone.db_dns_zone.id
 
-  zone                         = var.availability_zone
+  zone                         = var.availability_zone != "" ? var.availability_zone : null
   geo_redundant_backup_enabled = var.geo_redundant_backup_enabled
 
   dynamic "high_availability" {

--- a/modules/azure/infra/modules/postgres/main.tf
+++ b/modules/azure/infra/modules/postgres/main.tf
@@ -44,11 +44,16 @@ resource "azurerm_postgresql_flexible_server" "db" {
   zone                         = var.availability_zone != "" ? var.availability_zone : null
   geo_redundant_backup_enabled = var.geo_redundant_backup_enabled
 
+  # standby_availability_zone is optional on the provider's high_availability
+  # block: with mode set and no zone named, Azure picks a standby in a zone
+  # other than the primary's. Naming one is a pin, not the switch. A non-empty
+  # zone still enables HA by itself so that configurations predating
+  # var.high_availability keep the standby they already have.
   dynamic "high_availability" {
-    for_each = var.standby_availability_zone != "" ? [1] : []
+    for_each = var.high_availability || var.standby_availability_zone != "" ? [1] : []
     content {
       mode                      = "ZoneRedundant"
-      standby_availability_zone = var.standby_availability_zone
+      standby_availability_zone = var.standby_availability_zone != "" ? var.standby_availability_zone : null
     }
   }
 

--- a/modules/azure/infra/modules/postgres/variables.tf
+++ b/modules/azure/infra/modules/postgres/variables.tf
@@ -83,7 +83,7 @@ variable "tags" {
 
 variable "availability_zone" {
   type        = string
-  description = "Primary availability zone for the Postgres server (\"1\", \"2\", or \"3\")"
+  description = "Primary availability zone for the Postgres server (\"1\", \"2\", or \"3\"). Empty lets Azure choose, which is required for SKUs that are not offered in every zone of the region."
   default     = "1"
 }
 

--- a/modules/azure/infra/modules/postgres/variables.tf
+++ b/modules/azure/infra/modules/postgres/variables.tf
@@ -83,13 +83,19 @@ variable "tags" {
 
 variable "availability_zone" {
   type        = string
-  description = "Primary availability zone for the Postgres server (\"1\", \"2\", or \"3\"). Empty lets Azure choose, which is required for SKUs that are not offered in every zone of the region."
-  default     = "1"
+  description = "Primary availability zone for the Postgres server (\"1\", \"2\", or \"3\"). The default, empty, lets Azure choose, which is required for SKUs that are not offered in every zone of the region."
+  default     = ""
+}
+
+variable "high_availability" {
+  type        = bool
+  description = "Enable ZoneRedundant HA. Azure places the standby unless standby_availability_zone names a zone. Requires a GeneralPurpose or MemoryOptimized SKU."
+  default     = false
 }
 
 variable "standby_availability_zone" {
   type        = string
-  description = "Standby availability zone for HA. Leave empty to disable zone-redundant HA."
+  description = "Pin the HA standby to a zone. Empty lets Azure choose. A non-empty value also enables HA on its own, so a configuration written before high_availability existed keeps its standby."
   default     = ""
 }
 

--- a/modules/azure/infra/terraform.tfvars.example
+++ b/modules/azure/infra/terraform.tfvars.example
@@ -212,6 +212,7 @@ sizing_profile = "production"
 
 # ── Multi-AZ (optional) ───────────────────────────────────────────────────────
 # availability_zones                   = ["1", "2", "3"]  # zone-redundant HA
+# availability_zones                   = []               # let Azure choose
 # postgres_standby_availability_zone   = "2"              # Postgres HA standby
 # postgres_geo_redundant_backup        = true             # geo-redundant backups
 

--- a/modules/azure/infra/terraform.tfvars.example
+++ b/modules/azure/infra/terraform.tfvars.example
@@ -211,9 +211,12 @@ sizing_profile = "production"
 # create_bastion     = true   # Jump VM for private AKS node access
 
 # ── Multi-AZ (optional) ───────────────────────────────────────────────────────
-# availability_zones                   = ["1", "2", "3"]  # zone-redundant HA
-# availability_zones                   = []               # let Azure choose
-# postgres_standby_availability_zone   = "2"              # Postgres HA standby
+# availability_zones defaults to [], which lets Azure place the node pool and
+# the database. Pin zones only when your VM and database sizes are offered in
+# all of them — README.md "Multi-AZ Support" has the az vm list-skus check.
+# postgres_high_availability           = true             # Postgres standby in another zone
+# availability_zones                   = ["1", "2", "3"]  # pin the AKS node pool
+# postgres_standby_availability_zone   = "2"              # pin the standby; needs pinned zones
 # postgres_geo_redundant_backup        = true             # geo-redundant backups
 
 # ── Networking (optional — override only if reusing existing VNet) ─────────────

--- a/modules/azure/infra/variables.tf
+++ b/modules/azure/infra/variables.tf
@@ -749,7 +749,7 @@ variable "ingress_ip" {
 
 variable "availability_zones" {
   type        = list(string)
-  description = "Availability zones to deploy into. Use [\"1\",\"2\",\"3\"] for zone-redundant HA. Default [\"1\"] for single-zone."
+  description = "Availability zones to deploy into. Use [\"1\",\"2\",\"3\"] for zone-redundant HA. Default [\"1\"] for single-zone. Use [] to let Azure choose, which is required when the VM or database SKU is not offered in every zone of the region."
   default     = ["1"]
 }
 

--- a/modules/azure/infra/variables.tf
+++ b/modules/azure/infra/variables.tf
@@ -749,13 +749,19 @@ variable "ingress_ip" {
 
 variable "availability_zones" {
   type        = list(string)
-  description = "Availability zones to deploy into. Use [\"1\",\"2\",\"3\"] for zone-redundant HA. Default [\"1\"] for single-zone. Use [] to let Azure choose, which is required when the VM or database SKU is not offered in every zone of the region."
-  default     = ["1"]
+  description = "Availability zones to deploy into. The default [] lets Azure place the AKS node pool and the PostgreSQL server, the only setting that works when a VM or database SKU is not offered in every zone of the region. Set [\"1\",\"2\",\"3\"] for zone-redundant HA, or a single zone to pin placement. Applies at creation only."
+  default     = []
+}
+
+variable "postgres_high_availability" {
+  type        = bool
+  description = "Zone-redundant HA for PostgreSQL (primary + standby in different zones). Azure picks the standby zone unless postgres_standby_availability_zone names one. Requires a GeneralPurpose or MemoryOptimized SKU."
+  default     = false
 }
 
 variable "postgres_standby_availability_zone" {
   type        = string
-  description = "Standby AZ for Postgres HA (ZoneRedundant mode). Leave empty to disable HA standby."
+  description = "Pin the Postgres HA standby to a zone. Leave empty to let Azure choose. Setting this also turns HA on, for compatibility with configurations written before postgres_high_availability existed. Only pin the standby alongside a pinned availability_zones, so the primary cannot land in the same zone."
   default     = ""
 }
 


### PR DESCRIPTION
## Why

Azure does not offer every VM and database SKU in every zone of a region. `availability_zones` defaulted to `["1"]`, which pins the AKS node pool and the PostgreSQL primary to zone 1, so the default fails wherever the size a deployment needs is missing from that zone. The Azure error names the zone rather than the SKU, so it reads as a capacity problem:

```
The requested VM size <size> is not available in the requested zone.
```

A customer hit this on a region where their node VM size is not in all three zones.

`[]` hands placement to Azure and works everywhere, but it was not reachable: the Postgres module call indexed the list without a guard, so `[]` failed at plan time.

```
Error: Invalid index
The given key does not identify an element in this collection value.
```

That is the default path — `postgres_source` defaults to `external`, so the module block is instantiated. An in-cluster deployment never evaluates the expression, which is why the failure is easy to miss.

## What changed

**`availability_zones = []` works, and is the default**

- Guard the index with a ternary. Not a `length()` check joined by `&&`: that operator evaluates both sides below Terraform 1.14 and would error on the very input the guard exists to handle.
- Pass `null` rather than `""` into `azurerm_postgresql_flexible_server.zone` so the API treats it as unset instead of as an empty zone name.
- Flip the default to `[]` at the root and in the k8s-cluster module. The postgres module's own `availability_zone` default follows, `"1"` to `""`.
- Exempt an empty request from the `aks_node_pool_zone_drift` check. Without that, every cluster created under the old default warns on every plan about drift from a request nobody made.

**Postgres HA no longer needs a zone number**

- `standby_availability_zone` is optional on the provider's `high_availability` block — `mode` is the only required field, and Azure places the standby in a zone other than the primary's. The module keyed the block's `for_each` on that string, so the zone doubled as the on/off switch and HA was unreachable without pinning one.
- New `postgres_high_availability` bool, named to match the existing `redis_high_availability`. The standby zone becomes an optional pin and passes `null` when empty.
- A non-empty standby zone still enables HA on its own, so a configuration written before the flag keeps its standby instead of losing it on the next apply.

**Docs**

- README Multi-AZ section rewritten around the new default, with the `az vm list-skus` query that reports per-SKU zone coverage. `terraform.tfvars.example` and TEST_CYCLE.md follow.
- Correct the create-only variable list, which claimed the bastion uses `availability_zones`. Nothing in that module references a zone.
- Correct a README snippet that configured HA through `postgres_high_availability_mode`, a variable that has never existed.

## Existing behavior this does not change

`ignore_changes` still applies on both sides. An AKS cluster created with `["1"]` does not re-zone when the value changes to `[]`, and Postgres ignores zone drift since Azure moves servers during maintenance. Flipping the default therefore re-places nothing on an existing deployment.

## Known sharp edge

Pinning `postgres_standby_availability_zone` while leaving `availability_zones = []` lets Azure choose the primary, and it can choose the zone pinned for the standby, which `ZoneRedundant` does not allow. The README says to pin both or neither. Not blocked with a precondition: that would fail the plan for every existing HA deployment the moment the default flips, and with the new flag nobody needs to pin the standby alone.

## Testing

Applied live in `eastus2` against a throwaway harness that instantiates only the two
submodules this PR touches — no LangSmith stack, `ingress_controller = "none"`, four
cases in parallel.

**Greenfield on the new default**

| resource | requested | live result |
| --- | --- | --- |
| AKS default node pool | `availability_zones = []` | `zones: null` — non-zonal, node placed by Azure |
| Postgres, HA on | `availability_zone = ""`, `postgres_high_availability = true`, standby unset | primary zone `1`, standby zone `2`, `mode: ZoneRedundant`, `state: Healthy` |

The Postgres row is the claim the PR previously rested on the provider schema for.
`ZoneRedundant` with `standby_availability_zone` omitted is accepted, and Azure spreads
the pair across zones on its own.

**Migration off the old defaults**

Built an AKS cluster at `["1"]` and a Postgres server at `zone = "1"`, then re-planned with
both flipped to the new defaults. Neither resource appears in the plan and the
`aks_node_pool_zone_drift` check stays silent, so flipping the default re-places nothing
and warns about nothing.

**The check still catches real drift**

Re-planned the same cluster requesting `["3"]` against live zone `["1"]`. Warns rather than
errors, plan exits 0, and the message renders the live zones:

```
Warning: Check block assertion failed
AKS node pool zones are [1] but availability_zones requests [3]. ...
```

**Two bugs the live run found, both fixed here**

- `sort(tolist(...))` in the drift-check message aborted the plan on every greenfield
  cluster: azurerm reports an unzoned pool as `null`, not `[]`. Normalized in
  `local.live_node_pool_zones` (`b2072cd`).
- Azure reports the standby zone it chose, so the config's `null` produced a perpetual
  `standby_availability_zone = "2" -> null` diff and an update against a healthy HA pair on
  every apply. Added to `ignore_changes` beside `zone` (`7261113`).

**Static checks**

- `terraform fmt -check -recursive` — clean
- `bash agents/check.sh modules/azure` — `terraform validate` Success; 11 tflint warnings, all pre-existing unused declarations, none from this change

**Out of scope, found while testing:** Azure adds a `Microsoft.Storage` service endpoint to
the delegated Postgres subnet on its own. `modules/networking` declares that subnet without
`service_endpoints`, so every Azure deployment carries a standing in-place diff offering to
strip it. Pre-existing and untouched here.
