### PR TITLE
fix(gcp): allow admin email to be supplied non-interactively in init-values.sh

### DIFF
--- a/modules/gcp/helm/scripts/init-values.sh
+++ b/modules/gcp/helm/scripts/init-values.sh
@@ -247,8 +247,14 @@ else
   # the empty value instead. Testing "is there a tty" would be the wrong gate:
   # piped stdin is not a tty either, and several prompts below have no env
   # override, so `printf ... | init-values.sh` is the only way to drive them.
+  #
+  # Keep whatever read assigned: `|| true`, not `|| ADMIN_EMAIL=""`. read assigns
+  # the partial line and then returns 1 when the input has no trailing newline,
+  # so clearing the variable on failure discards a value the operator did supply.
+  # `printf 'you@example.com' | init-values.sh` is that case. At a true EOF read
+  # assigns the empty string, which the check below still catches.
   printf "Admin email: "
-  read -r ADMIN_EMAIL || ADMIN_EMAIL=""
+  read -r ADMIN_EMAIL || true
   if [[ -z "$ADMIN_EMAIL" ]]; then
     echo "" >&2
     echo "ERROR: Admin email is required." >&2
@@ -307,7 +313,10 @@ fi
 ADMIN_PASSWORD="${TF_VAR_langsmith_admin_password:-$EXISTING_ADMIN_PASSWORD}"
 if [[ -z "$ADMIN_PASSWORD" ]]; then
   printf "Initial admin password: "
-  read -rs ADMIN_PASSWORD || ADMIN_PASSWORD=""
+  # `|| true`, not `|| ADMIN_PASSWORD=""` — see the admin email prompt above.
+  # A password piped without a trailing newline is otherwise silently dropped,
+  # and the operator sees "password is required" for a password they supplied.
+  read -rs ADMIN_PASSWORD || true
   echo
   if [[ -z "$ADMIN_PASSWORD" ]]; then
     echo "ERROR: initial admin password is required." >&2
@@ -513,7 +522,11 @@ elif [[ "$_first_run" == "true" && "$_enable_sandboxes" != "true" ]]; then
   # EOF falls through to choice 1 rather than aborting: this block only runs on a
   # first run with no enable_* flags set in terraform.tfvars, and 1 is
   # "LangSmith only", which is what no flags already means.
-  read -r _tier_choice || _tier_choice=""
+  #
+  # `|| true`, not `|| _tier_choice=""` — see the admin email prompt above. Here
+  # the cleared value is not caught by any check: it defaults to 1 below, so
+  # `printf 4 | init-values.sh` would deploy LangSmith only and report nothing.
+  read -r _tier_choice || true
   _tier_choice="${_tier_choice:-1}"
 
   case "$_tier_choice" in

--- a/modules/gcp/helm/scripts/init-values.sh
+++ b/modules/gcp/helm/scripts/init-values.sh
@@ -238,13 +238,24 @@ fi
 if [[ -n "$EXISTING_EMAIL" ]]; then
   ADMIN_EMAIL="$EXISTING_EMAIL"
   echo "Reusing existing admin email: $ADMIN_EMAIL"
-else
+elif [[ -n "${LANGSMITH_ADMIN_EMAIL:-}" ]]; then
+  ADMIN_EMAIL="$LANGSMITH_ADMIN_EMAIL"
+  echo "Admin email (from LANGSMITH_ADMIN_EMAIL): $ADMIN_EMAIL"
+elif [[ -t 0 ]]; then
   printf "Admin email: "
   read -r ADMIN_EMAIL
   if [[ -z "$ADMIN_EMAIL" ]]; then
     echo "ERROR: Admin email is required." >&2
     exit 1
   fi
+else
+  # Every other input this script needs comes from terraform.tfvars or terraform
+  # output. Prompting for this one is what forces Pass 2 to have a TTY, so fail
+  # with the way to supply it rather than blocking on a read that cannot return.
+  echo "ERROR: Admin email is required and stdin is not a tty." >&2
+  echo "       Set it to run non-interactively:" >&2
+  echo "         export LANGSMITH_ADMIN_EMAIL=you@example.com" >&2
+  exit 1
 fi
 echo ""
 

