### PR TITLE
fix(gcp): stop deploy.sh overwriting a DNS hostname with the Gateway IP

### DIFF
--- a/modules/gcp/helm/scripts/deploy.sh
+++ b/modules/gcp/helm/scripts/deploy.sh
@@ -221,7 +221,21 @@ echo ""
 # leaves no intersection between the HTTPRoute and the listener. The route then
 # reports NoMatchingListenerHostname and every request 404s behind an otherwise
 # valid TLS certificate. The AWS module already guards this the same way.
-_langsmith_domain=$(_parse_tfvar "langsmith_domain") || _langsmith_domain=""
+#
+# Read the domain from the Terraform output, not from terraform.tfvars. That
+# file is only one of Terraform's variable sources and not the highest priority
+# one, so a file parse misses a value set in an .auto.tfvars file, a
+# .tfvars.json file, -var, -var-file or TF_VAR_langsmith_domain. Reading empty
+# there takes this branch for a domain-based install and rewrites the hostname
+# to the Gateway IP — the exact failure this guard exists to prevent. A domain
+# name is not a secret.
+#
+# A read failure means the state predates the langsmith_domain output, so fall
+# back to the file parse. An empty result from a successful read is an answer:
+# no domain is configured, so this is an IP-based install.
+if ! _langsmith_domain=$(terraform -chdir="$INFRA_DIR" output -raw langsmith_domain 2>/dev/null); then
+  _langsmith_domain=$(_parse_tfvar "langsmith_domain") || _langsmith_domain=""
+fi
 _live_gateway_ip=$(kubectl get gateway -n envoy-gateway-system \
   -o jsonpath='{.items[0].status.addresses[0].value}' 2>/dev/null || true)
 if [[ -n "$_live_gateway_ip" && -n "$_langsmith_domain" ]]; then
@@ -232,15 +246,28 @@ if [[ -n "$_live_gateway_ip" && -n "$_langsmith_domain" ]]; then
   # otherwise an absent dig would report "does not resolve yet" for a domain that
   # resolves perfectly well.
   if command -v dig >/dev/null 2>&1; then
