### PR TITLE
feat(aws): add langsmith_helm_chart_version to pin the chart from tfvars

### DIFF
--- a/modules/aws/helm/scripts/deploy.sh
+++ b/modules/aws/helm/scripts/deploy.sh
@@ -40,6 +40,14 @@ if [[ -n "${CHART_VERSION:-}" ]]; then
   echo "NOTE: CHART_VERSION='${CHART_VERSION}' comes from your environment and overrides the ~0.16.0 pin."
   echo "      Run 'unset CHART_VERSION' to deploy the pinned chart line."
 fi
+# Fall back to the langsmith_helm_chart_version tfvar before the line default, so
+# the pin can live in version-controlled config rather than only in a shell
+# variable. Env var still wins. Matches Azure and GCP.
+if [[ -z "${CHART_VERSION:-}" ]]; then
+  CHART_VERSION=$(_parse_tfvar "langsmith_helm_chart_version") || CHART_VERSION=""
+  [[ -n "$CHART_VERSION" ]] && \
+    echo "Chart version pinned by langsmith_helm_chart_version: ${CHART_VERSION}"
+fi
 CHART_VERSION="${CHART_VERSION:-~0.16.0}"
 
 _chart_version_supports_sandboxes() {

--- a/modules/aws/infra/terraform.tfvars.example
+++ b/modules/aws/infra/terraform.tfvars.example
@@ -480,6 +480,20 @@ s3_ttl_long_days  = 400    # delete long-lived traces after ~13 months
 langsmith_namespace = "langsmith"
 
 #------------------------------------------------------------------------------
+# HELM CHART VERSION
+#------------------------------------------------------------------------------
+# Pin the chart to an exact patch for reproducible deploys. Empty deploys the
+# latest patch on the pinned 0.16 line, so a rebuild months apart can land on a
+# different chart. Must be a 0.16.x version — deploy.sh refuses anything else.
+#
+# The CHART_VERSION environment variable still overrides this when set:
+#   CHART_VERSION=0.16.11 make deploy
+#
+# List what is published with:
+#   helm search repo langchain/langsmith --versions
+# langsmith_helm_chart_version = "0.16.11"
+
+#------------------------------------------------------------------------------
 # SECURITY ADD-ONS (all optional, all default to off)
 #------------------------------------------------------------------------------
 # These are independent features you can enable for compliance or auditing.

--- a/modules/aws/infra/variables.tf
+++ b/modules/aws/infra/variables.tf
@@ -602,6 +602,17 @@ variable "letsencrypt_email" {
   default     = ""
 }
 
+variable "langsmith_helm_chart_version" {
+  type        = string
+  description = "Pin the LangSmith Helm chart to an exact patch, e.g. \"0.16.11\". Empty deploys the latest patch on the pinned 0.16 line. Read by helm/scripts/deploy.sh; the CHART_VERSION environment variable still takes precedence."
+  default     = ""
+
+  validation {
+    condition     = var.langsmith_helm_chart_version == "" || can(regex("^0\\.16\\.", var.langsmith_helm_chart_version))
+    error_message = "langsmith_helm_chart_version must be empty or a 0.16.x version — deploy.sh refuses anything off the pinned chart line."
+  }
+}
+
 variable "langsmith_domain" {
   type        = string
   description = "Custom domain for LangSmith (e.g. langsmith.example.com). When set (and acm_certificate_arn is empty), activates the dns module to auto-provision a Route 53 hosted zone, ACM certificate, and alias record. Leave empty to skip DNS/ACM and access LangSmith via the ALB hostname directly."


### PR DESCRIPTION
Parity follow-up. Azure and GCP both support pinning the chart patch from `terraform.tfvars`; AWS had no equivalent.

## Problem

`aws/helm/scripts/deploy.sh:43` resolved the version from the environment only:

```bash
CHART_VERSION="${CHART_VERSION:-~0.16.0}"
```

`grep -c 'variable "langsmith_helm_chart_version"' aws/infra/variables.tf` → **0**. The variable simply doesn't exist on AWS.

So the only way to pin an exact patch is an env var on the deploy command:

```bash
CHART_VERSION=0.16.11 make deploy
```

That lives outside version control, is easy to forget between deploys, and an exported value silently persists across shell sessions — something the script already warns about:

```
NOTE: CHART_VERSION='...' comes from your environment and overrides the ~0.16.0 pin.
```

Without a pin, `make deploy` takes the newest patch on the 0.16 line, so the same committed config deployed months apart can land on different charts.

## Prior art

| Provider | tfvar declared | read by `deploy.sh` |
|---|:--:|:--:|
| Azure | ✅ | ✅ `deploy.sh:432` |
| GCP | ✅ | ✅ (after #199) |
| AWS | ❌ | ❌ |

Azure's implementation:

```bash
if [[ -z "$CHART_VERSION" ]]; then
  CHART_VERSION=$(_parse_tfvar "langsmith_helm_chart_version") || CHART_VERSION=""
fi
CHART_VERSION="${CHART_VERSION:-~0.16.0}"
```

## Change

- Declare `langsmith_helm_chart_version` in `infra/variables.tf`
- Wire it into `deploy.sh` between the env var and the line default
- Document it in `terraform.tfvars.example`, including that `CHART_VERSION` still overrides

Resolution order: **environment → tfvar → pinned line**, matching Azure and GCP.

## Validation rule

The variable rejects anything outside `0.16.x`:

```hcl
validation {
  condition     = var.langsmith_helm_chart_version == "" || can(regex("^0\\.16\\.", var.langsmith_helm_chart_version))
  error_message = "langsmith_helm_chart_version must be empty or a 0.16.x version — deploy.sh refuses anything off the pinned chart line."
}
```

This surfaces an off-line pin at plan time rather than at `deploy.sh`'s chart-line guard several minutes later. It intentionally mirrors a guard that already exists downstream rather than introducing new policy.

## Testing

`terraform validate` passes on the full module. `bash -n` clean on `deploy.sh`. Validation exercised in an isolated module:

| value | result |
|---|---|
| `0.16.11` | accepted |
| `0.16.0` | accepted |
| *(empty)* | accepted |
| `0.17.1` | rejected |
| `0.15.9` | rejected |

No helper relocation was needed — `deploy.sh` sources `_common.sh` at line 30, well before `CHART_VERSION` is resolved at line 43. (GCP needed `_parse_tfvar` moved; AWS does not.)

## Scope

AWS only. Azure already had this; GCP is #199.
