### PR TITLE
Add AWS Network Firewall permissions to BYOC role

### DIFF
--- a/modules/byoc/aws/langsmith-byoc-role/policies.tf
+++ b/modules/byoc/aws/langsmith-byoc-role/policies.tf
@@ -15,6 +15,7 @@ locals {
   iam_karpenter_eks_profiles_statements = jsondecode(templatefile("${path.module}/policies/iam-karpenter-eks-profiles.json", local.policy_template_vars))
   kms_statements                        = jsondecode(templatefile("${path.module}/policies/kms.json", local.policy_template_vars))
   lambda_statements                     = jsondecode(templatefile("${path.module}/policies/lambda.json", local.policy_template_vars))
+  network_firewall_statements           = jsondecode(templatefile("${path.module}/policies/network_firewall.json", local.policy_template_vars))
   delete_statements                     = jsondecode(templatefile("${path.module}/policies/delete.json", local.policy_template_vars))
   rds_statements                        = jsondecode(templatefile("${path.module}/policies/rds.json", local.policy_template_vars))
   route53_statements                    = jsondecode(templatefile("${path.module}/policies/route53.json", local.policy_template_vars))
@@ -34,7 +35,7 @@ locals {
     # Keep optional delete permissions packed into smaller existing policies so
     # each managed policy stays under IAM's 6,144 character policy size limit.
     vpc                        = local.vpc_statements
-    ec2-eni                    = concat(local.ec2_eni_statements, local.delete_statements_for_policy.vpc)
+    ec2-eni                    = concat(local.ec2_eni_statements, local.network_firewall_statements, local.delete_statements_for_policy.vpc)
     iam                        = concat(local.iam_statements, local.delete_statements_for_policy.iam)
     iam-karpenter-eks-profiles = concat(local.iam_karpenter_eks_profiles_statements, local.delete_statements_for_policy["iam-karpenter-eks-profiles"])
     eks                        = concat(local.eks_statements, local.delete_statements_for_policy.eks)

--- a/modules/byoc/aws/langsmith-byoc-role/policies/delete.json
+++ b/modules/byoc/aws/langsmith-byoc-role/policies/delete.json
@@ -28,7 +28,10 @@
         "ec2:DeleteVpcEndpoints",
         "ec2:DeleteVpcEndpointServiceConfigurations",
         "ec2:DeleteFlowLogs",
-        "ec2:DeleteRoute"
+        "ec2:DeleteRoute",
+        "network-firewall:DeleteFirewall",
+        "network-firewall:DeleteFirewallPolicy",
+        "network-firewall:DeleteRuleGroup"
       ],
       "Resource": [
         "arn:aws:ec2:*:${account_id}:vpc/*",
@@ -42,7 +45,11 @@
         "arn:aws:ec2:*:${account_id}:vpc-endpoint/*",
         "arn:aws:ec2:*:${account_id}:vpc-endpoint-service/*",
         "arn:aws:ec2:*:${account_id}:vpc-flow-log/*",
-        "arn:aws:ec2:*:${account_id}:network-acl/*"
+        "arn:aws:ec2:*:${account_id}:network-acl/*",
+        "arn:aws:network-firewall:*:${account_id}:firewall/*-smith-*",
+        "arn:aws:network-firewall:*:${account_id}:firewall-policy/*-smith-*",
+        "arn:aws:network-firewall:*:${account_id}:stateful-rulegroup/*-smith-*",
+        "arn:aws:network-firewall:*:${account_id}:stateless-rulegroup/*-smith-*"
       ],
       "Condition": {
         "StringEquals": {

--- a/modules/byoc/aws/langsmith-byoc-role/policies/network_firewall.json
+++ b/modules/byoc/aws/langsmith-byoc-role/policies/network_firewall.json
@@ -1,0 +1,70 @@
+[
+  {
+    "Sid": "NetworkFirewallRead",
+    "Effect": "Allow",
+    "Action": [
+      "network-firewall:DescribeFirewall",
+      "network-firewall:DescribeFirewallPolicy",
+      "network-firewall:DescribeLoggingConfiguration",
+      "network-firewall:DescribeRuleGroup",
+      "network-firewall:ListFirewallPolicies",
+      "network-firewall:ListFirewalls",
+      "network-firewall:ListRuleGroups",
+      "network-firewall:ListTLSInspectionConfigurations",
+      "network-firewall:ListTagsForResource"
+    ],
+    "Resource": "*"
+  },
+  {
+    "Sid": "NetworkFirewallCreate",
+    "Effect": "Allow",
+    "Action": [
+      "network-firewall:AssociateFirewallPolicy",
+      "network-firewall:CreateFirewall",
+      "network-firewall:CreateFirewallPolicy",
+      "network-firewall:CreateRuleGroup",
+      "network-firewall:TagResource"
+    ],
+    "Resource": [
+      "arn:aws:network-firewall:*:${account_id}:firewall/*-smith-*",
+      "arn:aws:network-firewall:*:${account_id}:firewall-policy/*-smith-*",
+      "arn:aws:network-firewall:*:${account_id}:stateful-rulegroup/*-smith-*",
+      "arn:aws:network-firewall:*:${account_id}:stateless-rulegroup/*-smith-*"
+    ],
+    "Condition": {
+      "StringEquals": {
+        "aws:RequestTag/managed_by": "langsmith"
+      }
+    }
+  },
+  {
+    "Sid": "NetworkFirewallManage",
+    "Effect": "Allow",
+    "Action": [
+      "network-firewall:AssociateFirewallPolicy",
+      "network-firewall:AssociateSubnets",
+      "network-firewall:DisassociateSubnets",
+      "network-firewall:TagResource",
+      "network-firewall:UntagResource",
+      "network-firewall:UpdateFirewallDeleteProtection",
+      "network-firewall:UpdateFirewallDescription",
+      "network-firewall:UpdateFirewallEncryptionConfiguration",
+      "network-firewall:UpdateFirewallPolicy",
+      "network-firewall:UpdateFirewallPolicyChangeProtection",
+      "network-firewall:UpdateLoggingConfiguration",
+      "network-firewall:UpdateRuleGroup",
+      "network-firewall:UpdateSubnetChangeProtection"
+    ],
+    "Resource": [
+      "arn:aws:network-firewall:*:${account_id}:firewall/*-smith-*",
+      "arn:aws:network-firewall:*:${account_id}:firewall-policy/*-smith-*",
+      "arn:aws:network-firewall:*:${account_id}:stateful-rulegroup/*-smith-*",
+      "arn:aws:network-firewall:*:${account_id}:stateless-rulegroup/*-smith-*"
+    ],
+    "Condition": {
+      "StringEquals": {
+        "aws:ResourceTag/managed_by": "langsmith"
+      }
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- add firewall permissions to the module
- keep delete permissions scoped out by default, like other modules