### PR TITLE
fix(gcp): honour langsmith_helm_chart_version instead of ignoring it

### DIFF
--- a/modules/gcp/helm/scripts/deploy.sh
+++ b/modules/gcp/helm/scripts/deploy.sh
@@ -56,19 +56,42 @@ RELEASE_NAME="${RELEASE_NAME:-langsmith}"
 NAMESPACE="${NAMESPACE:-langsmith}"
 # Pin the chart *line*: deploy the latest 0.16.x, never auto-jump to 0.17.
 # Override with the CHART_VERSION env var for an exact patch if needed.
+#
+# Read the pin from the Terraform output, not from terraform.tfvars. That file is
+# only one of Terraform's variable sources, and not the highest priority one, so
+# a parse of the file alone misses a value set in an .auto.tfvars file, a
+# .tfvars.json file, -var, -var-file or TF_VAR_langsmith_helm_chart_version, and
+# Helm then installs a different chart than the applied configuration declares.
+# The output is a plain string and carries no secret.
+#
+# The read fails when the state carries outputs but not this one, which is a
+# state applied before this output existed, and when terraform cannot run at all.
+# Fall back to the file parse there, so an older state keeps its documented pin.
+# An empty result is an answer rather than a failure: it means no pin, so let the
+# chart line default below apply. A tree with no state at all also reads as
+# empty, and the cluster_name check further down stops that run regardless.
+_chart_version_pin_source="terraform output"
+if ! _chart_version_pin=$(terraform -chdir="$INFRA_DIR" output -raw langsmith_helm_chart_version 2>/dev/null); then
+  _chart_version_pin_source="terraform.tfvars"
+  _chart_version_pin=$(_parse_tfvar "langsmith_helm_chart_version") || _chart_version_pin=""
+fi
+
 # An exported CHART_VERSION outlives the command that set it, so a value left over
 # from an earlier session silently wins over the pin. Say so rather than deploying
-# a different chart than the branch intends.
+# a different chart than the branch intends, and name the version that an unset
+# returns to, which is the pin when there is one.
 if [[ -n "${CHART_VERSION:-}" ]]; then
-  echo "NOTE: CHART_VERSION='${CHART_VERSION}' comes from your environment and overrides the ~0.16.0 pin."
-  echo "      Run 'unset CHART_VERSION' to deploy the pinned chart line."
-fi
-# Fall back to the langsmith_helm_chart_version tfvar before the line default,
-# so the documented pin actually takes effect. Env var still wins.
-if [[ -z "${CHART_VERSION:-}" ]]; then
-  CHART_VERSION=$(_parse_tfvar "langsmith_helm_chart_version") || CHART_VERSION=""
-  [[ -n "$CHART_VERSION" ]] && \
-    echo "Chart version pinned by langsmith_helm_chart_version: ${CHART_VERSION}"
+  echo "NOTE: CHART_VERSION='${CHART_VERSION}' comes from your environment."
+  if [[ -n "$_chart_version_pin" ]]; then
+    echo "      It overrides langsmith_helm_chart_version=${_chart_version_pin} (${_chart_version_pin_source})."
+    echo "      Run 'unset CHART_VERSION' to deploy ${_chart_version_pin}."
+  else
+    echo "      It overrides the ~0.16.0 chart line pin."
+    echo "      Run 'unset CHART_VERSION' to deploy the pinned chart line."
+  fi
+elif [[ -n "$_chart_version_pin" ]]; then
+  CHART_VERSION="$_chart_version_pin"
+  echo "Chart version pinned by langsmith_helm_chart_version (${_chart_version_pin_source}): ${CHART_VERSION}"
 fi
 CHART_VERSION="${CHART_VERSION:-~0.16.0}"
 

--- a/modules/gcp/helm/scripts/deploy.sh
+++ b/modules/gcp/helm/scripts/deploy.sh
@@ -37,6 +37,19 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HELM_DIR="$SCRIPT_DIR/.."
 INFRA_DIR="$HELM_DIR/../infra"
