### PR TITLE
fix(helm): gate --server-side=false on the Helm major, and wait on playground

### DIFF
--- a/modules/aws/README.md
+++ b/modules/aws/README.md
@@ -675,7 +675,7 @@ The sizing file is always loaded last so it can override replicas/resources set 
 
 **Step 7 — Broken release recovery.** Checks the current Helm release status. If `pending-upgrade` (left by a Ctrl+C'd upgrade), rolls back automatically. If `failed` (common after a first deploy timeout), logs a warning and proceeds — Helm upgrade works fine on a failed release.
 
-**Step 8 — Helm upgrade.** Runs `helm upgrade --install` with `--server-side=false`. Server-side apply (Helm 3.14+ default) conflicts with the AWS Load Balancer Controller over ownership of `ingress.spec.rules` — client-side apply avoids this. Does **not** use `--wait` because the chart's post-install hooks and the operator's agent pods can take 10+ minutes to settle on new nodes.
+**Step 8 — Helm upgrade.** Runs `helm upgrade --install`, adding `--server-side=false` only when the installed Helm is 4.x. Server-side apply is a Helm 4 feature and its default for a fresh install, and it conflicts with the AWS Load Balancer Controller over ownership of `ingress.spec.rules`, so the deploy asks for client-side apply. Helm 3 has no such flag and applies client-side regardless, so the flag is omitted there. Does **not** use `--wait` because the chart's post-install hooks and the operator's agent pods can take 10+ minutes to settle on new nodes.
 
 **Step 9 — Core readiness.** Polls each core deployment with `kubectl rollout status --timeout=5m`:
 - `langsmith-frontend`, `langsmith-backend`, `langsmith-platform-backend`, `langsmith-ingest-queue`, `langsmith-queue`

--- a/modules/aws/TROUBLESHOOTING.md
+++ b/modules/aws/TROUBLESHOOTING.md
@@ -401,8 +401,9 @@ orphaned ALB. `init-values.sh` no longer emits it.
 **Prevention:**
 - Ensure the `group.name` annotation is set (`init-values.sh` does this automatically)
 - Never delete the ingress unless you plan to update all hostname-dependent config
-- Avoid `helm rollback` without `--server-side=false` — the ingress SSA conflict
-  can trigger a delete/recreate cycle
+- On Helm 4, avoid `helm rollback` without `--server-side=false`: the ingress SSA
+  conflict can trigger a delete/recreate cycle. Helm 3 has no server-side apply, so
+  it is unaffected and rejects the flag.
 
 **Fix:**
 ```bash

--- a/modules/aws/helm/scripts/deploy.sh
+++ b/modules/aws/helm/scripts/deploy.sh
@@ -495,10 +495,22 @@ fi
 # hardcoded 20m because of sequential stateful rollouts and migration jobs.
 _helm_timeout="${HELM_TIMEOUT:-30m}"
 
-# Deploy with --server-side=false to avoid SSA field ownership conflicts with the
-# ALB ingress controller. Helm 3.14+ defaults to server-side apply, which fights
-# with the controller over .spec.rules ownership. Client-side apply sidesteps this.
-#
+# --server-side is a Helm 4 flag. Helm 3 has no server-side apply and rejects the
+# whole invocation with "unknown flag: --server-side" (verified on v3.21.4), so
+# passing it unconditionally blocks the deploy on the Helm 3 the docs require.
+# On Helm 4, SSA is the default for a fresh install and fights the ALB ingress
+# controller over .spec.rules ownership, so ask for client-side apply explicitly
+# there. Helm 3 only ever applies client-side, making the flag redundant as well
+# as unsupported. If the version cannot be read, omit it: omitting is valid on
+# both majors, passing it fails outright on one.
+_helm_major=$(helm version --template '{{.Version}}' 2>/dev/null | sed -e 's/^v//' -e 's/[^0-9].*$//') || _helm_major=""
+_ssa_flag=""
+if [[ -z "$_helm_major" ]]; then
+  echo "WARNING: could not read the Helm version; omitting --server-side=false." >&2
+elif [[ "$_helm_major" -ge 4 ]]; then
+  _ssa_flag="--server-side=false"
+fi
+
 # We intentionally do NOT use --wait here. The chart's post-install hooks and the
 # operator's agent pods can take 10+ minutes to settle on a cold cluster with
 # autoscaling. Using --wait causes the release to go 'failed' if a hook exceeds the
@@ -529,7 +541,7 @@ helm upgrade --install "$RELEASE_NAME" langchain/langsmith \
   ${CHART_VERSION:+--version "$CHART_VERSION"} \
   ${_devel_flag} \
   "${VALUES_ARGS[@]}" \
-  --server-side=false \
+  ${_ssa_flag} \
   --timeout "$_helm_timeout"
 
 echo ""
@@ -622,7 +634,7 @@ if [[ -n "$_active_host" ]]; then
       ${CHART_VERSION:+--version "$CHART_VERSION"} \
       ${_devel_flag} \
       "${VALUES_ARGS[@]}" \
-      --server-side=false \
+      ${_ssa_flag} \
       --timeout "$_helm_timeout"
     echo ""
     echo "LangSmith redeployed with hostname: $_active_host"

--- a/modules/aws/infra/scripts/preflight.sh
+++ b/modules/aws/infra/scripts/preflight.sh
@@ -310,6 +310,19 @@ if [[ -n "$AWS_VERSION" && "$AWS_VERSION" -lt 2 ]]; then
   exit 1
 fi
 
+# The documented floor is Helm 3.12, and deploy.sh picks the apply mode from the
+# major, so 3.12+ and 4.x both work. Checked here rather than at the last step of
+# Pass 2, where a wrong version fails after every resource is already metered.
+HELM_VERSION=$(helm version --template '{{.Version}}' 2>/dev/null | sed 's/^v//') || HELM_VERSION=""
+HELM_MAJOR=${HELM_VERSION%%.*}
+HELM_MINOR=$(echo "$HELM_VERSION" | cut -s -d. -f2)
+if ! echo "${HELM_MAJOR}|${HELM_MINOR}" | grep -qE '^[0-9]+\|[0-9]+$'; then
+  info "helm: could not parse a version from '${HELM_VERSION:-no output}', so the 3.12 minimum is unverified"
+elif [[ "$HELM_MAJOR" -lt 3 ]] || { [[ "$HELM_MAJOR" -eq 3 ]] && [[ "$HELM_MINOR" -lt 12 ]]; }; then
+  error "Helm 3.12+ required (found ${HELM_VERSION}). Upgrade: https://helm.sh/docs/intro/install/"
+  exit 1
+fi
+
 printf "\n"
 info "=== LangSmith AWS Preflight (Pass 1 — pre-Terraform) ==="
 info "Default mode: READ-ONLY. Use --create-test-resources to test resource creation."

--- a/modules/azure/helm/scripts/deploy.sh
+++ b/modules/azure/helm/scripts/deploy.sh
@@ -588,13 +588,30 @@ if [[ -z "$_resolved_chart" ]]; then
   exit 1
 fi
 
+# --server-side is a Helm 4 flag. Helm 3 has no server-side apply and rejects the
+# whole invocation with "unknown flag: --server-side" (verified on v3.21.4), so
+# passing it unconditionally blocks the deploy on the Helm 3 the docs require.
+# On Helm 4, SSA is the default for a fresh install, which is what this module
+# does. The chart was written and tested against client-side apply, so ask for it
+# explicitly rather than let the Helm binary decide the apply semantics. Helm 3
+# only ever applies client-side, making the flag redundant as well as unsupported.
+# If the version cannot be read, omit it: omitting is valid on both majors,
+# passing it fails outright on one.
+_helm_major=$(helm version --template '{{.Version}}' 2>/dev/null | sed -e 's/^v//' -e 's/[^0-9].*$//') || _helm_major=""
+_ssa_flag=""
+if [[ -z "$_helm_major" ]]; then
+  echo "WARNING: could not read the Helm version; omitting --server-side=false." >&2
+elif [[ "$_helm_major" -ge 4 ]]; then
+  _ssa_flag="--server-side=false"
+fi
+
 helm upgrade --install "$RELEASE_NAME" langchain/langsmith \
   --namespace "$NAMESPACE" \
   --create-namespace \
   ${CHART_VERSION:+--version "$CHART_VERSION"} \
   "${VALUES_ARGS[@]}" \
   ${EXTRA_HELM_ARGS:+$EXTRA_HELM_ARGS} \
-  --server-side=false \
+  ${_ssa_flag} \
   --timeout 20m
 
 echo ""

--- a/modules/azure/helm/scripts/deploy.sh
+++ b/modules/azure/helm/scripts/deploy.sh
@@ -625,6 +625,9 @@ _core_deployments=(
   "${RELEASE_NAME}-platform-backend"
   "${RELEASE_NAME}-ingest-queue"
   "${RELEASE_NAME}-queue"
+  # The chart always installs playground. Without it here, a sizing profile that
+  # leaves playground crash-looping still reports "All core deployments ready" (#217).
+  "${RELEASE_NAME}-playground"
 )
 if [[ "$_enable_deployments" == "true" ]]; then
   _core_deployments+=(

--- a/modules/azure/infra/scripts/preflight.sh
+++ b/modules/azure/infra/scripts/preflight.sh
@@ -828,6 +828,22 @@ for TOOL in terraform kubectl helm; do
   fi
 done
 
+# The documented floor is Helm 3.12, and deploy.sh picks the apply mode from the
+# major, so 3.12+ and 4.x both work. Checked here rather than at the last step of
+# Pass 2, where a wrong version fails after every resource is already metered.
+HELM_VER=$(helm version --template '{{.Version}}' 2>/dev/null | sed 's/^v//') || HELM_VER=""
+HELM_MAJ=${HELM_VER%%.*}
+HELM_MIN=$(echo "$HELM_VER" | cut -s -d. -f2)
+if ! echo "${HELM_MAJ}|${HELM_MIN}" | grep -qE '^[0-9]+\|[0-9]+$'; then
+  warn "helm: could not parse a version from '${HELM_VER:-no output}', so the 3.12 minimum is unverified"
+elif [ "$HELM_MAJ" -lt 3 ] || { [ "$HELM_MAJ" -eq 3 ] && [ "$HELM_MIN" -lt 12 ]; }; then
+  fail "helm ${HELM_VER} is below the documented 3.12 minimum. Upgrade before Pass 2."
+elif [ "$HELM_MAJ" -ge 4 ]; then
+  pass "helm ${HELM_VER}: deploy.sh will pass --server-side=false to keep client-side apply"
+else
+  pass "helm ${HELM_VER}: client-side apply is Helm 3's only mode, so no flag is needed"
+fi
+
 # ── Summary ───────────────────────────────────────────────────────────────────
 echo ""
 echo "══════════════════════════════════════════════════════"


### PR DESCRIPTION
Fixes #207 and closes #217. Two independent changes, one per commit, kept in one PR because both edit `deploy.sh` and #218 deferred the second one waiting on the first.

## 1. Gate `--server-side=false` on the Helm major version

`deploy.sh` passed the flag unconditionally. It does not exist in Helm 3:

```
$ helm version --template '{{.Version}}'
v3.21.4
$ helm upgrade --install ... --server-side=false
Error: unknown flag: --server-side
```

Helm 3 rejects the whole invocation, so Pass 2 could not complete on the Helm version every published prerequisite table requires (`3.12` on four pages, `3.x` on a fifth). It failed at the final step, after all infrastructure was created and billing.

**Removing the flag is not the fix.** Helm 4 defaults to server-side apply for a fresh install, which is what these modules do, and on AWS that fights the ALB ingress controller over ownership of `ingress.spec.rules`. The flag is load-bearing on Helm 4 and unusable on Helm 3.

So read the major and pass it only on 4.x. If the version cannot be read, omit it: omitting is valid on both majors, passing it fails outright on one.

**Why not just require Helm 4.** Helm 3 is security-supported until 2027-02-10 (extended from 2026-11-11). Regulated and air-gapped operators pin approved tooling, where a Helm upgrade is a procurement cycle. Requiring 4.x today strands them for no gain. Worth revisiting after that date.

Three call sites: `modules/azure/helm/scripts/deploy.sh` (1), `modules/aws/helm/scripts/deploy.sh` (2). GCP has none.

Also in this commit:

- Both preflights now check the documented Helm 3.12 floor, so a wrong version surfaces before any resource is billed instead of two hours in.
- `modules/aws/README.md` and `modules/aws/TROUBLESHOOTING.md` attributed server-side apply to "Helm 3.14+". Helm 3 has no server-side apply in `helm upgrade` at any minor; it is a Helm 4 feature.

## 2. Wait on `playground` before reporting success

The readiness wait listed five deployments. Chart 0.16.15 installs seven:

```
$ helm template langsmith langchain/langsmith --version '~0.16.0' ... | grep -A1 'kind: Deployment'
langsmith-ace-backend      langsmith-ingest-queue     langsmith-platform-backend
langsmith-backend          langsmith-playground       langsmith-queue
langsmith-frontend
```

So a deploy that left `playground` crash-looping still printed "All core deployments ready". That is how #217 stayed invisible: the minimum profile capped playground's CPU limit below the chart's own default request, the pod never passed its startup probe, and nothing in the deploy path noticed. #218 raised the limit but left this out on purpose, because `deploy.sh` was about to be edited for the flag above.

## Testing

- Gate exercised against stubbed Helm `3.22.0`, `4.0.1`, `4.1.0-rc.2`, `10.0.0`, a missing binary, and unparseable output. Correct in all six.
- Preflight floor checked at the boundary: `3.12.0` passes, `3.11.9` and `2.17.0` fail, unparseable warns without failing.
- Confirmed an empty `_ssa_flag` leaves no stray argument: 8 argv entries when empty, 9 with the flag.
- `bash agents/check.sh --scripts` exits 0 across 62 scripts, with no new shellcheck findings at any severity (10 info-level before this change, 10 after, none on changed lines).
- No HCL touched, so no `terraform validate` run.

## Not in this PR

- **`ace-backend` is also missing from all three readiness lists**, same defect class as #217 but a different service and not described by that issue. Say the word and I will add it here, otherwise it wants its own issue.
- **`playground` is missing from the AWS and GCP readiness lists too.** #217 is filed as Azure, so this change is scoped to Azure.
- **The five prerequisite tables** on docs.langchain.com still say Helm 3.12. They are now correct rather than contradictory, since 3.12+ works again; widening them to "3.12+ or 4.x" needs a docs-repo PR.
- **GCP never passed the flag.** If the ALB-style SSA conflict has an analogue there, GCP may be latently broken on Helm 4 in the opposite direction. Unreproduced, untouched.
