### PR TITLE
fix(gcp): let uninstall.sh run without Terraform state

### DIFF
--- a/modules/gcp/helm/scripts/uninstall.sh
+++ b/modules/gcp/helm/scripts/uninstall.sh
@@ -83,48 +83,57 @@ _parse_tfvar() {
   ' "$INFRA_DIR/terraform.tfvars" 2>/dev/null || true
 }
 
-# ── Resolve config from terraform.tfvars ──────────────────────────────────────
-if [[ ! -f "$INFRA_DIR/terraform.tfvars" ]]; then
-  echo "ERROR: terraform.tfvars not found at $INFRA_DIR/terraform.tfvars" >&2
-  exit 1
+# ── Resolve config from terraform.tfvars (best effort) ────────────────────────
+# TEARDOWN.md Option B documents teardown with no Terraform state and instructs
+# running this script, so hard-requiring terraform.tfvars and `terraform output`
+# made it unusable in exactly the situation it is documented for. Both are now
+# optional: when they resolve, the script retargets kubeconfig itself; when they
+# do not, it falls back to the active kubectl context and names the cluster it is
+# about to act on so the operator can confirm.
+_project_id=""; _name_prefix=""; _environment=""; _region=""
+if [[ -f "$INFRA_DIR/terraform.tfvars" ]]; then
+  _project_id=$(_parse_tfvar "project_id")
+  _name_prefix=$(_parse_tfvar "name_prefix")
+  _environment=$(_parse_tfvar "environment")
+  _region=$(_parse_tfvar "region")
+  _region="${_region:-us-west2}"
+  echo "Resolved from terraform.tfvars:"
+  echo "  name_prefix  = ${_name_prefix:-(empty)}"
+  echo "  environment  = ${_environment:-(empty)}"
+  echo "  project_id   = ${_project_id:-(empty)}"
+  echo "  region       = $_region"
+else
+  echo "NOTE: no terraform.tfvars at $INFRA_DIR."
+  echo "      Falling back to the active kubectl context (TEARDOWN.md Option B)."
 fi
-
-_project_id=$(_parse_tfvar "project_id")
-_name_prefix=$(_parse_tfvar "name_prefix")
-_environment=$(_parse_tfvar "environment")
-_region=$(_parse_tfvar "region")
-_region="${_region:-us-west2}"
-
-if [[ -z "$_project_id" || -z "$_environment" ]]; then
-  echo "ERROR: Could not resolve project_id and/or environment from $INFRA_DIR/terraform.tfvars." >&2
-  echo "       Ensure terraform.tfvars has these values set." >&2
-  exit 1
-fi
-
-echo "Resolved from terraform.tfvars:"
-echo "  name_prefix  = ${_name_prefix:-(empty)}"
-echo "  environment  = $_environment"
-echo "  project_id   = $_project_id"
-echo "  region       = $_region"
 echo ""
 
-# ── Get cluster name from Terraform output ────────────────────────────────────
-echo "Reading cluster name from Terraform output..."
-_cluster_name=$(terraform -chdir="$INFRA_DIR" output -raw cluster_name 2>/dev/null) || {
-  echo "ERROR: Could not read cluster_name. Is 'terraform apply' complete?" >&2
-  exit 1
-}
-echo "  cluster_name = $_cluster_name"
-echo ""
+# ── Point kubeconfig at the right cluster, if Terraform can tell us ───────────
+_cluster_name=""
+if [[ -n "$_project_id" && -n "$_region" ]]; then
+  _cluster_name=$(terraform -chdir="$INFRA_DIR" output -raw cluster_name 2>/dev/null) || _cluster_name=""
+fi
 