+
+# Defined here rather than further down because CHART_VERSION resolution below
+# needs it, and the chart-line guard runs before the old definition site.
+_parse_tfvar() {
+  awk -v key="$1" '
+    $0 ~ "^[[:space:]]*" key "[[:space:]]*=" {
+      sub(/^[^=]*=[[:space:]]*/, "")
+      if (substr($0, 1, 1) == "\"") { sub(/^"/, ""); sub(/".*$/, "") }
+      else { sub(/#.*$/, ""); gsub(/[[:space:]]+$/, "") }
+      print; exit
+    }
+  ' "$INFRA_DIR/terraform.tfvars" 2>/dev/null || true
+}
 VALUES_DIR="$HELM_DIR/values"
 
 RELEASE_NAME="${RELEASE_NAME:-langsmith}"
@@ -49,6 +62,13 @@ NAMESPACE="${NAMESPACE:-langsmith}"
 if [[ -n "${CHART_VERSION:-}" ]]; then
   echo "NOTE: CHART_VERSION='${CHART_VERSION}' comes from your environment and overrides the ~0.16.0 pin."
   echo "      Run 'unset CHART_VERSION' to deploy the pinned chart line."
+fi
+# Fall back to the langsmith_helm_chart_version tfvar before the line default,
+# so the documented pin actually takes effect. Env var still wins.
+if [[ -z "${CHART_VERSION:-}" ]]; then
+  CHART_VERSION=$(_parse_tfvar "langsmith_helm_chart_version") || CHART_VERSION=""
+  [[ -n "$CHART_VERSION" ]] && \
+    echo "Chart version pinned by langsmith_helm_chart_version: ${CHART_VERSION}"
 fi
 CHART_VERSION="${CHART_VERSION:-~0.16.0}"
 
@@ -133,16 +153,6 @@ fi
 # Values are cut at the closing quote, or at an inline # for bare booleans and
 # numbers, so a commented flag line still reads as a flag. Keep identical to the
 # other copies of this function.
-_parse_tfvar() {
-  awk -v key="$1" '
-    $0 ~ "^[[:space:]]*" key "[[:space:]]*=" {
-      sub(/^[^=]*=[[:space:]]*/, "")
-      if (substr($0, 1, 1) == "\"") { sub(/^"/, ""); sub(/".*$/, "") }
-      else { sub(/#.*$/, ""); gsub(/[[:space:]]+$/, "") }
-      print; exit
-    }
-  ' "$INFRA_DIR/terraform.tfvars" 2>/dev/null || true
-}
 _tfvar_is_true() { local v; v=$(_parse_tfvar "$1"); [[ "$v" == "true" ]]; }
 
 # SmithDB needs chart 0.16 or newer, which the line guard above already


### PR DESCRIPTION
## Problem

`terraform.tfvars.example` and `README.md:371` both document this as the way to pin the chart:

```hcl
# Optional: Pin Helm chart version (recommended for reproducible deploys)
# Empty = use latest available chart version
langsmith_helm_chart_version = ""
```

**Nothing reads it.** Every reference in the GCP module is a declaration or documentation:

```
infra/variables.tf:567          declaration
infra/outputs.tf:255            echoed straight back out
infra/terraform.tfvars.example  documented
README.md:371                   documented
```

`deploy.sh` resolved the version from the environment only:

```bash
CHART_VERSION="${CHART_VERSION:-~0.16.0}"
```

So `langsmith_helm_chart_version = "0.16.11"` silently deploys latest-`0.16.x`. Worse, `outputs.tf` echoes the requested value straight back, so `terraform output` reports `0.16.11` and the pin *looks* effective. The only mechanism that actually worked was the `CHART_VERSION` env var — which that README row doesn't mention.

On the deploy that surfaced this, the pin had to be applied as `CHART_VERSION=0.16.11 make deploy`, and the tfvar left deliberately empty with a comment explaining why.

## Already solved in Azure

`azure/helm/scripts/deploy.sh:432`:

```bash
if [[ -z "$CHART_VERSION" ]]; then
  CHART_VERSION=$(_parse_tfvar "langsmith_helm_chart_version") || CHART_VERSION=""
fi
CHART_VERSION="${CHART_VERSION:-~0.16.0}"
```

This ports that resolution order to GCP: **environment → tfvar → pinned line**.

## Note on the helper move

`_parse_tfvar` is relocated above the `CHART_VERSION` block. It's a pure function over `INFRA_DIR` (set earlier), and the chart-line guard that consumes `CHART_VERSION` runs *before* the old definition site, so it had to move for the lookup to be callable. `_tfvar_is_true` still resolves — it's only invoked later. Verified there's exactly one definition and it precedes every use.

## Testing

`bash -n` clean. Precedence exercised against a real tfvars file:

| `CHART_VERSION` env | tfvar | resolved |
|---|---|---|
| `0.16.5` | `0.16.11` | `0.16.5` (env wins) |
| unset | `0.16.11` | `0.16.11` (pin applies) |
| unset | empty | `~0.16.0` (line default) |

The existing 0.16-line guard still runs against a tfvar-supplied version, so an off-line pin is refused exactly as an off-line env var is.

## Alternative considered

Deleting the variable, its output, and the README row so `CHART_VERSION` is the single documented mechanism. Wiring it up seemed better: it's already documented as the reproducible-deploy knob, it belongs in version-controlled config rather than an env var, and Azure sets the precedent.

## Scope

GCP only. Azure already handles it; AWS doesn't declare the variable at all.

Found while deploying chart 0.16.11 with all features enabled.
