### PR TITLE
fix(azure): fail with guidance when admin email cannot be prompted for

### DIFF
--- a/modules/azure/helm/scripts/init-values.sh
+++ b/modules/azure/helm/scripts/init-values.sh
@@ -178,7 +178,23 @@ if [[ -z "$ADMIN_EMAIL" ]]; then
   fi
 fi
 
+if [[ -z "$ADMIN_EMAIL" && -n "${LANGSMITH_ADMIN_EMAIL:-}" ]]; then
+  ADMIN_EMAIL="$LANGSMITH_ADMIN_EMAIL"
+  info "Admin email (from LANGSMITH_ADMIN_EMAIL): $ADMIN_EMAIL"
+fi
+
 if [[ -z "$ADMIN_EMAIL" ]]; then
+  # Without a tty the read returns empty and the generic "Admin email is
+  # required" gives no hint that the run failed for lack of a terminal. Every
+  # other input comes from terraform.tfvars or terraform output, so this is the
+  # only value that would otherwise force Pass 2 to be interactive.
+  if [[ ! -t 0 ]]; then
+    fail "Admin email is required and stdin is not a tty"
+    info "Set it to run non-interactively:"
+    info "  export LANGSMITH_ADMIN_EMAIL=you@example.com"
+    info "Or set langsmith_admin_email in terraform.tfvars and re-apply."
+    exit 1
+  fi
   printf "  Initial org admin email: "
   read -r ADMIN_EMAIL
   if [[ -z "$ADMIN_EMAIL" ]]; then

--- a/modules/azure/helm/scripts/init-values.sh
+++ b/modules/azure/helm/scripts/init-values.sh
@@ -159,9 +159,12 @@ if [[ -z "$HOSTNAME" ]]; then
   warn "No hostname found — set dns_label or langsmith_domain in terraform.tfvars"
   echo ""
   printf "  Enter hostname (e.g. langsmith.example.com): "
-  read -r HOSTNAME
+  read -r HOSTNAME || HOSTNAME=""
   if [[ -z "$HOSTNAME" ]]; then
+    echo ""
     fail "Hostname is required"
+    info "Set dns_label or langsmith_domain in terraform.tfvars and re-apply,"
+    info "or pipe the value in: printf '%s\\n' host.example.com | $(basename "$0")"
     exit 1
   fi
 fi
@@ -184,21 +187,19 @@ if [[ -z "$ADMIN_EMAIL" && -n "${LANGSMITH_ADMIN_EMAIL:-}" ]]; then
 fi
 
 if [[ -z "$ADMIN_EMAIL" ]]; then
-  # Without a tty the read returns empty and the generic "Admin email is
-  # required" gives no hint that the run failed for lack of a terminal. Every
-  # other input comes from terraform.tfvars or terraform output, so this is the
-  # only value that would otherwise force Pass 2 to be interactive.
-  if [[ ! -t 0 ]]; then
-    fail "Admin email is required and stdin is not a tty"
-    info "Set it to run non-interactively:"
-    info "  export LANGSMITH_ADMIN_EMAIL=you@example.com"
-    info "Or set langsmith_admin_email in terraform.tfvars and re-apply."
-    exit 1
-  fi
+  # `read` returns 1 at EOF and set -euo pipefail aborts the script there, so a
+  # headless run exits 1 with nothing printed. Tolerate the failure and report on
+  # the empty value instead, which also keeps `printf '...' | init-values.sh`
+  # working — several prompts below have no env override, so piped stdin is the
+  # only way to drive them.
   printf "  Initial org admin email: "
-  read -r ADMIN_EMAIL
+  read -r ADMIN_EMAIL || ADMIN_EMAIL=""
   if [[ -z "$ADMIN_EMAIL" ]]; then
+    echo ""
     fail "Admin email is required"
+    info "Supply it without a prompt using either:"
+    info "  export LANGSMITH_ADMIN_EMAIL=you@example.com"
+    info "  langsmith_admin_email = \"you@example.com\"  in terraform.tfvars, then re-apply"
     exit 1
   fi
 fi
@@ -213,7 +214,10 @@ if [[ "$_sizing_profile" == "default" ]]; then
   echo "    4) production — HA production (3+ replicas, higher CPU/mem)"
   echo ""
   printf "  Sizing choice [1]: "
-  read -r _sizing_choice
+  # EOF here is not an error: the block only runs when sizing_profile is already
+  # "default" in terraform.tfvars, so falling through to 1 preserves exactly what
+  # was configured rather than aborting a headless run.
+  read -r _sizing_choice || _sizing_choice=""
   case "${_sizing_choice:-1}" in
     2) _sizing_profile="minimum" ;;
     3) _sizing_profile="dev" ;;


### PR DESCRIPTION
Parity follow-up to #198, which made the equivalent change for GCP.

## Problem

`init-values.sh` resolves the admin email from the `langsmith_admin_email` Terraform output (line 100), then from a previously generated values file, and otherwise prompts:

```bash
if [[ -z "$ADMIN_EMAIL" ]]; then
  printf "  Initial org admin email: "
  read -r ADMIN_EMAIL
  if [[ -z "$ADMIN_EMAIL" ]]; then
    fail "Admin email is required"
    exit 1
  fi
fi
```

