### PR TITLE
fix(azure): give playground the CPU it needs to pass its startup probe

### DIFF
--- a/modules/azure/helm/values/examples/langsmith-values-sizing-minimum.yaml
+++ b/modules/azure/helm/values/examples/langsmith-values-sizing-minimum.yaml
@@ -64,8 +64,17 @@ playground:
         cpu: "25m"
         memory: "384Mi"
       limits:
-        cpu: "250m"
+        # Same image as backend above, so the same CPU. At the previous 250m the
+        # container bound to its port just after the 60s startup-probe budget expired
+        # and crash-looped. Measured at 500m: ready in 39s, 1 probe failure of 6.
+        cpu: "500m"
         memory: "512Mi"
+    # Only the two fields we change; Helm merges the rest, so path and port stay
+    # whatever the chart says. Startup saturates the CPU limit, so a cold pull or a
+    # busy node can outlast the chart's 60s.
+    startupProbe:
+      failureThreshold: 12
+      timeoutSeconds: 10
 
 queue:
   deployment:


### PR DESCRIPTION
Closes part of #217. The readiness-wait bullet from that issue is deliberately left out; see below.

## Problem

The `minimum` sizing profile capped `playground` at a 250m CPU limit. It never became Ready: the container bound to `:1988` milliseconds after the 60-second startup-probe budget expired, so the kubelet killed it and it crash-looped indefinitely, on a node that was 22% utilized with three cores free.

The Playground, one of the seven core Pass 2 services, was unavailable on the profile we ship as the cost-minimal option. `make deploy` reported "All core deployments ready" regardless, because `playground` is not in its readiness list.

## Why 500m

`playground` runs the same `langsmith-backend` image as `backend`, so it now gets the same CPU allowance:

| | image | CPU limit before | CPU limit after | probe timeout |
|---|---|---|---|---|
| `backend` | `langsmith-backend:0.16.47` | 500m | 500m | 10s |
| `playground` | `langsmith-backend:0.16.47` | **250m** | **500m** | **1s → 10s** |

250m was also half the chart's own default request for this container.

`failureThreshold` goes past backend's 6 to 12 because startup here saturates the limit throughout, so a contended node or a cold image pull stretches it. Raising it costs nothing: it changes only how long the kubelet waits.

Memory is unchanged. Observed peak is 163Mi against the existing 512Mi limit.

## Verification

There is no test for sizing values, so this was measured on a live minimum-profile AKS cluster (chart 0.16.13, single `Standard_D4s_v3`, in-cluster Postgres/Redis/ClickHouse):

```
before   0/1  CrashLoopBackOff, 5 restarts, never Ready
after    1/1  Running, 0 restarts
         ready in 39s of the 60s budget
         1 startup-probe failure of the 6 allowed
         497m CPU at ready, 163Mi memory
         stable across a 96s hold
```

All other pods in the namespace stayed Running with 0 restarts through the change.

## Two notes for the reviewer

**The audit suggestion in #217 is wrong, and I have retracted it there.** It proposed flagging any profile that sets a limit below the chart's default request. In this profile 11 of 15 containers do, and the eight others this configuration deploys all run correctly. Squeezing below the chart default is what a minimum profile is for. The pattern actually worth auditing is a container sharing an image with a better-resourced sibling.

**The readiness-wait fix is not in this PR.** Adding `playground` to `_core_deployments` in `deploy.sh` is a one-line change, but that file is also where #207's Helm 4 flag lives, and it will be edited properly once that decision lands. Keeping this PR to the sizing file avoids entangling the two.