-# ── Point kubeconfig at the right cluster ─────────────────────────────────────
-echo "Updating kubeconfig for cluster: $_cluster_name..."
-"$SCRIPT_DIR/get-kubeconfig.sh" "$_cluster_name" "$_region" "$_project_id"
-echo "  Active context: $(kubectl config current-context)"
+if [[ -n "$_cluster_name" ]]; then
+  echo "Updating kubeconfig for cluster: $_cluster_name..."
+  "$SCRIPT_DIR/get-kubeconfig.sh" "$_cluster_name" "$_region" "$_project_id"
+else
+  echo "NOTE: cluster name unavailable from Terraform output — kubeconfig left as is."
+fi
+
+_ctx=$(kubectl config current-context 2>/dev/null) || _ctx=""
+if [[ -z "$_ctx" ]]; then
+  echo "ERROR: no active kubectl context, and no cluster resolvable from Terraform." >&2
+  echo "       Point kubectl at the target cluster first:" >&2
+  echo "         gcloud container clusters get-credentials <cluster> \\" >&2
+  echo "           --region <region> --project <project-id>" >&2
+  exit 1
+fi
+echo "  Active context: $_ctx"
 echo ""
 
 # ── Confirm ───────────────────────────────────────────────────────────────────
-echo "This will remove:"
+echo "This will remove, from cluster context '$_ctx':"
 echo "  - Helm release '$RELEASE_NAME' from namespace '$NAMESPACE'"
 echo "  - Operator-managed LangSmith resources in namespace '$NAMESPACE'"
 echo "  - JuiceFS / sandbox volumes (while CSI is still present)"


### PR DESCRIPTION
## Problem

`TEARDOWN.md` **Option B — Teardown Without Terraform State** instructs running this script:

```bash
DELETE_DATA_PVCS=true ./helm/scripts/uninstall.sh
```

It could never work there. The script hard-required both `terraform.tfvars` and a successful `terraform output` — neither of which exists in the no-state scenario the section is written for:

```
ERROR: terraform.tfvars not found at .../infra/terraform.tfvars
ERROR: Could not read cluster_name. Is 'terraform apply' complete?
```

Hit during a real stateless teardown, which is what surfaced it.

## Why the requirement was too strong

Both inputs exist **only** to point kubeconfig at the right cluster. Nothing resolved from them is referenced after that step:

```console
$ awk 'NR>126 && /_project_id|_environment|_name_prefix|_region|_cluster_name/' uninstall.sh
(no output)
```

So the script was demanding Terraform state to do something `kubectl config current-context` already answers.

## Fix

Both inputs become best-effort, following the shape `azure/helm/scripts/uninstall.sh:36` already uses:

```bash
CLUSTER_NAME=$(terraform -chdir="$INFRA_DIR" output -raw aks_cluster_name 2>/dev/null) || CLUSTER_NAME=""
if [[ -n "$CLUSTER_NAME" && -n "$RESOURCE_GROUP" ]]; then ...
```

- Terraform can name the cluster → retarget kubeconfig, as before.
- It cannot → fall back to the active kubectl context.
- No context either → refuse, with the `get-credentials` command to fix it.

The confirmation prompt now names the context being acted on, so the fallback can't silently hit the wrong cluster:

```
This will remove, from cluster context 'gke_langchain-test-387119_us-west2_ps-dc-test-gke':
  - Helm release 'langsmith' from namespace 'langsmith'
  ...
Proceed? [y/N]
```

## Why this matters beyond convenience

The Option B path is exactly where JuiceFS mount pods have to be removed **while the CSI driver is still running**. With the script unusable, operators fall back to `helm uninstall` directly — which strips the controller first and leaves pods stuck on `juicefs.com/finalizer` with nothing left to clear them. That happened during the teardown that found this: `sandbox-host` and a JuiceFS mount pod both hung, and the finalizer had to be patched out by hand.

## Testing

`bash -n` clean. Both paths exercised against a live cluster, aborting at the confirmation so nothing was touched:

| scenario | behaviour |
|---|---|
| tfvars present, no state | falls back to context, names it, aborts cleanly |
| no tfvars at all | same, plus the Option B note |
| no context, no state | refuses with the `get-credentials` remediation |

Before this change, both of the first two aborted with a hard error instead.

## Scope

GCP only. Azure already tolerates missing outputs. **AWS has the same defect** (2 hard-fails on tfvars in its `uninstall.sh`) and should get the same treatment in a follow-up — I've kept this PR single-provider so the AWS change can be reviewed against its own teardown docs.