--- a/modules/gcp/helm/scripts/init-values.sh
+++ b/modules/gcp/helm/scripts/init-values.sh
@@ -241,21 +241,21 @@ if [[ -n "$EXISTING_EMAIL" ]]; then
 elif [[ -n "${LANGSMITH_ADMIN_EMAIL:-}" ]]; then
   ADMIN_EMAIL="$LANGSMITH_ADMIN_EMAIL"
   echo "Admin email (from LANGSMITH_ADMIN_EMAIL): $ADMIN_EMAIL"
-elif [[ -t 0 ]]; then
+else
+  # read returns 1 at EOF and set -euo pipefail (line 48) aborts there, so a
+  # headless run exits 1 with nothing printed. Tolerate the failure and report on
+  # the empty value instead. Testing "is there a tty" would be the wrong gate:
+  # piped stdin is not a tty either, and several prompts below have no env
+  # override, so `printf ... | init-values.sh` is the only way to drive them.
   printf "Admin email: "
-  read -r ADMIN_EMAIL
+  read -r ADMIN_EMAIL || ADMIN_EMAIL=""
   if [[ -z "$ADMIN_EMAIL" ]]; then
+    echo "" >&2
     echo "ERROR: Admin email is required." >&2
+    echo "       Supply it without a prompt:" >&2
+    echo "         export LANGSMITH_ADMIN_EMAIL=you@example.com" >&2
     exit 1
   fi
-else
-  # Every other input this script needs comes from terraform.tfvars or terraform
-  # output. Prompting for this one is what forces Pass 2 to have a TTY, so fail
-  # with the way to supply it rather than blocking on a read that cannot return.
-  echo "ERROR: Admin email is required and stdin is not a tty." >&2
-  echo "       Set it to run non-interactively:" >&2
-  echo "         export LANGSMITH_ADMIN_EMAIL=you@example.com" >&2
-  exit 1
 fi
 echo ""
 
@@ -307,10 +307,12 @@ fi
 ADMIN_PASSWORD="${TF_VAR_langsmith_admin_password:-$EXISTING_ADMIN_PASSWORD}"
 if [[ -z "$ADMIN_PASSWORD" ]]; then
   printf "Initial admin password: "
-  read -rs ADMIN_PASSWORD
+  read -rs ADMIN_PASSWORD || ADMIN_PASSWORD=""
   echo
   if [[ -z "$ADMIN_PASSWORD" ]]; then
     echo "ERROR: initial admin password is required." >&2
+    echo "       Source infra/scripts/setup-env.sh first so" >&2
+    echo "       TF_VAR_langsmith_admin_password is exported from Secret Manager." >&2
     exit 1
   fi
 fi
@@ -508,7 +510,10 @@ elif [[ "$_first_run" == "true" && "$_enable_sandboxes" != "true" ]]; then
   echo "  4) LangSmith + Deployments + Agent Builder + Insights"
   echo ""
   printf "  Choice [1]: "
-  read -r _tier_choice
+  # EOF falls through to choice 1 rather than aborting: this block only runs on a
+  # first run with no enable_* flags set in terraform.tfvars, and 1 is
+  # "LangSmith only", which is what no flags already means.
+  read -r _tier_choice || _tier_choice=""
   _tier_choice="${_tier_choice:-1}"
 
   case "$_tier_choice" in


### PR DESCRIPTION
## Problem

`init-values.sh:242` prompts unconditionally, with no environment override and no tty check:

```bash
printf "Admin email: "
read -r ADMIN_EMAIL
if [[ -z "$ADMIN_EMAIL" ]]; then
  echo "ERROR: Admin email is required." >&2
  exit 1
fi
```

The only reuse path is scraping `initialOrgAdminEmail` out of a previously generated `values-overrides.yaml`. On a first deploy, this one value is the **sole** reason Pass 2 cannot run unattended — every other input comes from `terraform.tfvars` or `terraform output`.

Pre-exporting `ADMIN_EMAIL` doesn't help: the `read` overwrites it.

