### PR TITLE
feat(aws): support existing Route 53 hosted zones

### DIFF
--- a/modules/aws/Makefile
+++ b/modules/aws/Makefile
@@ -12,7 +12,7 @@
 # Where am I?        make status
 # Terraform flags:   make plan ARGS="-target=module.eks"   (see make help)
 
-.PHONY: help quickstart status status-quick setup-env init plan apply destroy purge-secrets tf \
+.PHONY: help quickstart test-quickstart status status-quick setup-env init plan apply destroy purge-secrets tf \
         preflight preflight-post preflight-ssm kubeconfig ssm secrets secrets-list tls \
         init-values deploy apply-eso uninstall clean deploy-all \
         test-e2e test-permutations test-parallel \
@@ -53,6 +53,9 @@ status-quick: ## Quick status check (skip SSM and K8s queries)
 
 quickstart: ## Interactive setup wizard — generates terraform.tfvars
 	$(INFRA_DIR)/scripts/quickstart.sh
+
+test-quickstart: ## Test QuickStart Route 53 choices and update-mode defaults (no AWS calls)
+	$(INFRA_DIR)/scripts/test-quickstart-dns.sh
 
 # ── Pass 1: Infrastructure ────────────────────────────────────────────────────
 

--- a/modules/aws/README.md
+++ b/modules/aws/README.md
@@ -226,6 +226,32 @@ acm_certificate_arn    = "arn:aws:acm:us-west-2:<account-id>:certificate/<cert-i
 langsmith_domain = "langsmith.<your-domain>"
 ```
 
+### Route 53 hosted zone modes
+
+When `langsmith_domain` is set and `acm_certificate_arn` is empty, Terraform
+requests a DNS-validated ACM certificate and manages the DNS records for it.
+The default, `dns_create_zone = true`, creates a public hosted zone exactly
+matching `langsmith_domain`. Delegate the returned `dns_name_servers` from the
+parent zone before enabling ACM-backed HTTPS.
+
+To reuse an existing authoritative public Route 53 zone, pass the zone ID:
+
+```hcl
+langsmith_domain     = "langsmith.example.com"
+dns_create_zone      = false
+dns_existing_zone_id = "Z1ABCDEF123456"
+```
+
+The existing zone may be `langsmith.example.com` itself or a parent such as
+`example.com`. Terraform writes the ACM validation CNAME and LangSmith ALB
+alias record into that selected zone. The alias target continues to use the
+ALB's canonical hosted zone ID. `dns_name_servers` is empty when a zone is
+reused, and a private hosted zone cannot validate a public ACM certificate.
+
+Reusing a zone does not import or manage the zone itself. If this stack already
+created a dedicated zone, do not switch modes without separately planning the
+DNS and Terraform state migration.
+
 ### Terraform state backend (recommended for production)
 
 Configure `terraform/aws/infra/backend.tf`:
@@ -913,7 +939,10 @@ aws eks update-kubeconfig --name <cluster_name> --region <region>
 | `tls_certificate_source` | `acm` | no | `acm`, `letsencrypt`, or `none` |
 | `acm_certificate_arn` | `""` | when acm | ACM certificate ARN |
 | `letsencrypt_email` | `""` | when letsencrypt | Email for Let's Encrypt |
-| `langsmith_domain` | `""` | no | Custom hostname (empty = use ALB DNS name) |
+| `langsmith_domain` | `""` | no | Custom hostname; activates managed DNS/ACM when no certificate ARN is supplied |
+| `dns_create_zone` | `true` | no | Create a dedicated public Route 53 zone exactly matching `langsmith_domain` |
+| `dns_existing_zone_id` | `""` | when reusing DNS | Existing public parent or same-name Route 53 zone ID |
+| `dns_include_wildcard_san` | `false` | no | Add `*.langsmith_domain` to the managed ACM certificate |
 | `langsmith_namespace` | `langsmith` | no | Kubernetes namespace for LangSmith |
 | `clickhouse_source` | `in-cluster` | no | `in-cluster` or `external` |
 | `alb_scheme` | `internet-facing` | no | ALB scheme: `internet-facing` or `internal` |

--- a/modules/aws/infra/main.tf
+++ b/modules/aws/infra/main.tf
@@ -81,6 +81,11 @@ resource "terraform_data" "validate_inputs" {
     }
 
     precondition {
+      condition     = !local.dns_enabled || var.dns_create_zone || var.dns_existing_zone_id != ""
+      error_message = "dns_existing_zone_id is required when the DNS module is enabled and dns_create_zone = false."
+    }
+
+    precondition {
       condition     = var.tls_certificate_source != "letsencrypt" || var.letsencrypt_email != ""
       error_message = "letsencrypt_email is required when tls_certificate_source = 'letsencrypt'."
     }
@@ -429,16 +434,21 @@ module "cert_manager" {
 
 # ── DNS / ACM ────────────────────────────────────────────────────────────────
 # Activates whenever langsmith_domain is set (regardless of tls_certificate_source).
-# This lets you deploy with tls_certificate_source = "none" first, delegate
-# NS records at your leisure, then flip to "acm" in a later apply.
+# This lets you deploy with tls_certificate_source = "none" first, finish the
+# selected zone's DNS setup at your leisure, then flip to "acm" in a later apply.
 #
-# When tls_certificate_source != "acm": creates the Route 53 zone, requests
-# the ACM certificate, writes DNS validation records, and creates the alias
-# record — but does NOT block waiting for certificate validation.
+# By default, creates a hosted zone exactly matching langsmith_domain. Set
+# dns_create_zone = false to put the certificate validation and ALB alias
+# records in an existing public parent or same-name hosted zone instead.
+# Only a newly created hosted zone needs NS delegation from its parent.
+#
+# When tls_certificate_source != "acm": requests the ACM certificate, writes
+# DNS validation records, and creates the alias record — but does NOT block
+# waiting for certificate validation.
 #
 # When tls_certificate_source == "acm": additionally blocks until the ACM
-# certificate is validated (NS delegation must be complete), then wires the
-# validated cert into the ALB HTTPS listener.
+# certificate is validated (the selected zone must be authoritative), then
+# wires the validated cert into the ALB HTTPS listener.
 
 locals {
   dns_enabled = var.langsmith_domain != "" && var.acm_certificate_arn == ""
@@ -449,7 +459,8 @@ module "dns" {
   count  = local.dns_enabled ? 1 : 0
 
   domain_name          = var.langsmith_domain
-  create_zone          = true
+  create_zone          = var.dns_create_zone
+  existing_zone_id     = var.dns_existing_zone_id
   create_certificate   = true
   wait_for_validation  = var.tls_certificate_source == "acm"
   include_wildcard_san = var.dns_include_wildcard_san
@@ -457,6 +468,8 @@ module "dns" {
 
 # Alias record lives here (not in the dns module) to avoid a circular
 # dependency: dns needs nothing from alb, and alb needs dns's cert ARN.
+# The record's zone_id is the selected Route 53 zone; alias.zone_id is the
+# ALB's canonical hosted zone ID required by Route 53 for the alias target.
 resource "aws_route53_record" "langsmith_alb_alias" {
   count   = local.dns_enabled ? 1 : 0
   zone_id = module.dns[0].zone_id

--- a/modules/aws/infra/modules/dns/main.tf
+++ b/modules/aws/infra/modules/dns/main.tf
@@ -1,43 +1,18 @@
-# AWS DNS module (optional — not wired into main.tf by default)
+# AWS DNS module
 #
-# Provisions a Route 53 hosted zone and DNS-validated ACM certificate.
+# Requests a DNS-validated ACM certificate and manages its validation records.
+# It supports two hosted-zone modes:
+#   - create_zone = true creates a public hosted zone exactly matching
+#     domain_name. Its NS records must be delegated from the parent zone before
+#     the new zone becomes authoritative.
+#   - create_zone = false writes records into existing_zone_id. That public
+#     hosted zone may exactly match domain_name or be one of its parent zones.
+#     An already-authoritative existing zone needs no new NS delegation.
 #
-# Most customers already manage DNS zones outside of this stack (shared zones,
-# separate teams, or existing domain registrars). The default deployment path
-# expects a pre-existing ACM certificate ARN passed via `acm_certificate_arn`
-# in terraform.tfvars — this module is NOT required for that flow.
-#
-# Important caveat — registrar delegation:
-#   Creating a Route 53 zone does NOT make it authoritative. The domain's NS
-#   records must be updated at the registrar to point to the Route 53 name
-#   servers — a manual step that Terraform cannot automate (unless the registrar
-#   is also Route 53, which is uncommon in enterprise). Without this delegation:
-#     - ACM DNS validation hangs indefinitely (cert never issues)
-#     - `terraform apply` blocks or times out on aws_acm_certificate_validation
-#   This makes the module inherently two-pass: apply once to get name servers,
-#   delegate at the registrar, then apply again for cert validation to complete.
-#
-# When to use this module:
-#   - The customer wants Terraform to own the full DNS lifecycle (zone + cert)
-#   - There is no pre-existing Route 53 zone or ACM certificate
-#   - The deployment is greenfield with no shared DNS infrastructure
-#   - The registrar delegation step is understood and acceptable
-#
-# To wire in, add a module block in main.tf:
-#
-#   module "dns" {
-#     source      = "./modules/dns"
-#     domain_name = var.langsmith_domain
-#     create_zone = true           # false to use existing_zone_id instead
-#   }
-#
-# Then feed the certificate ARN into the ALB module:
-#
-#   acm_certificate_arn = module.dns.certificate_arn
-#
-# instead of:
-#
-#   acm_certificate_arn = var.acm_certificate_arn
+# Reusing a zone does not import or otherwise manage the zone itself. The root
+# module separately creates the ALB alias record in the same selected zone.
+# Public ACM certificates require publicly resolvable validation records, so a
+# private hosted zone is not suitable for existing_zone_id.
 
 resource "aws_route53_zone" "langsmith" {
   count = var.create_zone ? 1 : 0

--- a/modules/aws/infra/modules/dns/outputs.tf
+++ b/modules/aws/infra/modules/dns/outputs.tf
@@ -4,7 +4,7 @@ output "zone_id" {
 }
 
 output "name_servers" {
-  description = "Route 53 name servers (only populated when create_zone = true)"
+  description = "Route 53 name servers for a newly created zone (empty when an existing zone is reused)"
   value       = var.create_zone ? aws_route53_zone.langsmith[0].name_servers : []
 }
 

--- a/modules/aws/infra/modules/dns/variables.tf
+++ b/modules/aws/infra/modules/dns/variables.tf
@@ -4,13 +4,13 @@ variable "domain_name" {
 }
 
 variable "create_zone" {
-  description = "Whether to create a new Route 53 hosted zone"
+  description = "Whether to create a new public Route 53 hosted zone exactly matching domain_name"
   type        = bool
   default     = true
 }
 
 variable "existing_zone_id" {
-  description = "ID of an existing Route 53 hosted zone (used when create_zone = false)"
+  description = "ID of an existing public Route 53 hosted zone for domain_name or one of its parent domains (used when create_zone = false)"
   type        = string
   default     = ""
 }
@@ -32,4 +32,3 @@ variable "include_wildcard_san" {
   type        = bool
   default     = false
 }
-

--- a/modules/aws/infra/outputs.tf
+++ b/modules/aws/infra/outputs.tf
@@ -254,10 +254,10 @@ output "langsmith_domain" {
 }
 
 #------------------------------------------------------------------------------
-# DNS / ACM (auto-provisioned)
+# DNS / ACM
 #------------------------------------------------------------------------------
 output "dns_name_servers" {
-  description = "Route 53 NS records — delegate these from your registrar to enable your custom domain and ACM certificate validation"
+  description = "Route 53 NS records for a newly created zone; empty when an existing zone is reused or the DNS module is disabled"
   value       = local.dns_enabled ? module.dns[0].name_servers : []
 }
 
@@ -366,16 +366,16 @@ output "next_steps" {
     - Redis:        ${var.redis_source == "external" ? "external (ElastiCache)" : "in-cluster (Helm)"}
     - S3 Bucket:    ${local.bucket_name}
     - ALB:          ${module.alb.alb_dns_name}
-    - TLS:          ${var.tls_certificate_source}${local.dns_enabled ? "\n    - Domain:       ${var.langsmith_domain} (Route 53 + ACM auto-provisioned)" : ""}${var.create_bastion ? "\n    - Bastion:      ${module.bastion[0].instance_id} (SSM: aws ssm start-session --target ${module.bastion[0].instance_id} --region ${var.region})" : ""}
+    - TLS:          ${var.tls_certificate_source}${local.dns_enabled ? "\n    - Domain:       ${var.langsmith_domain} (${var.dns_create_zone ? "new" : "existing"} Route 53 zone + ACM)" : ""}${var.create_bastion ? "\n    - Bastion:      ${module.bastion[0].instance_id} (SSM: aws ssm start-session --target ${module.bastion[0].instance_id} --region ${var.region})" : ""}
 
     Next Steps:
 
     1. Update kubeconfig:
        aws eks update-kubeconfig --name ${module.eks.cluster_name} --region ${var.region}
-${local.dns_enabled && var.tls_certificate_source != "acm" ? <<-DNS
+${local.dns_enabled && var.tls_certificate_source != "acm" && var.dns_create_zone ? <<-NEWDNS
 
     2. DELEGATE DNS — required before enabling HTTPS
-       Terraform created a Route 53 hosted zone for ${var.langsmith_domain}.
+       Terraform created a Route 53 hosted zone exactly matching ${var.langsmith_domain}.
        Add NS records at your registrar (or parent zone) pointing to:
 
          terraform output dns_name_servers
@@ -395,7 +395,30 @@ ${local.dns_enabled && var.tls_certificate_source != "acm" ? <<-DNS
     5. Access LangSmith:
        http://${module.alb.alb_dns_name}  (HTTP — until you complete step 3)
 
-DNS
+NEWDNS
+  : local.dns_enabled && var.tls_certificate_source != "acm" ? <<-EXISTINGDNS
+
+    2. WAIT FOR ACM VALIDATION
+       Terraform wrote the validation CNAME and ALB alias records into the
+       existing Route 53 hosted zone ${var.dns_existing_zone_id}.
+
+       No new NS delegation is needed if that public zone is already authoritative
+       for ${var.langsmith_domain}. Otherwise, correct its delegation first.
+       Wait for the ACM certificate status to become ISSUED (~5-30 min).
+
+    3. ENABLE HTTPS — after the certificate is issued
+       In terraform.tfvars, change:
+         tls_certificate_source = "acm"
+       Then run: terraform apply
+       This adds the HTTPS listener to the ALB and redirects HTTP → HTTPS.
+
+    4. Run the Helm deployment:
+       cd ../helm && source ../infra/setup-env.sh --deploy && ./scripts/deploy.sh
+
+    5. Access LangSmith:
+       http://${module.alb.alb_dns_name}  (HTTP — until you complete step 3)
+
+EXISTINGDNS
   : local.dns_enabled && var.tls_certificate_source == "acm" ? <<-ACMDONE
 
     2. Deploy LangSmith:

--- a/modules/aws/infra/scripts/quickstart.sh
+++ b/modules/aws/infra/scripts/quickstart.sh
@@ -515,6 +515,7 @@ else
 fi
 
 ACM_ARN=""; LE_EMAIL=""; DOMAIN=""; CREATE_CERT_MANAGER="false"; HOSTED_ZONE_ID=""
+DNS_CREATE_ZONE="true"; DNS_EXISTING_ZONE_ID=""
 
 # ACM ARN
 if [[ "$TLS_SOURCE" == "acm" ]]; then
@@ -527,6 +528,33 @@ fi
 echo ""
 _ask "Custom domain for LangSmith (e.g. langsmith.example.com, blank = use LB hostname)" "$_ex_domain"
 DOMAIN="$_REPLY"
+
+# The DNS module is enabled whenever a custom domain is set and no existing
+# ACM certificate ARN is supplied, regardless of the selected TLS mode.
+if [[ -n "$DOMAIN" && -z "$ACM_ARN" ]]; then
+  _ex_dns_create_zone=$(_existing "dns_create_zone" "true")
+  _dns_zone_default=1
+  [[ "$_ex_dns_create_zone" == "false" ]] && _dns_zone_default=2
+
+  _ask_choice --default "$_dns_zone_default" "Route 53 hosted zone for ${DOMAIN}:" \
+    "Create a new public hosted zone exactly matching ${DOMAIN}" \
+    "Reuse an existing public parent or same-name hosted zone"
+
+  if [[ "$_CHOICE" == "2" ]]; then
+    DNS_CREATE_ZONE="false"
+    echo ""
+    printf "  ${DIM}Find the zone ID: aws route53 list-hosted-zones --query 'HostedZones[*].[Name,Id]' --output table${RESET}\n"
+    while true; do
+      _ask "Existing Route 53 hosted zone ID (e.g. Z1ABCDEF123456)" "$(_existing "dns_existing_zone_id" "")"
+      DNS_EXISTING_ZONE_ID="$_REPLY"
+      if [[ "$DNS_EXISTING_ZONE_ID" =~ ^Z[A-Z0-9]{1,31}$ ]]; then
+        break
+      fi
+      _red "  ERROR: enter a valid Route 53 hosted zone ID starting with Z."
+      echo ""
+    done
+  fi
+fi
 
 # Let's Encrypt email (HTTP-01 or DNS-01)
 if [[ "$TLS_SOURCE" == "letsencrypt" ]] || \
@@ -865,6 +893,13 @@ TFVARS
 [[ -n "$LE_EMAIL" ]] && echo "letsencrypt_email      = \"${LE_EMAIL}\""  >> "$OUTPUT"
 [[ -n "$DOMAIN" ]]   && echo "langsmith_domain       = \"${DOMAIN}\""    >> "$OUTPUT"
 
+if [[ -n "$DOMAIN" && -z "$ACM_ARN" ]]; then
+  echo "dns_create_zone        = ${DNS_CREATE_ZONE}" >> "$OUTPUT"
+  if [[ "$DNS_CREATE_ZONE" == "false" ]]; then
+    echo "dns_existing_zone_id   = \"${DNS_EXISTING_ZONE_ID}\"" >> "$OUTPUT"
+  fi
+fi
+
 if [[ "$CREATE_CERT_MANAGER" == "true" ]]; then
   cat >> "$OUTPUT" << TFVARS
 
@@ -965,6 +1000,10 @@ printf "  %-26s %s\n" "ClickHouse:"   "$CH_SOURCE"
 printf "  %-26s %s\n" "Gateway mode:" "$GATEWAY_MODE"
 printf "  %-26s %s\n" "TLS:"          "$([[ "$CREATE_CERT_MANAGER" == "true" ]] && echo "Let's Encrypt DNS-01 (Route 53)" || echo "$TLS_SOURCE")"
 [[ -n "$DOMAIN" ]] && printf "  %-26s %s\n" "Domain:" "$DOMAIN"
+if [[ -n "$DOMAIN" && -z "$ACM_ARN" ]]; then
+  printf "  %-26s %s\n" "Route 53 zone:" \
+    "$([[ "$DNS_CREATE_ZONE" == "true" ]] && echo "new (${DOMAIN})" || echo "existing (${DNS_EXISTING_ZONE_ID})")"
+fi
 printf "  %-26s %s\n" "Sizing:"       "$SIZING"
 printf "  %-26s %s\n" "Deployments:"  "$ENABLE_DEPLOYMENTS"
 [[ "$ENABLE_AGENT_BUILDER" == "true" ]] && printf "  %-26s %s\n" "Agent Builder:" "$ENABLE_AGENT_BUILDER"

--- a/modules/aws/infra/scripts/test-quickstart-dns.sh
+++ b/modules/aws/infra/scripts/test-quickstart-dns.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+
+# MIT License - Copyright (c) 2026 LangChain, Inc.
+# NOTICE: Actively being tested and subject to change. Not officially supported by LangChain.
+# See LICENSE at the root of this repository for full license text.
+
+# test-quickstart-dns.sh — Regression tests for QuickStart Route 53 choices.
+#
+# Runs the full AWS wizard against temp directories with scripted answers. It
+# covers new-zone and existing-zone output, invalid existing zone IDs, update
+# mode preserving both existing-zone answers, and the existing-ACM path that
+# does not activate the DNS module. No AWS, Terraform, credentials, or state.
+#
+# Usage:
+#   ./infra/scripts/test-quickstart-dns.sh
+#
+# Also available as: make test-quickstart
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC="$SCRIPT_DIR/quickstart.sh"
+
+PASS=0
+FAIL=0
+
+ok() {
+  PASS=$((PASS + 1))
+  echo "  PASS  $1"
+}
+
+bad() {
+  FAIL=$((FAIL + 1))
+  echo "  FAIL  $1"
+}
+
+has_line() {
+  local name="$1" file="$2" expected="$3"
+  if grep -Fqx "$expected" "$file"; then
+    ok "$name"
+  else
+    bad "$name (missing '$expected')"
+  fi
+}
+
+lacks_key() {
+  local name="$1" file="$2" key="$3"
+  if grep -Eq "^[[:space:]]*${key}[[:space:]]*=" "$file"; then
+    bad "$name ($key was written)"
+  else
+    ok "$name"
+  fi
+}
+
+log_has() {
+  local name="$1" file="$2" expected="$3"
+  if grep -Fq "$expected" "$file"; then
+    ok "$name"
+  else
+    bad "$name (log is missing '$expected')"
+  fi
+}
+
+log_lacks() {
+  local name="$1" file="$2" unexpected="$3"
+  if grep -Fq "$unexpected" "$file"; then
+    bad "$name (log contains '$unexpected')"
+  else
+    ok "$name"
+  fi
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# Write answers for a fresh dev deployment using ALB + ACM. When acm_arn is
+# blank, the DNS module activates and dns_choice is consumed (1=new, 2=reuse).
+write_fresh_answers() {
+  local file="$1" acm_arn="$2" domain="$3" dns_choice="${4:-}"
+  local invalid_zone_id="${5:-}" zone_id="${6:-}"
+  {
+    printf '%s\n' "1"             # Deployment profile: dev
+    printf '\n'                    # Name prefix
+    printf '\n'                    # Environment
+    printf '\n'                    # Region
+    printf '\n'                    # Owner
+    printf '\n'                    # Cost center
+    printf '\n'                    # Create VPC: yes
+    printf '\n'                    # EKS version
+    printf '\n'                    # Node instance type
+    printf '\n'                    # Node min
+    printf '\n'                    # Node max
+    printf '%s\n' "2"             # Backends: in-cluster
+    printf '\n'                    # ClickHouse: in-cluster
+    printf '%s\n' "2"             # Gateway: ALB
+    printf '%s\n' "1"             # TLS: ACM
+    printf '%s\n' "$acm_arn"      # Existing ACM ARN or auto-provision
+    printf '%s\n' "$domain"       # Custom domain
+    if [[ -z "$acm_arn" ]]; then
+      printf '%s\n' "$dns_choice" # Route 53: new or reuse
+      if [[ "$dns_choice" == "2" ]]; then
+        [[ -n "$invalid_zone_id" ]] && printf '%s\n' "$invalid_zone_id"
+        printf '%s\n' "$zone_id"
+      fi
+    fi
+    printf '\n'                    # Sizing: dev
+    printf '\n'                    # Deployments: no
+    printf '\n'                    # Insights: no
+    printf '\n'                    # SmithDB: no
+    printf '\n'                    # Sandboxes: no
+  } > "$file"
+}
+
+# Every answer is accepted from terraform.tfvars in update mode. Keeping this
+# list explicit makes a newly inserted prompt fail the test instead of silently
+# shifting later answers onto the wrong questions.
+write_update_defaults() {
+  local file="$1"
+  {
+    printf '\n' # Update existing file
+    printf '\n' # Deployment profile
+    printf '\n' # Name prefix
+    printf '\n' # Environment
+    printf '\n' # Region
+    printf '\n' # Owner
+    printf '\n' # Cost center
+    printf '\n' # Create VPC
+    printf '\n' # EKS version
+    printf '\n' # Node instance type
+    printf '\n' # Node min
+    printf '\n' # Node max
+    printf '\n' # Backends
+    printf '\n' # ClickHouse
+    printf '\n' # Gateway
+    printf '\n' # TLS
+    printf '\n' # ACM ARN
+    printf '\n' # Domain
+    printf '\n' # Route 53 choice
+    printf '\n' # Existing zone ID
+    printf '\n' # Sizing
+    printf '\n' # Deployments
+    printf '\n' # Insights
+    printf '\n' # SmithDB
+    printf '\n' # Sandboxes
+  } > "$file"
+}
+
+run_wizard() {
+  local name="$1" infra_dir="$2" answers="$3" log="$4"
+  mkdir -p "$infra_dir"
+  if INFRA_DIR="$infra_dir" bash "$SRC" < "$answers" > "$log" 2>&1; then
+    ok "$name"
+  else
+    bad "$name (wizard exited non-zero; see $log)"
+  fi
+}
+
+echo "1. Reusing an existing zone validates and writes both DNS answers"
+REUSE_INFRA="$TMP/reuse"
+write_fresh_answers "$TMP/reuse.answers" "" "langsmith.example.com" \
+  "2" "not-a-zone" "Z1ABCDEF123456"
+run_wizard "fresh existing-zone run completes" "$REUSE_INFRA" \
+  "$TMP/reuse.answers" "$TMP/reuse.log"
+has_line "reuse choice is written" "$REUSE_INFRA/terraform.tfvars" \
+  "dns_create_zone        = false"
+has_line "existing zone ID is written" "$REUSE_INFRA/terraform.tfvars" \
+  "dns_existing_zone_id   = \"Z1ABCDEF123456\""
+log_has "invalid zone ID is rejected" "$TMP/reuse.log" \
+  "ERROR: enter a valid Route 53 hosted zone ID starting with Z."
+log_has "summary shows reused zone" "$TMP/reuse.log" \
+  "existing (Z1ABCDEF123456)"
+
+echo "2. Update mode preserves the zone choice and ID as defaults"
+write_update_defaults "$TMP/update.answers"
+run_wizard "existing-zone update run completes" "$REUSE_INFRA" \
+  "$TMP/update.answers" "$TMP/update.log"
+has_line "reuse choice survives rerun" "$REUSE_INFRA/terraform.tfvars" \
+  "dns_create_zone        = false"
+has_line "existing zone ID survives rerun" "$REUSE_INFRA/terraform.tfvars" \
+  "dns_existing_zone_id   = \"Z1ABCDEF123456\""
+
+echo "3. Creating a new zone writes the choice without an existing ID"
+NEW_INFRA="$TMP/new"
+write_fresh_answers "$TMP/new.answers" "" "new.example.com" "1"
+run_wizard "fresh new-zone run completes" "$NEW_INFRA" \
+  "$TMP/new.answers" "$TMP/new.log"
+has_line "new-zone choice is written" "$NEW_INFRA/terraform.tfvars" \
+  "dns_create_zone        = true"
+lacks_key "new-zone mode omits an existing ID" "$NEW_INFRA/terraform.tfvars" \
+  "dns_existing_zone_id"
+log_has "summary shows newly created zone" "$TMP/new.log" "new (new.example.com)"
+
+echo "4. A supplied ACM ARN keeps the DNS module questions disabled"
+ACM_INFRA="$TMP/acm"
+write_fresh_answers "$TMP/acm.answers" \
+  "arn:aws:acm:us-west-2:123456789012:certificate/abc123" \
+  "acm.example.com"
+run_wizard "existing-ACM run completes" "$ACM_INFRA" \
+  "$TMP/acm.answers" "$TMP/acm.log"
+lacks_key "existing ACM omits dns_create_zone" "$ACM_INFRA/terraform.tfvars" \
+  "dns_create_zone"
+lacks_key "existing ACM omits dns_existing_zone_id" "$ACM_INFRA/terraform.tfvars" \
+  "dns_existing_zone_id"
+log_lacks "existing ACM skips the Route 53 question" "$TMP/acm.log" \
+  "Route 53 hosted zone for acm.example.com:"
+
+echo ""
+echo "passed=$PASS failed=$FAIL"
+[[ "$FAIL" -eq 0 ]]

--- a/modules/aws/infra/terraform.tfvars.example
+++ b/modules/aws/infra/terraform.tfvars.example
@@ -374,16 +374,18 @@ clickhouse_source = "in-cluster"
 # Choose how TLS is handled for the LangSmith web UI and API.
 #
 # ┌─────────────────────────────────────────────────────────────────────────────
-# │ RECOMMENDED: Staged deploy with auto-provisioned DNS + ACM
+# │ RECOMMENDED: Staged deploy with a new Route 53 zone + ACM
 # │
-# │ This is the easiest path. Terraform creates a Route 53 hosted zone and
-# │ ACM certificate for your domain. You deploy HTTP first, delegate DNS at
-# │ your own pace, then flip to HTTPS in a second apply.
+# │ This is the default path. Terraform creates a public Route 53 hosted zone
+# │ exactly matching your LangSmith domain and requests an ACM certificate.
+# │ You deploy HTTP first, delegate DNS at your own pace, then flip to HTTPS
+# │ in a second apply.
 # │
 # │ Step 1 — Initial deploy (HTTP, no DNS needed yet):
 # │
 # │   tls_certificate_source = "none"
 # │   langsmith_domain       = "langsmith.example.com"
+# │   dns_create_zone        = true
 # │
 # │   Run: terraform apply
 # │   → Creates all infra (EKS, RDS, ALB, etc.) immediately.
@@ -408,6 +410,24 @@ clickhouse_source = "in-cluster"
 # │   → Adds HTTPS listener, redirects HTTP → HTTPS.
 # │   → Your domain now serves LangSmith over HTTPS.
 # └─────────────────────────────────────────────────────────────────────────────
+#
+# REUSE AN EXISTING PUBLIC ROUTE 53 HOSTED ZONE:
+#   The zone can exactly match langsmith_domain (langsmith.example.com) or be
+#   one of its parents (example.com). Terraform writes the ACM validation CNAME
+#   and LangSmith ALB alias records into that zone; it does not manage the zone.
+#
+#   tls_certificate_source = "none"
+#   langsmith_domain       = "langsmith.example.com"
+#   dns_create_zone        = false
+#   dns_existing_zone_id   = "Z1ABCDEF123456"
+#
+#   If the selected zone is already authoritative, skip the NS delegation step
+#   and wait for the certificate to become ISSUED before switching to "acm".
+#   Public ACM certificates cannot validate through a private hosted zone.
+#
+#   This is not an import path for a zone already managed by this Terraform
+#   state. Migrating an existing deployment from a dedicated zone requires a
+#   separate DNS and state migration; do not only flip dns_create_zone to false.
 #
 # ALTERNATIVE OPTIONS:
 #
@@ -435,10 +455,17 @@ clickhouse_source = "in-cluster"
 # See the staged deploy guide above.
 tls_certificate_source = "none"
 
-# Your domain for LangSmith. When set (without acm_certificate_arn), Terraform
-# auto-provisions a Route 53 hosted zone, ACM certificate, DNS validation
-# records, and an alias record pointing the domain to the ALB.
+# Your domain for LangSmith. When set without acm_certificate_arn, Terraform
+# requests an ACM certificate and creates its validation records plus an ALB
+# alias in either a new or existing Route 53 hosted zone.
 # langsmith_domain = "langsmith.example.com"
+
+# Create a dedicated public hosted zone exactly matching langsmith_domain.
+# Set false to reuse an authoritative public parent or same-name zone instead.
+dns_create_zone = true
+
+# Existing public hosted zone ID, required when dns_create_zone = false.
+# dns_existing_zone_id = "Z1ABCDEF123456"
 
 # Pre-existing ACM certificate ARN — only needed for Option B above.
 # When set, the dns module is skipped (you manage DNS yourself).

--- a/modules/aws/infra/variables.tf
+++ b/modules/aws/infra/variables.tf
@@ -51,6 +51,23 @@ variable "vpc_public_subnets" {
   default     = []
 }
 
+variable "dns_create_zone" {
+  type        = bool
+  description = "Create a dedicated public Route 53 hosted zone for langsmith_domain. Set to false to write DNS validation and ALB alias records into dns_existing_zone_id instead."
+  default     = true
+}
+
+variable "dns_existing_zone_id" {
+  type        = string
+  description = "ID of an existing public Route 53 hosted zone for langsmith_domain or one of its parent domains. Used when dns_create_zone is false."
+  default     = ""
+
+  validation {
+    condition     = var.dns_existing_zone_id == "" || can(regex("^Z[A-Z0-9]{1,31}$", var.dns_existing_zone_id))
+    error_message = "dns_existing_zone_id must be a valid Route 53 hosted zone ID (starts with Z, e.g., Z1ABCDEF123456)."
+  }
+}
+
 variable "dns_include_wildcard_san" {
   type        = bool
   description = "Include a wildcard SAN (*.<langsmith_domain>) on the ACM certificate created by module.dns. Needed for HTTPS on subdomains like mission-control.langsmith.example.com."
@@ -604,7 +621,7 @@ variable "letsencrypt_email" {
 
 variable "langsmith_domain" {
   type        = string
-  description = "Custom domain for LangSmith (e.g. langsmith.example.com). When set (and acm_certificate_arn is empty), activates the dns module to auto-provision a Route 53 hosted zone, ACM certificate, and alias record. Leave empty to skip DNS/ACM and access LangSmith via the ALB hostname directly."
+  description = "Custom domain for LangSmith (e.g. langsmith.example.com). When set and acm_certificate_arn is empty, activates the DNS module to create or reuse a Route 53 hosted zone, request an ACM certificate, and create an ALB alias record. Leave empty to skip DNS/ACM and access LangSmith via the ALB hostname directly."
   default     = ""
 }
 


### PR DESCRIPTION
## Summary

- Expose `dns_create_zone` and `dns_existing_zone_id` from the AWS root module.
- Support either a dedicated zone for `langsmith_domain` or an existing public parent/same-name Route 53 zone.
- Keep the DNS outputs, post-apply guidance, example tfvars, and README aligned with both modes.

## Why

The AWS root module hardcoded `create_zone = true` even though the DNS child module already accepted `existing_zone_id`. This forced customers with an authoritative Route 53 zone to create and delegate another hosted zone.

When an existing zone is selected, the ACM validation records and LangSmith alias record use that zone ID. The alias target continues to use the ALB canonical hosted zone ID.

## Testing

- `bash agents/check.sh modules/aws`
  - Terraform validation passed.
  - TFLint reported only the pre-existing `default.redis7` notice.
- `terraform fmt -check -recursive modules/aws`
- `git diff --check`
- Temporary mocked Terraform tests: 5 passed, covering input validation, ACM validation records, and ALB alias zone IDs.

No live AWS plan or apply was run.

Fixes #148
