### PR TITLE
fix(aws): let uninstall.sh run without Terraform state

### DIFF
--- a/modules/aws/TEARDOWN.md
+++ b/modules/aws/TEARDOWN.md
@@ -287,9 +287,22 @@ Same as Option A, but since there's no Terraform to clean up k8s-bootstrap resou
 1. Delete ingress resources *before* uninstalling the ALB controller
 2. Uninstall KEDA *after* deleting namespaces that contain ScaledObjects, OR delete ScaledObjects first
 
+Point kubectl at the cluster first, since there is no Terraform output to resolve it:
+
 ```bash
-# Uninstall LangSmith app
-helm uninstall langsmith -n langsmith
+aws eks update-kubeconfig --name <cluster-name> --region $REGION
+kubectl config current-context
+```
+
+```bash
+# Uninstall LangSmith app. Use the script rather than `helm uninstall` directly:
+# the JuiceFS CSI driver ships in this release, so removing the release first
+# strands mount pods on juicefs.com/finalizer with no controller left to clear
+# them. The script deletes sandbox-host and the JuiceFS claims while the driver
+# is still up, and works without Terraform state (it falls back to the active
+# kubectl context). Add DELETE_DATA_PVCS=true to also reclaim the ClickHouse EBS
+# volume, which Terraform does not track.
+DELETE_DATA_PVCS=true ./scripts/uninstall.sh
 
 # Delete the retained LGP CRD
 kubectl delete crd lgps.apps.langchain.ai 2>/dev/null

--- a/modules/aws/helm/scripts/uninstall.sh
+++ b/modules/aws/helm/scripts/uninstall.sh
@@ -67,45 +67,53 @@ _force_clear_stuck_pods() {
   )
 }
 
-# ── Resolve config from terraform.tfvars ──────────────────────────────────────
-if [[ ! -f "$INFRA_DIR/terraform.tfvars" ]]; then
-  echo "ERROR: terraform.tfvars not found at $INFRA_DIR/terraform.tfvars" >&2
-  exit 1
+# ── Resolve config from terraform.tfvars (best effort) ────────────────────────
+# TEARDOWN.md Option B covers teardown with no Terraform state. Hard-requiring
+# terraform.tfvars and `terraform output` made this script unusable there, which
+# is why Option B fell back to a bare `helm uninstall` — the very ordering that
+# strands JuiceFS mount pods on juicefs.com/finalizer. Both inputs are now
+# optional: when they resolve, the script retargets kubeconfig itself; when they
+# do not, it uses the active kubectl context and names it in the confirmation.
+_environment=""; _name_prefix=""; _region="${AWS_REGION:-}"
+if [[ -f "$INFRA_DIR/terraform.tfvars" ]]; then
+  _environment=$(_parse_tfvar "environment") || _environment="${LANGSMITH_ENV:-}"
+  _name_prefix=$(_parse_tfvar "name_prefix") || _name_prefix=""
+  _region=$(_parse_tfvar "region") || _region="${AWS_REGION:-}"
+  echo "Resolved from terraform.tfvars:"
+  echo "  name_prefix  = ${_name_prefix:-(empty)}"
+  echo "  environment  = ${_environment:-(empty)}"
+  echo "  region       = ${_region:-(empty)}"
+else
+  echo "NOTE: no terraform.tfvars at $INFRA_DIR."
+  echo "      Falling back to the active kubectl context (TEARDOWN.md Option B)."
 fi
-
-_environment=$(_parse_tfvar "environment") || _environment="${LANGSMITH_ENV:-}"
-_name_prefix=$(_parse_tfvar "name_prefix") || _name_prefix=""
-_region=$(_parse_tfvar "region") || _region="${AWS_REGION:-}"
-
-if [[ -z "$_environment" || -z "$_region" ]]; then
-  echo "ERROR: Could not resolve environment and/or region from $INFRA_DIR/terraform.tfvars." >&2
-  echo "       Ensure terraform.tfvars has 'environment' and 'region' set." >&2
-  exit 1
-fi
-
-echo "Resolved from terraform.tfvars:"
-echo "  name_prefix  = ${_name_prefix:-(empty)}"
-echo "  environment  = $_environment"
-echo "  region       = $_region"
 echo ""
 
-# ── Get cluster name from Terraform output ────────────────────────────────────
-echo "Reading cluster name from Terraform output..."
-_cluster_name=$(terraform -chdir="$INFRA_DIR" output -raw cluster_name 2>/dev/null) || {
-  echo "ERROR: Could not read cluster_name. Is 'terraform apply' complete?" >&2
-  exit 1
-}
-echo "  cluster_name = $_cluster_name"
-echo ""
+# ── Point kubeconfig at the right cluster, if Terraform can tell us ───────────
+_cluster_name=""
+if [[ -n "$_region" ]]; then
+  _cluster_name=$(terraform -chdir="$INFRA_DIR" output -raw cluster_name 2>/dev/null) || _cluster_name=""
+fi
 
-# ── Point kubeconfig at the right cluster ─────────────────────────────────────
-echo "Updating kubeconfig for cluster: $_cluster_name..."
-aws eks update-kubeconfig --name "$_cluster_name" --region "$_region"
-echo "  Active context: $(kubectl config current-context)"
+if [[ -n "$_cluster_name" ]]; then
+  echo "Updating kubeconfig for cluster: $_cluster_name..."
+  aws eks update-kubeconfig --name "$_cluster_name" --region "$_region"
+else
+  echo "NOTE: cluster name unavailable from Terraform output — kubeconfig left as is."
+fi
+
+_ctx=$(kubectl config current-context 2>/dev/null) || _ctx=""
+if [[ -z "$_ctx" ]]; then
+  echo "ERROR: no active kubectl context, and no cluster resolvable from Terraform." >&2
+  echo "       Point kubectl at the target cluster first:" >&2
+  echo "         aws eks update-kubeconfig --name <cluster> --region <region>" >&2
+  exit 1
+fi
+echo "  Active context: $_ctx"
 echo ""
 
 # ── Confirm ───────────────────────────────────────────────────────────────────
-echo "This will remove:"
+echo "This will remove, from cluster context '$_ctx':"
 echo "  - Helm release '$RELEASE_NAME' from namespace '$NAMESPACE'"
 echo "  - ExternalSecret 'langsmith-config' from namespace '$NAMESPACE'"
 echo "  - ClusterSecretStore 'langsmith-ssm'"


### PR DESCRIPTION
Parity follow-up to #200, which made the same change for GCP.

## Problem

`TEARDOWN.md` **Option B — Teardown Without Terraform State** is written for exactly the case where `uninstall.sh` cannot run:

```bash
if [[ ! -f "$INFRA_DIR/terraform.tfvars" ]]; then
  echo "ERROR: terraform.tfvars not found at $INFRA_DIR/terraform.tfvars" >&2
  exit 1