Without a tty the read returns empty and the script exits on *"Admin email is required"*, which gives no hint that the actual problem was the missing terminal. Worked around during a real deploy by piping the value in:

```bash
printf "you@example.com\n" | ./helm/scripts/init-values.sh
```

## Already solved in both sibling providers

**AWS** (`aws/helm/scripts/init-values.sh:194`):

```bash
if   [[ -n "$EXISTING_EMAIL" ]];             then ADMIN_EMAIL="$EXISTING_EMAIL"
elif [[ -n "${LANGSMITH_ADMIN_EMAIL:-}" ]];  then ADMIN_EMAIL="$LANGSMITH_ADMIN_EMAIL"
elif [[ -t 0 ]];                             then printf "Admin email: "; read -r ADMIN_EMAIL
```

**Azure** sources it from a Terraform output (`init-values.sh:100`):

```bash
ADMIN_EMAIL=$(terraform -chdir="$INFRA_DIR" output -raw langsmith_admin_email 2>/dev/null) || ADMIN_EMAIL=""
```

GCP had neither. This ports the AWS shape.

## Change

Resolution order becomes:

```
existing values file  >  LANGSMITH_ADMIN_EMAIL  >  interactive prompt  >  error
```

The no-tty branch now names the variable to set rather than failing with a message that points at the wrong thing.

## Testing

`bash -n` clean. Resolution order exercised across all branches:

| existing | `LANGSMITH_ADMIN_EMAIL` | tty | result |
|---|---|---|---|
| `old@x.com` | — | yes | reuse existing |
| `old@x.com` | `new@x.com` | yes | reuse existing |
| — | `new@x.com` | no | from env |
| — | — | yes | prompt |
| — | — | no | error naming the variable |

Existing-file precedence is unchanged, so this cannot alter the value on an established install.

## Scope

GCP only. Azure gets the equivalent treatment in #203.

Found while deploying chart 0.16.11 with all features enabled.



---

## Revised after review (75d1543)

The review on #203 — the Azure version of this change — found two defects that applied
here too, plus two more prompts specific to this script. **This PR no longer adds a
`[[ -t 0 ]]` guard.** The AWS snippet quoted above is still the prior art for the
*resolution order*; the terminal test itself turned out to be the wrong gate.

### `[[ -t 0 ]]` would have regressed piped stdin

Piped input is not a tty, so `printf 'email\npassword\n3\n' | init-values.sh` would have
begun failing with "stdin is not a tty" despite every value being supplied. That matters
more here than on Azure: the admin password and product tier prompts have **no env
override**, so piping is the only way to drive them headlessly.

Now gated on **the read producing nothing** rather than on the terminal.

### Two prompts after the email block aborted silently

`read` returns 1 at EOF and `set -euo pipefail` (line 48) aborts there, so a headless run
exited 1 with nothing printed:

```console
$ printf '' | bash -c 'set -euo pipefail; echo before; read -r X; echo after'
before
  exit=1
```

| prompt | reached when | now |
|---|---|---|
| admin password (310) | `TF_VAR_langsmith_admin_password` unset — `setup-env.sh` not sourced | reports the failure, points at `setup-env.sh` |
| product tier (511) | first run with no `enable_*` flags in tfvars | falls through to choice 1 |

The tier defaults rather than erroring because that block only runs when no `enable_*`
flags are set, and choice 1 is "LangSmith only" — exactly what no flags already means.

External-ClickHouse prompts (574–596) are deliberately untouched: reachable only with an
external ClickHouse configured, and driveable by piping, which this change preserves.

### Resolution order

```
existing values file  >  LANGSMITH_ADMIN_EMAIL  >  prompt / piped stdin  >  error
```

### Testing

Reduced harness carrying `set -euo pipefail` and all three blocks:

| scenario | result |
|---|---|
| piped stdin | completes, tier honoured from input |
| `LANGSMITH_ADMIN_EMAIL` + `TF_VAR_langsmith_admin_password`, no stdin | completes headlessly, tier defaults to 1 |
| nothing supplied, no stdin | reports the missing email instead of exiting silently |
