### PR TITLE
feat(aws): add SmithDB sizing and migration defaults

### DIFF
--- a/modules/aws/SMITHDB.md
+++ b/modules/aws/SMITHDB.md
@@ -38,11 +38,11 @@ Apply infrastructure, then generate values:
 make init-values
 ```
 
-SmithDB requires an explicit stable Helm chart version of 0.16 or newer.
-Infrastructure enablement does not upgrade the normal repository chart line:
+SmithDB requires a stable Helm chart version of 0.16 or newer.
+The deploy script already pins the latest 0.16.x chart (`~0.16.0`):
 
 ```sh
-CHART_VERSION=0.16.21 make deploy
+make deploy
 ```
 
 The generated values deploy SmithDB services with all LangSmith integration

--- a/modules/aws/helm/values/examples/langsmith-values-sizing-dev.yaml
+++ b/modules/aws/helm/values/examples/langsmith-values-sizing-dev.yaml
@@ -175,6 +175,73 @@ fleetTriggerServer:
 # are sized via the top-level apiServer/queue resources in their own overlays
 # (langsmith-values-fleet.yaml, -standalone-polly.yaml, -standalone-insights.yaml).
 
+# -- SmithDB ---------------------------------------------------------------
+
+smithdb:
+  query:
+    deployment:
+      resources:
+        requests:
+          cpu: "4"
+          memory: "8Gi"
+          ephemeral-storage: "200Gi"
+        limits:
+          cpu: "4"
+          memory: "8Gi"
+          ephemeral-storage: "200Gi"
+    autoscaling:
+      minReplicas: 1
+
+  ingestion:
+    deployment:
+      resources:
+        requests:
+          cpu: "4"
+          memory: "8Gi"
+          ephemeral-storage: "100Gi"
+        limits:
+          cpu: "4"
+          memory: "8Gi"
+          ephemeral-storage: "100Gi"
+    autoscaling:
+      minReplicas: 1
+
+  compaction:
+    deployment:
+      replicas: 1
+      resources:
+        requests:
+          cpu: "2"
+          memory: "4Gi"
+        limits:
+          cpu: "2"
+          memory: "4Gi"
+
+  compactionWorker:
+    deployment:
+      resources:
+        requests:
+          cpu: "8"
+          memory: "16Gi"
+          ephemeral-storage: "100Gi"
+        limits:
+          cpu: "8"
+          memory: "16Gi"
+          ephemeral-storage: "100Gi"
+    autoscaling:
+      minReplicas: 1
+
+  clusterManager:
+    deployment:
+      replicas: 1
+      resources:
+        requests:
+          cpu: "250m"
+          memory: "256Mi"
+        limits:
+          cpu: "250m"
+          memory: "256Mi"
+
 # -- In-cluster data services (Tier 1 only) -----------------------------------
 # These apply when using in-cluster postgres, redis, and clickhouse.
 # If you're pointing at managed services (RDS, ElastiCache, ClickHouse Cloud),

--- a/modules/aws/helm/values/examples/langsmith-values-sizing-minimum.yaml
+++ b/modules/aws/helm/values/examples/langsmith-values-sizing-minimum.yaml
@@ -168,6 +168,73 @@ fleetTriggerServer:
 # are sized via the top-level apiServer/queue resources in their own overlays
 # (langsmith-values-fleet.yaml, -standalone-polly.yaml, -standalone-insights.yaml).
 
+# -- SmithDB ---------------------------------------------------------------
+
+smithdb:
+  query:
+    deployment:
+      resources:
+        requests:
+          cpu: "4"
+          memory: "8Gi"
+          ephemeral-storage: "200Gi"
+        limits:
+          cpu: "4"
+          memory: "8Gi"
+          ephemeral-storage: "200Gi"
+    autoscaling:
+      minReplicas: 1
+
+  ingestion:
+    deployment:
+      resources:
+        requests:
+          cpu: "4"
+          memory: "8Gi"
+          ephemeral-storage: "100Gi"
+        limits:
+          cpu: "4"
+          memory: "8Gi"
+          ephemeral-storage: "100Gi"
+    autoscaling:
+      minReplicas: 1
+
+  compaction:
+    deployment:
+      replicas: 1
+      resources:
+        requests:
+          cpu: "2"
+          memory: "4Gi"
+        limits:
+          cpu: "2"
+          memory: "4Gi"
+
+  compactionWorker:
+    deployment:
+      resources:
+        requests:
+          cpu: "8"
+          memory: "16Gi"
+          ephemeral-storage: "100Gi"
+        limits:
+          cpu: "8"
+          memory: "16Gi"
+          ephemeral-storage: "100Gi"
+    autoscaling:
+      minReplicas: 1
+
+  clusterManager:
+    deployment:
+      replicas: 1
+      resources:
+        requests:
+          cpu: "250m"
+          memory: "256Mi"
+        limits:
+          cpu: "250m"
+          memory: "256Mi"
+
 # -- In-cluster data services (Tier 1 only) -----------------------------------
 # ClickHouse is the one component that actually uses its resources.
 # Don't go below this or queries will time out.

--- a/modules/aws/helm/values/examples/langsmith-values-sizing-production-large.yaml
+++ b/modules/aws/helm/values/examples/langsmith-values-sizing-production-large.yaml
@@ -204,6 +204,85 @@ fleetTriggerServer:
         cpu: "2"
         memory: "4Gi"
 
+# -- SmithDB ---------------------------------------------------------------
+
+smithdb:
+  query:
+    deployment:
+      resources:
+        requests:
+          cpu: "28"
+          memory: "50Gi"
+          ephemeral-storage: "1000Gi"
+        limits:
+          cpu: "28"
+          memory: "50Gi"
+          ephemeral-storage: "1000Gi"
+      volumes:
+        - name: local-ssd-storage
+          emptyDir:
+            sizeLimit: "1000Gi"
+    autoscaling:
+      minReplicas: 4
+
+  ingestion:
+    deployment:
+      resources:
+        requests:
+          cpu: "56"
+          memory: "150Gi"
+          ephemeral-storage: "1000Gi"
+        limits:
+          cpu: "56"
+          memory: "150Gi"
+          ephemeral-storage: "1000Gi"
+      volumes:
+        - name: local-ssd-storage
+          emptyDir:
+            sizeLimit: "1000Gi"
+    autoscaling:
+      minReplicas: 2
+
+  compaction:
+    deployment:
+      replicas: 1
+      resources:
+        requests:
+          cpu: "8"
+          memory: "16Gi"
+        limits:
+          cpu: "8"
+          memory: "16Gi"
+
+  compactionWorker:
+    deployment:
+      resources:
+        requests:
+          cpu: "28"
+          memory: "50Gi"
+          ephemeral-storage: "300Gi"
+        limits:
+          cpu: "28"
+          memory: "50Gi"
+          ephemeral-storage: "300Gi"
+      volumes:
+        - name: local-ssd-storage
+          emptyDir:
+            sizeLimit: "300Gi"
+    autoscaling:
+      minReplicas: 4
+
+  clusterManager:
+    deployment:
+      replicas: 1
+      resources:
+        requests:
+          cpu: "2"
+          memory: "2Gi"
+        limits:
+          cpu: "2"
+          memory: "2Gi"
+
 # -- In-cluster ClickHouse (dev/POC only — production should use external) -----
 # High/High pattern: 14+ CPU / 24+ Gi per node, 3-node cluster recommended.
 # In-cluster ClickHouse is a single StatefulSet pod — it cannot do 3-node.

--- a/modules/aws/helm/values/examples/langsmith-values-sizing-production.yaml
+++ b/modules/aws/helm/values/examples/langsmith-values-sizing-production.yaml
@@ -208,6 +208,73 @@ fleetTriggerServer:
         cpu: "1"
         memory: "2Gi"
 
+# -- SmithDB ---------------------------------------------------------------
+
+smithdb:
+  query:
+    deployment:
+      resources:
+        requests:
+          cpu: "28"
+          memory: "48Gi"
+          ephemeral-storage: "200Gi"
+        limits:
+          cpu: "28"
+          memory: "48Gi"
+          ephemeral-storage: "200Gi"
+    autoscaling:
+      minReplicas: 1
+
+  ingestion:
+    deployment:
+      resources:
+        requests:
+          cpu: "16"
+          memory: "32Gi"
+          ephemeral-storage: "100Gi"
+        limits:
+          cpu: "16"
+          memory: "32Gi"
+          ephemeral-storage: "100Gi"
+    autoscaling:
+      minReplicas: 1
+
+  compaction:
+    deployment:
+      replicas: 1
+      resources:
+        requests:
+          cpu: "4"
+          memory: "8Gi"
+        limits:
+          cpu: "4"
+          memory: "8Gi"
+
+  compactionWorker:
+    deployment:
+      resources:
+        requests:
+          cpu: "16"
+          memory: "32Gi"
+          ephemeral-storage: "100Gi"
+        limits:
+          cpu: "16"
+          memory: "32Gi"
+          ephemeral-storage: "100Gi"
+    autoscaling:
+      minReplicas: 3
+
+  clusterManager:
+    deployment:
+      replicas: 1
+      resources:
+        requests:
+          cpu: "250m"
+          memory: "256Mi"
+        limits:
+          cpu: "250m"
+          memory: "256Mi"
+
 # -- In-cluster ClickHouse (dev/POC only — production should use external) -----
 
 clickhouse:

--- a/modules/aws/helm/values/examples/langsmith-values-smithdb.yaml
+++ b/modules/aws/helm/values/examples/langsmith-values-smithdb.yaml
@@ -24,13 +24,6 @@ smithdb:
   # groups in infra.
   query:
     deployment:
-      volumes:
-        - name: local-ssd-storage
-          emptyDir:
-            sizeLimit: 200Gi
-      volumeMounts:
-        - name: local-ssd-storage
-          mountPath: /data
       nodeSelector:
         smithdb-local/instance-store: "true"
       tolerations:
@@ -48,6 +41,27 @@ smithdb:
           value: "true"
           effect: NoSchedule
   compactionWorker:
+    deployment:
+      nodeSelector:
+        smithdb-local/instance-store: "true"
+      tolerations:
+        - key: smithdb-local/instance-store
+          operator: Equal
+          value: "true"
+          effect: NoSchedule
+
+  # The chart defaults to one 8-vCPU migration pod, which the documented
+  # formula estimates at about 40 million historical runs per day. Actual
+  # throughput varies.
+  migration:
+    taskdb:
+      postgres:
+        auth:
+          # Set TASKDB_PASSWORD to a stable value, then create this Secret in
+          # the Helm release namespace before enabling migration:
+          # kubectl create secret generic smithdb-migration-taskdb --namespace "${NAMESPACE:-langsmith}" --from-literal=postgres_password="$TASKDB_PASSWORD"
+          existingSecretName: "smithdb-migration-taskdb"
+          passwordSecretKey: "postgres_password"
     deployment:
       nodeSelector:
         smithdb-local/instance-store: "true"

--- a/modules/aws/infra/scripts/quickstart.sh
+++ b/modules/aws/infra/scripts/quickstart.sh
@@ -1033,8 +1033,7 @@ fi
 
 if [[ "$ENABLE_SMITHDB" == "true" ]]; then
   echo ""
-  printf "  ${DIM}SmithDB requires an explicit stable chart version of 0.16 or newer:${RESET}\n"
-  printf "     ${CYAN}make init-values && CHART_VERSION=0.16.21 make deploy${RESET}\n"
+  printf "  ${DIM}SmithDB uses the repository's pinned 0.16.x chart line.${RESET}\n"
 fi
 
 echo ""

--- a/modules/aws/infra/variables.tf
+++ b/modules/aws/infra/variables.tf
@@ -1027,7 +1027,7 @@ variable "smithdb_capacity_type" {
 variable "smithdb_instance_store_sizes" {
   type        = list(string)
   description = "Allowed instance sizes for the SmithDB instance-store pool (karpenter.k8s.aws/instance-size). Combined with the local-NVMe requirement, this selects families like m6id/m5d/r6id at these sizes."
-  default     = ["4xlarge", "8xlarge"]
+  default     = ["4xlarge", "8xlarge", "16xlarge"]
 }
 
 variable "smithdb_instance_store_min_local_nvme_gib" {


### PR DESCRIPTION
## Summary

- align SmithDB resources and replica floors with the Small, Medium, and Large sizing tiers
- keep resource requests and limits equal across all sizing profiles
- add TaskDB Secret guidance and instance-store placement for historical migration
- use the pinned Helm 0.16.x chart line and support 16xlarge instance-store nodes

## Validation

- `bash agents/check.sh modules/aws/infra`
- `bash agents/check.sh --scripts`
- rendered SmithDB workloads and autoscalers against Helm chart 0.16.12
- parsed the changed YAML files and ran `git diff --check`
