### PR TITLE
fix(azure): derive the Redis client mode from the clustering policy

### DIFF
--- a/modules/azure/SERVICES.md
+++ b/modules/azure/SERVICES.md
@@ -76,7 +76,8 @@ All passes verified during production deploy (external Postgres + Redis).
 - **Version**: Redis ≥ 5 required (Azure Managed Redis runs the Redis Enterprise engine)
 - **Dedicated instance**: Each LangSmith installation must use its own dedicated Redis — shared instances cause deployment tasks to route incorrectly
 - **Access**: Private endpoint only (subnet-redis, private DNS zone) · TLS port 10000
-- **Secret**: `langsmith-redis-secret` — created by Terraform k8s-bootstrap module
+- **Client mode**: Follows `clustering_policy`. OSSCluster (the default) answers MOVED slot redirects, so LangSmith connects with the cluster client; EnterpriseCluster proxies to one endpoint and uses the standalone client with `clusterSafeMode`. `init-values.sh` picks the matching Helm block from the terraform outputs.
+- **Secret**: `langsmith-redis-secret` — created by Terraform k8s-bootstrap module. Keys: `connection_url` (standalone), `redis_cluster_node_uris` and `redis_cluster_password` (cluster). All three are always written; the chart reads the pair its mode needs.
 
 ### Azure Blob Storage
 - **What**: Object store for trace payloads — large inputs/outputs, attachments

--- a/modules/azure/TEST_CYCLE.md
+++ b/modules/azure/TEST_CYCLE.md
@@ -195,7 +195,7 @@ NAME                        TYPE     DATA
 langsmith-config-secret     Opaque   8
 langsmith-license           Opaque   1
 langsmith-postgres-secret   Opaque   1
-langsmith-redis-secret      Opaque   1
+langsmith-redis-secret      Opaque   3
 
 # WI annotation
 annotations:

--- a/modules/azure/helm/scripts/init-values.sh
+++ b/modules/azure/helm/scripts/init-values.sh
@@ -99,7 +99,9 @@ WI_CLIENT_ID=$(terraform -chdir="$INFRA_DIR" output -raw storage_account_k8s_man
 NAMESPACE=$(terraform -chdir="$INFRA_DIR" output -raw langsmith_namespace 2>/dev/null) || NAMESPACE="langsmith"
 ADMIN_EMAIL=$(terraform -chdir="$INFRA_DIR" output -raw langsmith_admin_email 2>/dev/null) || ADMIN_EMAIL=""
 CLUSTER_NAME=$(terraform -chdir="$INFRA_DIR" output -raw aks_cluster_name 2>/dev/null) || CLUSTER_NAME=""
-# AMR (Azure Managed Redis) needs clusterSafeMode; classic cache does not. Driven by the TF output.
+# Redis client mode follows the AMR clustering policy. Both come from TF outputs and
+# are mutually exclusive — the chart rejects cluster.enabled and clusterSafeMode together.
+REDIS_CLUSTER_ENABLED=$(terraform -chdir="$INFRA_DIR" output -raw redis_cluster_enabled 2>/dev/null) || REDIS_CLUSTER_ENABLED="false"
 REDIS_SAFE_MODE=$(terraform -chdir="$INFRA_DIR" output -raw redis_cluster_safe_mode 2>/dev/null) || REDIS_SAFE_MODE="false"
 
 echo ""
@@ -293,17 +295,30 @@ fi
 
 # Build redis block
 if [[ "$_redis_source" == "external" ]]; then
-  _redis_block='redis:
+  if [[ "$REDIS_CLUSTER_ENABLED" == "true" ]]; then
+    # OSSCluster: the endpoint answers MOVED slot redirects, so LangSmith needs the
+    # cluster client. Node URIs and password come from the secret; the chart reads
+    # them under the default keys redis_cluster_node_uris and redis_cluster_password.
+    # Requires chart 0.13.33 or newer.
+    _redis_block='redis:
+  external:
+    enabled: true
+    existingSecretName: "langsmith-redis-secret"
+    cluster:
+      enabled: true
+      tlsEnabled: true'
+  else
+    # EnterpriseCluster: one proxied endpoint, so the standalone client plus
+    # clusterSafeMode to keep the application off cluster-unsafe operations.
+    _redis_block='redis:
   external:
     enabled: true
     existingSecretName: "langsmith-redis-secret"
     connectionUrlSecretKey: "connection_url"'
-  # AMR is an OSS cluster reached over TLS by hostname — LangSmith must use a
-  # standalone client (clusterSafeMode), not a cluster client (whose node-IP TLS
-  # verification fails). Classic cache leaves this false.
-  if [[ "$REDIS_SAFE_MODE" == "true" ]]; then
-    _redis_block="${_redis_block}
+    if [[ "$REDIS_SAFE_MODE" == "true" ]]; then
+      _redis_block="${_redis_block}
     clusterSafeMode: true"
+    fi
   fi
 else
   _redis_block='# redis: in-cluster (managed by Helm chart)'

--- a/modules/azure/infra/main.tf
+++ b/modules/azure/infra/main.tf
@@ -863,6 +863,8 @@ module "k8s_bootstrap" {
   postgres_admin_password = var.postgres_source == "external" ? var.postgres_admin_password : ""
   use_external_redis      = var.redis_source == "external"
   redis_connection_url    = var.redis_source == "external" ? module.redis[0].connection_url : ""
+  redis_cluster_node_uris = var.redis_source == "external" ? module.redis[0].cluster_node_uris : ""
+  redis_cluster_password  = var.redis_source == "external" ? module.redis[0].cluster_password : ""
 
   # Standalone Fleet — creates the langsmith-fleet-postgres secret pointing at the
   # dedicated langsmith_fleet database. No fleet Redis secret: Fleet uses the chart's

--- a/modules/azure/infra/modules/k8s-bootstrap/main.tf
+++ b/modules/azure/infra/modules/k8s-bootstrap/main.tf
@@ -247,8 +247,13 @@ resource "kubernetes_secret_v1" "redis" {
     namespace = kubernetes_namespace_v1.langsmith.metadata[0].name
   }
 
+  # All three keys are written regardless of client mode: the chart reads only the
+  # pair its mode calls for, and keeping the other present makes switching modes a
+  # values-file edit instead of a terraform apply.
   data = {
-    connection_url = var.redis_connection_url
+    connection_url          = var.redis_connection_url
+    redis_cluster_node_uris = var.redis_cluster_node_uris
+    redis_cluster_password  = var.redis_cluster_password
   }
 
   type = "Opaque"

--- a/modules/azure/infra/modules/k8s-bootstrap/variables.tf
+++ b/modules/azure/infra/modules/k8s-bootstrap/variables.tf
@@ -80,6 +80,20 @@ variable "redis_connection_url" {
   default     = ""
 }
 
+variable "redis_cluster_node_uris" {
+  type        = string
+  description = "JSON array of Redis node URIs. Read by the chart when redis.external.cluster.enabled is true."
+  sensitive   = true
+  default     = ""
+}
+
+variable "redis_cluster_password" {
+  type        = string
+  description = "Redis access key, not URL-encoded. Read by the chart when redis.external.cluster.enabled is true."
+  sensitive   = true
+  default     = ""
+}
+
 # ── Blob storage (Azure Workload Identity) ────────────────────────────────────
 
 variable "blob_managed_identity_client_id" {

--- a/modules/azure/infra/modules/redis/main.tf
+++ b/modules/azure/infra/modules/redis/main.tf
@@ -11,9 +11,12 @@
 #   classic used VNet subnet INJECTION; AMR doesn't support that, so the private
 #   equivalent is a Private Endpoint into the same redis subnet + a private DNS zone.
 #
-# Connection: rediss://:<url-encoded key>@<host>:10000 (TLS, OSS clustering policy).
-# LangSmith connects via redis.external.clusterSafeMode (standalone client to the
-# endpoint hostname — the cert matches the hostname; cluster node IPs would not).
+# Connection: TLS on port 10000. The client mode follows var.clustering_policy —
+# OSSCluster answers MOVED slot redirects, so LangSmith must use the cluster client
+# (redis.external.cluster.enabled); EnterpriseCluster proxies to one endpoint, so it
+# uses the standalone client plus redis.external.clusterSafeMode. Pairing OSSCluster
+# with the standalone client makes every usage-limit check fail on MOVED, which the
+# ingest path returns to the caller as a 503.
 # ══════════════════════════════════════════════════════════════════════════════
 
 # AMR cluster — Balanced SKU, TLS 1.2, no public access (private endpoint only).

--- a/modules/azure/infra/modules/redis/outputs.tf
+++ b/modules/azure/infra/modules/redis/outputs.tf
@@ -1,14 +1,45 @@
+# Client mode is derived from the clustering policy so the two can never disagree.
+# OSSCluster speaks the Redis Cluster protocol and answers MOVED redirects, which a
+# standalone client cannot follow — it needs the cluster client. EnterpriseCluster
+# hides the slot map behind a single proxy endpoint, so it needs the standalone
+# client plus clusterSafeMode (no MULTI/EXEC, hash-tagged keys).
+
+output "cluster_enabled" {
+  value       = var.clustering_policy == "OSSCluster"
+  description = "Whether LangSmith should set redis.external.cluster.enabled (true for OSSCluster)"
+}
+
+output "cluster_safe_mode" {
+  value       = var.clustering_policy == "EnterpriseCluster"
+  description = "Whether LangSmith should set redis.external.clusterSafeMode (true for EnterpriseCluster)"
+}
+
 output "connection_url" {
-  # AMR endpoint over TLS, OSS cluster, port 10000. Key is URL-encoded because AMR
+  # Standalone endpoint over TLS, port 10000. Used when cluster_safe_mode is on, and
+  # kept in the secret either way as the rollback path. Key is URL-encoded because AMR
   # access keys contain +, /, = which would otherwise break the rediss:// URL.
   value       = "rediss://:${urlencode(azapi_resource_action.amr_keys.output.primaryKey)}@${azapi_resource.amr.output.properties.hostName}:10000"
   description = "Redis (AMR) connection string using TLS"
   sensitive   = true
 }
 
-output "cluster_safe_mode" {
-  # AMR is always an OSS cluster — LangSmith must connect as a standalone client to
-  # the endpoint (redis.external.clusterSafeMode: true), not a cluster client.
-  value       = true
-  description = "Whether LangSmith should set redis.external.clusterSafeMode (true for AMR)"
+output "cluster_node_uris" {
+  # JSON array string — the shape redis.external.cluster.nodeUris and the backend's
+  # REDIS_CLUSTER_DATABASE_URIS both expect. Scheme is redis://, not rediss://: TLS
+  # comes from cluster.tlsEnabled. Hostname verification is off because the AMR proxy
+  # hands back node IPs that are absent from the endpoint certificate's SAN list.
+  value = jsonencode([
+    "redis://${azapi_resource.amr.output.properties.hostName}:10000?ssl_check_hostname=false"
+  ])
+  description = "AMR node URIs for redis.external.cluster.nodeUris (JSON array string)"
+  sensitive   = true
+}
+
+output "cluster_password" {
+  # Raw key, deliberately NOT urlencode()'d. connection_url encodes it only because it
+  # is embedded in a URL there; as a standalone secret value it must be verbatim or
+  # authentication fails.
+  value       = azapi_resource_action.amr_keys.output.primaryKey
+  description = "AMR primary access key for redis.external.cluster.password"
+  sensitive   = true
 }

--- a/modules/azure/infra/modules/redis/variables.tf
+++ b/modules/azure/infra/modules/redis/variables.tf
@@ -41,8 +41,15 @@ variable "amr_sku" {
 
 variable "clustering_policy" {
   type        = string
-  description = "AMR clustering policy. OSSCluster is what LangSmith expects."
+  description = "AMR clustering policy. OSSCluster is the default and drives the LangSmith cluster client; EnterpriseCluster drives the standalone client with clusterSafeMode."
   default     = "OSSCluster"
+
+  # The outputs branch on this string to pick the client mode, so a typo would
+  # silently select the standalone client against an OSS cluster.
+  validation {
+    condition     = contains(["OSSCluster", "EnterpriseCluster"], var.clustering_policy)
+    error_message = "clustering_policy must be 'OSSCluster' or 'EnterpriseCluster'."
+  }
 }
 
 variable "high_availability" {

--- a/modules/azure/infra/outputs.tf
+++ b/modules/azure/infra/outputs.tf
@@ -10,8 +10,13 @@ output "redis_connection_url" {
   value       = var.redis_source == "external" ? module.redis[0].connection_url : ""
 }
 
+output "redis_cluster_enabled" {
+  description = "Whether LangSmith should set redis.external.cluster.enabled (true for the OSSCluster policy). init-values.sh reads this."
+  value       = var.redis_source == "external" ? module.redis[0].cluster_enabled : false
+}
+
 output "redis_cluster_safe_mode" {
-  description = "Whether LangSmith should set redis.external.clusterSafeMode (true for AMR). init-values.sh reads this."
+  description = "Whether LangSmith should set redis.external.clusterSafeMode (true for the EnterpriseCluster policy). init-values.sh reads this."
   value       = var.redis_source == "external" ? module.redis[0].cluster_safe_mode : false
 }
 

--- a/modules/azure/infra/scripts/create-k8s-secrets.sh
+++ b/modules/azure/infra/scripts/create-k8s-secrets.sh
@@ -23,7 +23,8 @@ set -euo pipefail
 #
 # The other two required secrets are created by Terraform (Pass 1):
 #   langsmith-postgres-secret — connection_url
-#   langsmith-redis-secret    — connection_url
+#   langsmith-redis-secret    — connection_url, redis_cluster_node_uris,
+#                               redis_cluster_password
 #
 # Safe to re-run — uses --dry-run=client | kubectl apply so it updates in place.
 


### PR DESCRIPTION
## What breaks today

The AMR module provisions the database with `clusteringPolicy = OSSCluster` (the default) while `init-values.sh` renders the standalone Helm block with `clusterSafeMode: true`. Those two are mutually exclusive. An OSS cluster answers `MOVED` slot redirects, a standalone client cannot follow them, and LangSmith checks usage limits against Redis before every trace write. The check errors and the ingest path returns 503, so every Azure install on the default policy loses all trace ingestion. Caught in a production deployment this week:

```
error checking usage limits: error executing Redis pipeline: MOVED 10137 <ip>:8500
```

## The fix

`cluster_enabled` and `cluster_safe_mode` both derive from `var.clustering_policy`, so they cannot disagree. OSSCluster selects the cluster client, EnterpriseCluster selects the standalone client with `clusterSafeMode`, and the policy is validated against those two values.

`langsmith-redis-secret` gains `redis_cluster_node_uris` and `redis_cluster_password` next to the existing `connection_url`. All three are written in either mode, which makes switching a values-file edit instead of a `terraform apply` and keeps `connection_url` as the rollback path.

Two things worth a reviewer's eye. The password output is deliberately not `urlencode()`d: `connection_url` encodes it only because it is embedded in a URL, and the encoded form fails auth as a standalone value. Node URIs use `redis://` with `ssl_check_hostname=false` because TLS comes from `cluster.tlsEnabled` and the AMR proxy returns node IPs absent from the endpoint certificate's SAN list, which matches the guidance in the self-hosted external Redis docs.

## Files

| File | Change |
| --- | --- |
| `infra/modules/redis/outputs.tf` | `cluster_enabled` / `cluster_safe_mode` derived from the policy; new `cluster_node_uris` and `cluster_password` |
| `infra/modules/redis/variables.tf` | validate `clustering_policy` against the two supported values |
| `infra/modules/redis/main.tf` | header comment corrected |
| `infra/modules/k8s-bootstrap/variables.tf` | two new sensitive variables |
| `infra/modules/k8s-bootstrap/main.tf` | secret carries all three keys |
| `infra/main.tf`, `infra/outputs.tf` | wiring, plus root output `redis_cluster_enabled` |
| `helm/scripts/init-values.sh` | renders the cluster block or the standalone block off the outputs |
| `SERVICES.md`, `TEST_CYCLE.md`, `infra/scripts/create-k8s-secrets.sh` | docs follow the new key set |

## Verification

`terraform validate`, `terraform fmt -recursive -check`, `shellcheck -S error` and `bash -n` on `init-values.sh`, plus both values blocks rendered to check indentation. No live `terraform plan` against Azure yet. Expected on an existing deployment is `~ update in-place` on `kubernetes_secret_v1.redis`, and pods pick up the new keys on the next rollout. Requires chart 0.13.33 or newer; the Azure line is pinned `~0.16.0`.

## Related

#212 is the same commit cherry-picked onto `test/azure-e2e`, so the affected customer can pick it up without waiting on this one.