fi
...
_cluster_name=$(terraform -chdir="$INFRA_DIR" output -raw cluster_name 2>/dev/null) || {
  echo "ERROR: Could not read cluster_name. Is 'terraform apply' complete?" >&2
```

Both inputs exist **only** to point kubeconfig at the cluster. Nothing resolved from them is referenced after that step:

```console
$ awk 'NR>105 && /_environment|_name_prefix|_region|_cluster_name/' uninstall.sh
(no output)
```

## The part that makes this more than an inconvenience

Because the script was unusable, **Option B B1 told operators to do the unsafe thing**:

```bash
# Uninstall LangSmith app
helm uninstall langsmith -n langsmith
```

That is the exact ordering Option A warns against at line 78 of the same file:

> the JuiceFS CSI driver is part of the LangSmith Helm release. Uninstalling the release before the JuiceFS PVCs leaves mount pods holding `juicefs.com/finalizer` with no controller left to clear it, so `kubectl delete` blocks past the grace period and never returns. `uninstall.sh` therefore deletes the sandbox-host workload and the JuiceFS claims first…

So the doc contradicted itself, because the safe path was unavailable in the stateless case. This exact failure was hit on GCP during a real stateless teardown — `sandbox-host` and a JuiceFS mount pod both hung, and the finalizer had to be patched out by hand.

## Fix

Both inputs become best-effort, matching `azure/helm/scripts/uninstall.sh:36` and the GCP change in #200:

- Terraform can name the cluster → retarget kubeconfig, as before
- It cannot → fall back to the active kubectl context
- No context either → refuse, printing the `aws eks update-kubeconfig` command

The confirmation prompt now names the context being acted on:

```
This will remove, from cluster context 'arn:aws:eks:us-west-2:...:cluster/acme-test':
  - Helm release 'langsmith' from namespace 'langsmith'
  ...
```

`TEARDOWN.md` Option B B1 now uses the script, with `DELETE_DATA_PVCS=true` so the untracked ClickHouse EBS volume is reclaimed rather than orphaned.

## Testing

`bash -n` clean; confirmed no resolved variable is referenced after the kubeconfig step.

Not exercised against a live EKS cluster — I don't have one. The equivalent GCP change (#200) was verified end to end against a live GKE cluster in both fallback modes, and the control flow here is identical; the only provider-specific line is `aws eks update-kubeconfig` in place of `get-kubeconfig.sh`. Worth a smoke test by someone with an EKS cluster before merge.

## Scope

AWS only. GCP is #200; Azure already tolerates missing outputs.
