### PR TITLE
fix(tools): clarify root checks and update agent context

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,10 +8,10 @@ before the PR does, not a separate standard.
 
 ## Layout
 
-- `modules/<provider>/{infra,app}` — each is its own Terraform root: own
-  `versions.tf`, `backend.tf`, state. `infra/` provisions the cloud foundation;
-  `app/` Helm-deploys LangSmith. `aws`, `azure`, and `gcp` have both.
-- `modules/byoc/aws/langsmith-byoc-role/` — a seventh root, one level deeper
+- `modules/<provider>/infra` — its own Terraform root: own `versions.tf`,
+  `backend.tf`, state. It provisions the cloud foundation. `aws`, `azure`, and
+  `gcp` each have one.
+- `modules/byoc/aws/langsmith-byoc-role/` — another root, one level deeper
   than the rest: the customer-side IAM role and break-glass role for BYOC.
   Gated like the others, so run the checks after touching the policies.
 - `modules/<provider>/helm/scripts/` — the shell drivers (`deploy.sh`,
@@ -21,10 +21,10 @@ before the PR does, not a separate standard.
   (networking, k8s-cluster, postgres, redis, storage, dns, secrets, iam…).
   Local `source = "./modules/..."` only; no registry module publishing here.
   Validated transitively via `--call-module-type=all`, not as their own roots —
-  even the two that carry a `versions.tf` (azure `keyvault`, azure `redis`), so
-  the gate identifies a child module by its path, not by depth.
-- Not gated for terraform: `modules/ocp`. The OpenShift port is still stubs
-  with no `versions.tf` anywhere, so there is nothing to init against. Its
+  even the three that carry a `versions.tf` (azure `keyvault`, `redis`,
+  `k8s-cluster`), so the gate identifies a child module by its path, not by depth.
+- Not gated for terraform: `modules/ocp`. It has provider requirements in
+  `infra/main.tf`, but no `versions.tf` for root discovery. Its
   shell scripts are covered (CI lints every tracked `*.sh`); the HCL has only
   `terraform fmt -check`. Edit with extra care.
 - `.terraform.lock.hcl`, `*.tfvars`, `*.tfstate*` are gitignored per provider

--- a/agents/check.sh
+++ b/agents/check.sh
@@ -46,8 +46,8 @@ lint_scripts() {
 # CI leg can scope itself to modules/<provider> without carrying a second copy
 # of the rule. A root is any directory with its own versions.tf, minus the
 # internal child modules under modules/<provider>/<root>/modules/<child>/:
-# those are validated transitively via --call-module-type=all, and two of them
-# (azure keyvault, azure redis) do carry a versions.tf, so depth alone cannot
+# those are validated transitively via --call-module-type=all, and three of them
+# (azure keyvault, redis, k8s-cluster) do carry a versions.tf, so depth alone cannot
 # tell them apart from a root. Depth varies anyway, modules/aws/infra is two
 # levels down and modules/byoc/aws/langsmith-byoc-role is three.
 discover_roots() {
@@ -91,8 +91,8 @@ for arg in "$@"; do
 $(discover_roots "$arg")
 EOF
   if [ "${#roots[@]}" -eq "$before" ]; then
-    echo "check: no terraform root under $arg, so this run would have checked" >&2
-    echo "nothing. The directory was renamed, or its versions.tf is gone." >&2
+    echo "check: no terraform root under $arg. A root has its own versions.tf; child" >&2
+    echo "modules (modules/*/infra/modules/*) are checked via their parent root." >&2
     exit 2
   fi
 done


### PR DESCRIPTION
When given a child-module directory, `check.sh` suggested that the directory was renamed or `versions.tf` was missing. The error now directs agents to check the parent Terraform root.

Also correct stale context in `AGENTS.md` and checker comments: removed application roots, the Azure child-module count, and why OpenShift is excluded from root discovery.

Validation passed: Bash syntax, ShellCheck across all 62 tracked scripts, and `git diff --check`.
