### PR TITLE
fix(azure): raise Kubernetes and Helm provider floors

### DIFF
--- a/modules/azure/infra/versions.tf
+++ b/modules/azure/infra/versions.tf
@@ -14,11 +14,11 @@ terraform {
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 2.0"
+      version = ">= 2.37.1, < 3.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.0"
+      version = "~> 2.16"
     }
     null = {
       source  = "hashicorp/null"


### PR DESCRIPTION
Closes #154.

## Summary

- Raise the Azure Kubernetes provider floor to 2.37.1 while keeping the 2.x line.
- Raise the Azure Helm provider floor to 2.16.

## Why

Azure currently accepts any 2.x release of both providers. A fresh init resolves current versions, but an existing lock file can keep provider releases far below the versions used by the other cloud modules.

The Kubernetes floor starts at 2.37.1 rather than 2.37.0. Version 2.37.0 cannot load schemas with Terraform >= 1.12.1 because it is missing the `GetResourceIdentitySchemas` implementation; 2.37.1 is the patch release that fixes that compatibility issue. The `< 3.0` upper bound keeps Azure on the current major line.

A fresh init with the final constraints still resolves the same versions observed before the change: Kubernetes 2.38.0 and Helm 2.17.0. The change therefore rejects stale low locks without changing current fresh-init selections.

## Testing

- Initialized and validated the complete Azure root with the exact floors: Kubernetes 2.37.1 and Helm 2.16.0.
- Confirmed the floor schemas contain every Kubernetes resource and Helm provider/release field used by the Azure modules.
- `terraform -chdir=modules/azure/infra fmt -recursive -check -diff`
- `bash agents/check.sh modules/azure`