-    _resolved_ip=$(dig +short "$_langsmith_domain" A 2>/dev/null | tail -1) || _resolved_ip=""
-    if [[ -z "$_resolved_ip" ]]; then
+    # Compare the whole A-record set against the one Gateway address. Taking a
+    # single record instead ties the verdict to the order the resolver happens
+    # to return, which rotates: a domain answering with both the Gateway IP and
+    # a stale one then passes on some runs and warns on others, and a run that
+    # passes hides that part of the traffic never reaches this cluster.
+    # Keep only IPv4 literals, since dig prints the CNAME target as well when
+    # the name is an alias.
+    _resolved_ips=$(dig +short "$_langsmith_domain" A 2>/dev/null \
+      | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$') || _resolved_ips=""
+    if [[ -z "$_resolved_ips" ]]; then
       echo "NOTE: ${_langsmith_domain} does not resolve yet."
       echo "      Point its DNS A record at ${_live_gateway_ip} — TLS issuance and"
       echo "      ingress stay pending until it does."
       echo ""
-    elif [[ "$_resolved_ip" != "$_live_gateway_ip" ]]; then
-      echo "WARNING: ${_langsmith_domain} resolves to ${_resolved_ip}, not the Gateway"
-      echo "         IP ${_live_gateway_ip}. Update the DNS A record."
+    elif ! printf '%s\n' "$_resolved_ips" | grep -qxF "$_live_gateway_ip"; then
+      echo "WARNING: ${_langsmith_domain} resolves to ${_resolved_ips//$'\n'/, }, not the"
+      echo "         Gateway IP ${_live_gateway_ip}. Update the DNS A record."
+      echo ""
+    elif [[ $(printf '%s\n' "$_resolved_ips" | wc -l) -gt 1 ]]; then
+      echo "WARNING: ${_langsmith_domain} resolves to ${_resolved_ips//$'\n'/, }."
+      echo "         Only ${_live_gateway_ip} is this Gateway. Requests that take one of"
+      echo "         the other addresses do not reach it. Remove the stale A records."
       echo ""
     fi
   else

--- a/modules/gcp/helm/scripts/deploy.sh
+++ b/modules/gcp/helm/scripts/deploy.sh
@@ -214,9 +214,31 @@ echo ""
 # If the Envoy Gateway IP has changed since last deploy (e.g. after Gateway
 # resource recreation), warn the operator and update values-overrides.yaml
 # to prevent the Deployments operator from hitting stale endpoints.
+#
+# This only applies to IP-based installs. When langsmith_domain is set,
+# config.hostname must remain the DNS name: Terraform creates the Gateway
+# listener with that hostname, so rewriting the chart's hostname to the IP
+# leaves no intersection between the HTTPRoute and the listener. The route then
+# reports NoMatchingListenerHostname and every request 404s behind an otherwise
+# valid TLS certificate. The AWS module already guards this the same way.
+_langsmith_domain=$(_parse_tfvar "langsmith_domain") || _langsmith_domain=""
 _live_gateway_ip=$(kubectl get gateway -n envoy-gateway-system \
   -o jsonpath='{.items[0].status.addresses[0].value}' 2>/dev/null || true)
-if [[ -n "$_live_gateway_ip" ]]; then
+if [[ -n "$_live_gateway_ip" && -n "$_langsmith_domain" ]]; then
+  # Domain-based install: never rewrite the hostname. Surface a DNS mismatch
+  # instead, since that is the actual thing an operator needs to fix.
+  _resolved_ip=$(dig +short "$_langsmith_domain" A 2>/dev/null | tail -1) || _resolved_ip=""
+  if [[ -z "$_resolved_ip" ]]; then
+    echo "NOTE: ${_langsmith_domain} does not resolve yet."
+    echo "      Point its DNS A record at ${_live_gateway_ip} — TLS issuance and"
+    echo "      ingress stay pending until it does."
+    echo ""
+  elif [[ "$_resolved_ip" != "$_live_gateway_ip" ]]; then
+    echo "WARNING: ${_langsmith_domain} resolves to ${_resolved_ip}, not the Gateway"
+    echo "         IP ${_live_gateway_ip}. Update the DNS A record."
+    echo ""
+  fi
+elif [[ -n "$_live_gateway_ip" ]]; then
   _configured_hostname=$(grep -E '^\s*hostname:' "$OVERRIDES_FILE" 2>/dev/null \
     | sed 's/.*:[[:space:]]*"\(.*\)".*/\1/' | tr -d '[:space:]') || _configured_hostname=""
   if [[ -n "$_configured_hostname" && "$_configured_hostname" != "$_live_gateway_ip" ]]; then

--- a/modules/gcp/helm/scripts/deploy.sh
+++ b/modules/gcp/helm/scripts/deploy.sh
@@ -227,15 +227,25 @@ _live_gateway_ip=$(kubectl get gateway -n envoy-gateway-system \
 if [[ -n "$_live_gateway_ip" && -n "$_langsmith_domain" ]]; then
   # Domain-based install: never rewrite the hostname. Surface a DNS mismatch
   # instead, since that is the actual thing an operator needs to fix.
-  _resolved_ip=$(dig +short "$_langsmith_domain" A 2>/dev/null | tail -1) || _resolved_ip=""
-  if [[ -z "$_resolved_ip" ]]; then
-    echo "NOTE: ${_langsmith_domain} does not resolve yet."
-    echo "      Point its DNS A record at ${_live_gateway_ip} — TLS issuance and"
-    echo "      ingress stay pending until it does."
-    echo ""
-  elif [[ "$_resolved_ip" != "$_live_gateway_ip" ]]; then
-    echo "WARNING: ${_langsmith_domain} resolves to ${_resolved_ip}, not the Gateway"
-    echo "         IP ${_live_gateway_ip}. Update the DNS A record."
+  #
+  # Only claim a resolution result when a resolver is actually available —
+  # otherwise an absent dig would report "does not resolve yet" for a domain that
+  # resolves perfectly well.
+  if command -v dig >/dev/null 2>&1; then
+    _resolved_ip=$(dig +short "$_langsmith_domain" A 2>/dev/null | tail -1) || _resolved_ip=""
+    if [[ -z "$_resolved_ip" ]]; then
+      echo "NOTE: ${_langsmith_domain} does not resolve yet."
+      echo "      Point its DNS A record at ${_live_gateway_ip} — TLS issuance and"
+      echo "      ingress stay pending until it does."
+      echo ""
+    elif [[ "$_resolved_ip" != "$_live_gateway_ip" ]]; then
+      echo "WARNING: ${_langsmith_domain} resolves to ${_resolved_ip}, not the Gateway"
+      echo "         IP ${_live_gateway_ip}. Update the DNS A record."
+      echo ""
+    fi
+  else
+    echo "NOTE: Gateway IP is ${_live_gateway_ip}; config.hostname stays"
+    echo "      ${_langsmith_domain}. Install dig to have this checked against DNS."
     echo ""
   fi
 elif [[ -n "$_live_gateway_ip" ]]; then

--- a/modules/gcp/helm/scripts/init-values.sh
+++ b/modules/gcp/helm/scripts/init-values.sh
@@ -87,7 +87,25 @@ _region=$(_parse_tfvar "region")
 _region="${_region:-us-west2}"
 _tls_source=$(_parse_tfvar "tls_certificate_source")
 _tls_source="${_tls_source:-none}"
-_domain=$(_parse_tfvar "langsmith_domain")
+# Resolve the domain through Terraform rather than by parsing terraform.tfvars
+# alone. That file is only one of Terraform's variable sources and not the
+# highest priority one, so a file parse misses a value set in an .auto.tfvars
+# file, a .tfvars.json file, -var, -var-file or TF_VAR_langsmith_domain. Where
+# the two disagree, Terraform creates the Gateway listener for its value while
+# this script writes the file's value into config.hostname, and every request
+# then fails the listener match with NoMatchingListenerHostname. A domain name
+# is not a secret.
+#
+# A read failure means the state predates the langsmith_domain output, so fall
+# back to the file parse and keep an older stack working. An empty result from a
+# successful read is an answer rather than a failure: no domain is configured.
+# A tree with no state also reads empty, and the storage_bucket_name check below
+# stops that run regardless.
+_domain_source="terraform output"
+if ! _domain=$(terraform -chdir="$INFRA_DIR" output -raw langsmith_domain 2>/dev/null); then
+  _domain_source="terraform.tfvars"
+  _domain=$(_parse_tfvar "langsmith_domain") || _domain=""
+fi
 _postgres_source=$(_parse_tfvar "postgres_source")
 _postgres_source="${_postgres_source:-external}"
 _redis_source=$(_parse_tfvar "redis_source")
@@ -140,6 +158,7 @@ echo "  name_prefix            = $_name_prefix"
 echo "  environment            = $_environment"
 echo "  region                 = $_region"
 echo "  tls_certificate_source = $_tls_source (protocol: $_protocol)"
+echo "  langsmith_domain       = ${_domain:-(none)} (from $_domain_source)"
 echo "  postgres_source        = $_postgres_source"
 echo "  redis_source           = $_redis_source"
 echo "  clickhouse_source      = $_clickhouse_source"
@@ -211,20 +230,24 @@ fi
 echo ""
 
 # ── Hostname ──────────────────────────────────────────────────────────────────
-# Priority: existing OUT_FILE > langsmith_domain tfvar > ingress IP > empty
+# Priority: langsmith_domain > existing OUT_FILE > ingress IP > empty
 EXISTING_HOSTNAME=""
 if [[ -f "$OUT_FILE" ]]; then
   EXISTING_HOSTNAME=$(grep -E '^\s*hostname:' "$OUT_FILE" 2>/dev/null \
     | sed 's/.*:[[:space:]]*"\(.*\)".*/\1/' | tr -d '[:space:]') || EXISTING_HOSTNAME=""
 fi
 
-if [[ -n "$EXISTING_HOSTNAME" && -n "$_domain" \
-      && "$EXISTING_HOSTNAME" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-  # Self-heal: a bare IP in the existing file cannot be right when
-  # langsmith_domain names a host. Earlier revisions of deploy.sh rewrote the
-  # hostname to the Gateway IP unconditionally, and because the existing file
-  # outranked the tfvar the wrong value survived every regeneration.
-  echo "Replacing IP hostname ${EXISTING_HOSTNAME} with langsmith_domain ${_domain}"
+if [[ -n "$EXISTING_HOSTNAME" && -n "$_domain" && "$EXISTING_HOSTNAME" != "$_domain" ]]; then
+  # Self-heal: Terraform owns the Gateway listener hostname, so a configured
+  # langsmith_domain outranks whatever the file holds. Earlier revisions of
+  # deploy.sh rewrote the hostname to the Gateway IP unconditionally, and
+  # because the existing file outranked the variable the wrong value survived
+  # every regeneration.
+  #
+  # Test for "differs", not for "is an IPv4 literal". A stale DNS name left
+  # behind by an earlier langsmith_domain fails the listener match exactly as a
+  # bare IP does, and an IPv4-only test preserves it silently.
+  echo "Replacing hostname ${EXISTING_HOSTNAME} with langsmith_domain ${_domain}"
   HOSTNAME="$_domain"
 elif [[ -n "$EXISTING_HOSTNAME" ]]; then
   HOSTNAME="$EXISTING_HOSTNAME"

--- a/modules/gcp/helm/scripts/init-values.sh
+++ b/modules/gcp/helm/scripts/init-values.sh
@@ -218,7 +218,15 @@ if [[ -f "$OUT_FILE" ]]; then
     | sed 's/.*:[[:space:]]*"\(.*\)".*/\1/' | tr -d '[:space:]') || EXISTING_HOSTNAME=""
 fi
 
-if [[ -n "$EXISTING_HOSTNAME" ]]; then
+if [[ -n "$EXISTING_HOSTNAME" && -n "$_domain" \
+      && "$EXISTING_HOSTNAME" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  # Self-heal: a bare IP in the existing file cannot be right when
+  # langsmith_domain names a host. Earlier revisions of deploy.sh rewrote the
+  # hostname to the Gateway IP unconditionally, and because the existing file
+  # outranked the tfvar the wrong value survived every regeneration.
+  echo "Replacing IP hostname ${EXISTING_HOSTNAME} with langsmith_domain ${_domain}"
+  HOSTNAME="$_domain"
+elif [[ -n "$EXISTING_HOSTNAME" ]]; then
   HOSTNAME="$EXISTING_HOSTNAME"
 elif [[ -n "$_domain" ]]; then
   HOSTNAME="$_domain"


### PR DESCRIPTION
## Problem

`deploy.sh` rewrites `config.hostname` to the live Envoy Gateway IP whenever the two differ:

```bash
if [[ -n "$_live_gateway_ip" ]]; then
  ...
  if [[ -n "$_configured_hostname" && "$_configured_hostname" != "$_live_gateway_ip" ]]; then
    sed -i.bak "s|hostname: \"[^\"]*\"|hostname: \"${_live_gateway_ip}\"|" "$OVERRIDES_FILE"
```

For an IP-based install that resync is the point. **For a `langsmith_domain` install the condition is permanently true**, so every deploy replaces the configured DNS name with a bare IP.

Terraform creates the Gateway listener from `langsmith_domain`, so the chart's route and the listener stop agreeing:

```
Gateway listeners:  hostname: langsmith.example.com   (http :80, https :443)
HTTPRoute:          hostnames: ["34.94.4.48"]
HTTPRoute status:   Accepted=False  NoMatchingListenerHostname
```

Every path returns **404** — `/`, `/health`, `/login` — while TLS still terminates correctly against a valid Let's Encrypt certificate for the domain (`ssl_verify_result=0`). That combination sends you looking for a certificate fault that does not exist. `config.url` is rewritten too, so callback URLs point at the bare IP.

Hit on a real deploy with `langsmith_domain = "langsmith.davocoder.ai"`:

```
WARNING: config.hostname is stale.
  Configured: langsmith.davocoder.ai
  Gateway IP: 34.94.4.48
  Updating values-overrides.yaml before deploy...
```

## Why it was sticky

`init-values.sh` ranks the existing `values-overrides.yaml` **above** the `langsmith_domain` tfvar. Once `deploy.sh` wrote the IP, regenerating values did not restore the domain — the wrong value won on every subsequent run. Recovery required hand-editing the file *and* bypassing `deploy.sh`, which would clobber it again.

## Fix

**`deploy.sh`** — port the guard AWS already has. `aws/helm/scripts/deploy.sh:398`:

```bash
_langsmith_domain=$(_parse_tfvar "langsmith_domain") || _langsmith_domain=""   # :125
...
if [[ -n "$_live_lb" && -z "$_langsmith_domain" ]]; then      # only when NO domain
```

GCP's `deploy.sh` never parsed `langsmith_domain` at all (`grep` returns nothing), so it could not guard on it. The resync is now confined to installs with no domain. A domain install instead reports whether DNS resolves to the Gateway IP — the thing actually worth acting on:

```
NOTE: langsmith.example.com does not resolve yet.
      Point its DNS A record at 34.94.4.48 — TLS issuance and
      ingress stay pending until it does.
```

**`init-values.sh`** — a bare IPv4 in the existing file is replaced when `langsmith_domain` names a host, so an already-clobbered config self-heals on the next `init-values` run.

## Testing

`bash -n` clean on both scripts. Priority logic exercised across all branches:

| existing hostname | `langsmith_domain` | result |
|---|---|---|
| `34.94.4.48` | `langsmith.example.com` | self-heal to domain |
| `langsmith.example.com` | `langsmith.example.com` | keep existing |
| `custom.internal` | `langsmith.example.com` | keep existing (override preserved) |
| `34.94.4.48` | *(empty)* | keep existing (IP install) |
| *(empty)* | `langsmith.example.com` | use domain |

Non-IP values are never replaced, so intentional hostname overrides are unaffected.

## Scope

GCP only. AWS already has the guard; Azure has no equivalent logic.

Found while deploying chart 0.16.11 with all features enabled. One of several gaps where a fix exists in one provider and was never ported to the others.