With no terminal the `read` returns empty and the script exits on the generic *"Admin email is required"* — which reads as a missing value, not as "this needs a tty". Every other input comes from `terraform.tfvars` or `terraform output`, so when the output is unset this is the only thing forcing Pass 2 to be interactive.

Milder than the GCP case in #198 — Azure at least has the Terraform output path, so the normal flow is covered — but it's the remaining parity gap: AWS and GCP both have `[[ -t 0 ]]` guards, Azure has none.

```console
$ grep -c '\[\[ -t 0 \]\]' */helm/scripts/init-values.sh
aws:1  azure:0  gcp:0
```

(GCP is 0 on `main` today — #198 adds a guard there but is not merged. An earlier
revision of this description implied otherwise.)

**Superseded:** this PR no longer adds a `[[ -t 0 ]]` guard. Review showed that test
is wrong — piped stdin is not a tty either, so it regressed
`printf '...' | init-values.sh`. The fix now gates on the read producing nothing.
See the "Revised after review" section at the end.

## Change

- Explicit `[[ -t 0 ]]` check that names **both** ways to supply the value
- Accept `LANGSMITH_ADMIN_EMAIL` as an override, matching AWS and GCP

Resolution order becomes:

```
terraform output  >  existing values file  >  LANGSMITH_ADMIN_EMAIL  >  prompt  >  error
```

The Terraform output keeps precedence, so this cannot change the value on an existing install — it only affects runs that would previously have blocked or failed unhelpfully.

Error output uses the module's existing `fail`/`info` helpers:

```
  ✘  Admin email is required and stdin is not a tty
  ℹ  Set it to run non-interactively:
  ℹ    export LANGSMITH_ADMIN_EMAIL=you@example.com
  ℹ  Or set langsmith_admin_email in terraform.tfvars and re-apply.
```

## Testing

`bash -n` clean. Resolution order exercised across all branches:

| terraform output | `LANGSMITH_ADMIN_EMAIL` | tty | result |
|---|---|---|---|
| `tf@x.com` | — | yes | use output |
| `tf@x.com` | `env@x.com` | no | use output (precedence held) |
| — | `env@x.com` | no | from env |
| — | — | yes | prompt |
| — | — | no | error naming both options |

## Scope

Azure only. AWS already had this; GCP is #198. Completes `[[ -t 0 ]]` coverage across all three providers.



---

## Revised after review (cb38275)

Three findings, all confirmed and fixed.

### 1. `[[ ! -t 0 ]]` regressed piped stdin

Piped stdin is not a tty, so `printf 'host\nemail\n2\n' | init-values.sh` — which
worked before — started failing with "stdin is not a tty" despite every value being
supplied. That matters more here than elsewhere: the sizing prompt and the six
external-ClickHouse prompts have no env override, so piping is the only headless path.

Now gated on **the read producing nothing** rather than on the terminal, which keeps
piping working and still replaces the silent failure.

### 2. The guard did not achieve its stated goal

`read` returns 1 at EOF and `set -euo pipefail` (line 31) aborts there, so a headless run
exited 1 with nothing printed:

```console
$ printf '' | bash -c 'set -euo pipefail; echo before; read -r X; echo after'
before
  exit=1
```

And the **hostname** prompt at 162 runs *before* the email block, so with `dns_label` and
`langsmith_domain` unset the new message never printed at all. The **sizing** prompt at 216
aborted the same way whenever `sizing_profile` was absent or `"default"`.

All three now tolerate EOF:

| prompt | behaviour at EOF |
|---|---|
| hostname (162) | reports the failure, naming the tfvars keys to set |
| admin email (199) | reports the failure, naming both the env var and the tfvar |
| sizing (216) | falls through to the documented default rather than aborting |

Sizing defaults rather than erroring because the block only runs when `sizing_profile` is
already `"default"` in tfvars — falling through preserves exactly what was configured.

### 3. The comment misstated the failure

It claimed the generic "Admin email is required" prints; that line is unreachable at EOF
for the reason above. It also called admin email "the only value that would otherwise
force Pass 2 to be interactive", which hostname and sizing contradict. Both corrected.

### Scope note

External-ClickHouse prompts (592–622) are deliberately untouched: reachable only with an
external ClickHouse configured, and driveable by piping, which this change restores.

### On stdout vs stderr

Kept on stdout. Every `fail` in this file writes to stdout (`grep -c 'fail .*>&2'` → 0), so
matching the file wins over matching `seed-keyvault-secrets.sh`. Happy to switch if the
stderr convention is meant to be module-wide — that would be a separate sweep across all
`fail` call sites rather than just the ones I added.

### Testing

Reduced harness carrying `set -euo pipefail` and all three blocks:

| scenario | result |
|---|---|
| piped stdin | completes, sizing honoured from input |
| env email + tfvars hostname, no stdin | completes, sizing falls back to `default` |
| nothing supplied, no stdin | hostname error naming the tfvars keys |
| hostname only, no stdin | email error naming env var and tfvar |

Before this revision, the last three exited 1 with no output.
