### PR TITLE
feat(ocp): read secrets from existing Secrets, and generate Fernet keys

### DIFF
--- a/modules/ocp/QUICK_REFERENCE.md
+++ b/modules/ocp/QUICK_REFERENCE.md
@@ -24,6 +24,36 @@ oc version
 
 ---
 
+## Secrets
+
+The chart reads existing secrets on this module — see the key table in
+[README.md](README.md#secrets).
+
+```bash
+# Create or update them
+export LANGSMITH_LICENSE_KEY=...
+export INITIAL_ORG_ADMIN_PASSWORD=...
+export POSTGRES_CONNECTION_URL=...
+export REDIS_CONNECTION_URL=...
+./helm/scripts/generate-secrets.sh
+```
+
+```bash
+# Which keys are in the secret (names only, no values)
+oc get secret langsmith-secrets -n langsmith -o jsonpath='{range $k,$v := .data}{$k}{"\n"}{end}'
+```
+
+```bash
+# Confirm the chart is reading them rather than generating its own
+helm get values langsmith -n langsmith --all | grep -B1 -A1 existingSecretName
+```
+
+Rotating a secret does not restart the pods: with `existingSecretName` set the
+chart drops its `checksum/secrets` annotation, so roll the deployments yourself
+(`oc rollout restart deployment -n langsmith`) or run Reloader.
+
+---
+
 ## Planned Deployment
 
 ```bash
@@ -35,10 +65,11 @@ terraform apply
 helm repo add langchain https://langchain-ai.github.io/helm
 helm repo update
 
+# The license key comes from the secret above, not --set: with
+# config.existingSecretName set, config.langsmithLicenseKey is ignored.
 helm install langsmith langchain/langsmith \
   -f langsmith-values.yaml \
-  -n langsmith --create-namespace \
-  --set config.langsmithLicenseKey="<license-key>"
+  -n langsmith --create-namespace
 ```
 
 ---

--- a/modules/ocp/README.md
+++ b/modules/ocp/README.md
@@ -36,6 +36,73 @@ Pass 3 — LangSmith Deployments (LangGraph Platform)
 - Terraform 1.11.0+
 - Cluster admin role for initial setup
 
+## Secrets
+
+The chart can generate its own Kubernetes Secrets, or read secrets that already
+exist. This module always uses existing secrets: `helm/values/values.yaml` sets
+`config.existingSecretName: langsmith-secrets`, and the values-overrides example
+sets `postgres.external.existingSecretName` / `redis.external.existingSecretName`.
+See [Self-host using an existing secret](https://docs.langchain.com/langsmith/self-host-using-an-existing-secret).
+
+The consequence to know before editing values: with `config.existingSecretName`
+set, the chart never renders its own `secrets.yaml`, so every secret-bearing
+`config.*` value is inert. Setting `config.oauth.oauthClientSecret` or
+`insights.encryptionKey` in a values file does nothing — those go in the secret.
+
+### Creating them
+
+```bash
+export LANGSMITH_LICENSE_KEY=...
+export INITIAL_ORG_ADMIN_PASSWORD=...          # >= 12 bytes, upper, lower, symbol
+export POSTGRES_CONNECTION_URL="postgresql://langsmith:...@postgres.example.com:5432/langsmith"
+export REDIS_CONNECTION_URL="rediss://:...@redis.example.com:6380/0"
+./helm/scripts/generate-secrets.sh
+```
+
+The script creates the namespace, grants the SCC, applies the secrets and then
+lists the keys that landed. It never prints a value, and passes them to `oc` as
+base64 on stdin rather than as `--from-literal` arguments, so they stay out of the
+process list.
+
+| Secret | Key | Environment variable | Required when |
+|---|---|---|---|
+| `langsmith-secrets` | `langsmith_license_key` | `LANGSMITH_LICENSE_KEY` | always |
+| | `api_key_salt` | `API_KEY_SALT` | generated if unset |
+| | `jwt_secret` | `JWT_SECRET` | generated if unset |
+| | `initial_org_admin_password` | `INITIAL_ORG_ADMIN_PASSWORD` | `config.basicAuth.enabled` |
+| | `oauth_client_id` | `OAUTH_CLIENT_ID` | `config.oauth.enabled` |
+| | `oauth_client_secret` | `OAUTH_CLIENT_SECRET` | `config.authType: mixed` |
+| | `oauth_issuer_url` | `OAUTH_ISSUER_URL` | `config.oauth.enabled` |
+| | `blob_storage_access_key` | `BLOB_STORAGE_ACCESS_KEY` | static object-storage creds |
+| | `blob_storage_access_key_secret` | `BLOB_STORAGE_ACCESS_KEY_SECRET` | static object-storage creds |
+| | `agent_builder_encryption_key` | `AGENT_BUILDER_ENCRYPTION_KEY` | `config.agentBuilder.enabled` or `fleet.enabled` |
+| | `insights_encryption_key` | `INSIGHTS_ENCRYPTION_KEY` | `insights.enabled` |
+| | `polly_encryption_key` | `POLLY_ENCRYPTION_KEY` | `polly.enabled` |
+| | `engine_encryption_key` | `ENGINE_ENCRYPTION_KEY` | `engine.enabled` |
+| | `langsmith_signing_jwks` | `LANGSMITH_SIGNING_JWKS` | optional |
+| | `sandbox_callback_signing_jwk` | `SANDBOX_CALLBACK_SIGNING_JWK` | `sandboxes.enabled` |
+| `langsmith-postgres` | `connection_url` | `POSTGRES_CONNECTION_URL` | external Postgres |
+| `langsmith-redis` | `connection_url` | `REDIS_CONNECTION_URL` | external Redis |
+
+Key names are fixed by chart 0.16. A misspelled key reaches the pod as an empty
+environment variable rather than an error, so trust the table over improvisation.
+`api_key_salt` and `jwt_secret` are generated per run when not exported: a new
+`api_key_salt` invalidates every issued API key, and a new `jwt_secret` logs
+everyone out, so export both once you are past first install.
+
+### Terraform as the other writer
+
+`infra/modules/secrets` writes the same two datastore secrets when
+`postgres_connection_url` / `redis_connection_url` are set, and skips them when
+empty. Set each URL in one place — Terraform or the script — not both. Both URLs
+embed a password and land in Terraform state in plaintext, so keep state in an
+encrypted remote backend, or leave the variables empty and let the script own them.
+
+For production, swap either writer for the External Secrets Operator or the Vault
+Agent Injector. Note that the chart drops its `checksum/secrets` pod annotation
+whenever `existingSecretName` is set, so rotating a secret does not restart the
+pods on its own — drive that with Reloader or a deliberate restart.
+
 ## Reference
 
 - [LangSmith Self-Hosted Docs](https://docs.smith.langchain.com/self_hosting)

--- a/modules/ocp/README.md
+++ b/modules/ocp/README.md
@@ -75,10 +75,10 @@ process list.
 | | `oauth_issuer_url` | `OAUTH_ISSUER_URL` | `config.oauth.enabled` |
 | | `blob_storage_access_key` | `BLOB_STORAGE_ACCESS_KEY` | static object-storage creds |
 | | `blob_storage_access_key_secret` | `BLOB_STORAGE_ACCESS_KEY_SECRET` | static object-storage creds |
-| | `agent_builder_encryption_key` | `AGENT_BUILDER_ENCRYPTION_KEY` | `config.agentBuilder.enabled` or `fleet.enabled` |
-| | `insights_encryption_key` | `INSIGHTS_ENCRYPTION_KEY` | `insights.enabled` |
-| | `polly_encryption_key` | `POLLY_ENCRYPTION_KEY` | `polly.enabled` |
-| | `engine_encryption_key` | `ENGINE_ENCRYPTION_KEY` | `engine.enabled` |
+| | `agent_builder_encryption_key` | `AGENT_BUILDER_ENCRYPTION_KEY` | generated if unset |
+| | `insights_encryption_key` | `INSIGHTS_ENCRYPTION_KEY` | generated if unset |
+| | `polly_encryption_key` | `POLLY_ENCRYPTION_KEY` | generated if unset |
+| | `engine_encryption_key` | `ENGINE_ENCRYPTION_KEY` | generated if unset |
 | | `langsmith_signing_jwks` | `LANGSMITH_SIGNING_JWKS` | optional |
 | | `sandbox_callback_signing_jwk` | `SANDBOX_CALLBACK_SIGNING_JWK` | `sandboxes.enabled` |
 | `langsmith-postgres` | `connection_url` | `POSTGRES_CONNECTION_URL` | external Postgres |
@@ -86,9 +86,33 @@ process list.
 
 Key names are fixed by chart 0.16. A misspelled key reaches the pod as an empty
 environment variable rather than an error, so trust the table over improvisation.
-`api_key_salt` and `jwt_secret` are generated per run when not exported: a new
-`api_key_salt` invalidates every issued API key, and a new `jwt_secret` logs
-everyone out, so export both once you are past first install.
+
+Anything marked "generated if unset" is generated only on first run: after that
+the script reads the value back out of the secret and reuses it, because a new
+`api_key_salt` invalidates every issued API key, a new `jwt_secret` logs everyone
+out, and a new encryption key orphans that product's stored data. Export a value
+to set it explicitly instead.
+
+The four encryption keys are Fernet keys, not hex strings. The documented
+`openssl rand -hex 32` recipe produces 64 characters, which these products
+reject; the script generates 32 random bytes as URL-safe base64, matching the
+chart's own `Fernet.generate_key()` instruction. Generated keys exist only in the
+cluster, so back them up out of it before you rely on the install:
+
+```bash
+oc get secret langsmith-secrets -n langsmith -o jsonpath='{.data.insights_encryption_key}' | base64 --decode
+```
+
+### Pulling images from an internal registry
+
+A cluster with no egress to Docker Hub needs `images.registry` pointed at its
+proxy; the commented block in `helm/values/values-overrides.yaml.example` has the
+detail. The value is *prepended* to repositories that already carry their upstream
+host, so `nexus.example.com` yields
+`nexus.example.com/docker.io/langchain/langsmith-backend`. Chart 0.16 pulls from
+three upstream hosts — `docker.io`, `mcr.microsoft.com` (presidio, with insights)
+and `registry.k8s.io` (the CSI registrar, with sandboxes) — and each needs a proxy
+path before the install can pull.
 
 ### Terraform as the other writer
 

--- a/modules/ocp/helm/scripts/generate-secrets.sh
+++ b/modules/ocp/helm/scripts/generate-secrets.sh
@@ -29,9 +29,10 @@
 # error. Values are piped in as base64 rather than passed as --from-literal so
 # they never appear in the process list. Nothing here echoes a secret value.
 #
-# Safe to re-run: applies in place, and regenerating api_key_salt or jwt_secret is
-# avoided by exporting them (see below) — a new api_key_salt invalidates every
-# issued API key.
+# Safe to re-run: it applies in place and reuses any generated value already in
+# the secret, so a second run does not rotate api_key_salt (which would
+# invalidate every issued API key) or an encryption key (which would orphan that
+# product's stored data). Export a value to set it explicitly.
 set -euo pipefail
 
 NAMESPACE="${NAMESPACE:-langsmith}"
@@ -87,11 +88,62 @@ if [[ -n "${INITIAL_ORG_ADMIN_PASSWORD:-}" ]]; then
   fi
 fi
 
-# Generated once per run when not supplied. Export both to keep them stable across
-# re-runs: api_key_salt is what existing API keys are hashed against, and jwt_secret
-# invalidates live sessions when it changes.
-API_KEY_SALT="${API_KEY_SALT:-$(openssl rand -hex 32)}"
-JWT_SECRET="${JWT_SECRET:-$(openssl rand -hex 32)}"
+# _existing <secret-key> — the value already in langsmith-secrets, or empty when
+# the secret or the key is absent. Re-running must not rotate a generated value:
+# a new api_key_salt invalidates every issued API key, and a new encryption key
+# makes that product's stored data unreadable. Reusing what is already there
+# makes that mistake unreachable rather than merely documented.
+_existing() {
+  local encoded
+  encoded=$(oc get secret langsmith-secrets -n "$NAMESPACE" \
+    -o "jsonpath={.data.$1}" 2>/dev/null) || return 0
+  [[ -n "$encoded" ]] || return 0
+  printf '%s' "$encoded" | base64 --decode
+}
+
+# _fernet_key — 32 random bytes as URL-safe base64, the format the chart asks for
+# ("python -c \"from cryptography.fernet import Fernet; ...\""). The documented
+# `openssl rand -hex 32` recipe yields 64 characters, which these products reject.
+# tr swaps the two non-URL-safe base64 characters; Fernet keeps the = padding.
+_fernet_key() {
+  openssl rand 32 | base64 | tr -d '\n' | tr '+/' '-_'
+}
+
+# _resolve <var-name> <secret-key> <generator> — environment, else the value
+# already in the cluster, else freshly generated. Records anything generated so
+# the run can tell the operator to back it up.
+GENERATED_KEYS=""
+_resolve() {
+  local var="$1" key="$2" generator="$3" value
+  eval "value=\${$var:-}"
+  if [[ -z "$value" ]]; then
+    value=$(_existing "$key")
+  fi
+  if [[ -z "$value" ]]; then
+    value=$("$generator")
+    if [[ -z "$value" ]]; then
+      echo "ERROR: $generator produced an empty value for $key." >&2
+      exit 1
+    fi
+    GENERATED_KEYS="${GENERATED_KEYS}${key}
+"
+  fi
+  eval "$var=\$value"
+}
+
+_hex32() { openssl rand -hex 32; }
+
+_resolve API_KEY_SALT api_key_salt _hex32
+_resolve JWT_SECRET   jwt_secret   _hex32
+
+# Per-product Fernet keys. The chart only mounts each one when its product is
+# enabled, and then as a non-optional secretKeyRef, so a missing key fails that
+# pod at startup. Generating all four up front means enabling insights, polly,
+# agent builder or the engine later is a values change and not a secret edit.
+_resolve AGENT_BUILDER_ENCRYPTION_KEY agent_builder_encryption_key _fernet_key
+_resolve INSIGHTS_ENCRYPTION_KEY      insights_encryption_key      _fernet_key
+_resolve POLLY_ENCRYPTION_KEY         polly_encryption_key         _fernet_key
+_resolve ENGINE_ENCRYPTION_KEY        engine_encryption_key        _fernet_key
 
 DATA_LINES=""
 EXPECTED_KEYS=""
@@ -128,13 +180,12 @@ _put oauth_issuer_url            "${OAUTH_ISSUER_URL:-}"
 _put blob_storage_access_key         "${BLOB_STORAGE_ACCESS_KEY:-}"
 _put blob_storage_access_key_secret  "${BLOB_STORAGE_ACCESS_KEY_SECRET:-}"
 
-# Per-product encryption keys (Fernet). Required by the pods of whichever product
-# is enabled, so set the matching variable when you turn one on in
-# values-overrides.yaml. Losing one makes that product's stored data unreadable.
-_put agent_builder_encryption_key  "${AGENT_BUILDER_ENCRYPTION_KEY:-}"
-_put insights_encryption_key       "${INSIGHTS_ENCRYPTION_KEY:-}"
-_put polly_encryption_key          "${POLLY_ENCRYPTION_KEY:-}"
-_put engine_encryption_key         "${ENGINE_ENCRYPTION_KEY:-}"
+# Per-product encryption keys, resolved above. Losing one makes that product's
+# stored data unreadable, so back them up out of the cluster.
+_put agent_builder_encryption_key  "$AGENT_BUILDER_ENCRYPTION_KEY"
+_put insights_encryption_key       "$INSIGHTS_ENCRYPTION_KEY"
+_put polly_encryption_key          "$POLLY_ENCRYPTION_KEY"
+_put engine_encryption_key         "$ENGINE_ENCRYPTION_KEY"
 _put langsmith_signing_jwks        "${LANGSMITH_SIGNING_JWKS:-}"
 _put sandbox_callback_signing_jwk  "${SANDBOX_CALLBACK_SIGNING_JWK:-}"
 
@@ -211,6 +262,20 @@ echo ""
 if [[ "$MISSING" -ne 0 ]]; then
   echo "ERROR: $MISSING key(s) did not land in the secret." >&2
   exit 1
+fi
+
+if [[ -n "$GENERATED_KEYS" ]]; then
+  echo "  Generated this run, and now stored only in the cluster:"
+  while IFS= read -r key; do
+    [[ -n "$key" ]] || continue
+    echo "    $key"
+  done <<< "$GENERATED_KEYS"
+  echo ""
+  echo "  Back these up outside the cluster before you rely on the install. Losing an"
+  echo "  encryption key orphans that product's stored data; losing api_key_salt"
+  echo "  invalidates every issued API key. Read them with:"
+  echo "    oc get secret langsmith-secrets -n $NAMESPACE -o jsonpath='{.data.<key>}' | base64 --decode"
+  echo ""
 fi
 
 echo "  Secrets ready. values.yaml already points the chart at them:"

--- a/modules/ocp/helm/scripts/generate-secrets.sh
+++ b/modules/ocp/helm/scripts/generate-secrets.sh
@@ -4,36 +4,217 @@
 # NOTICE: Actively being tested and subject to change. Not officially supported by LangChain.
 # See LICENSE at the root of this repository for full license text.
 
-# Reads Terraform outputs and writes them as Kubernetes Secrets in the LangSmith namespace.
+# generate-secrets.sh — create the Kubernetes Secrets the LangSmith chart reads
+# via existingSecretName, on an OpenShift cluster.
+#
+# Usage:
+#   export LANGSMITH_LICENSE_KEY=...
+#   export INITIAL_ORG_ADMIN_PASSWORD=...
+#   ./generate-secrets.sh
+#
+# What this creates:
+#   langsmith-secrets  — application-level secret: license key, api_key_salt,
+#                        jwt_secret, admin password, OAuth, blob storage keys and
+#                        the per-product encryption keys. Read by every LangSmith
+#                        pod via config.existingSecretName (set in values.yaml).
+#   langsmith-postgres — connection_url, only when POSTGRES_CONNECTION_URL is set
+#   langsmith-redis    — connection_url, only when REDIS_CONNECTION_URL is set
+#
+# The two datastore secrets have a second possible writer: the Terraform secrets
+# module (infra/modules/secrets) creates them when postgres_connection_url /
+# redis_connection_url are set. Supply each URL in one place, not both.
+#
+# Key names are fixed by chart 0.16 — the chart looks up literal keys, and a
+# misspelled key surfaces as an empty environment variable in the pod, not an
+# error. Values are piped in as base64 rather than passed as --from-literal so
+# they never appear in the process list. Nothing here echoes a secret value.
+#
+# Safe to re-run: applies in place, and regenerating api_key_salt or jwt_secret is
+# avoided by exporting them (see below) — a new api_key_salt invalidates every
+# issued API key.
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-TF_DIR="${1:-$SCRIPT_DIR/../../infra}"
 NAMESPACE="${NAMESPACE:-langsmith}"
+SERVICE_ACCOUNT="${SERVICE_ACCOUNT:-langsmith}"
 
-echo "Reading Terraform outputs from: $TF_DIR"
+for tool in oc base64 openssl; do
+  command -v "$tool" >/dev/null 2>&1 || { echo "ERROR: $tool not found on PATH." >&2; exit 1; }
+done
 
-POSTGRES_HOST=$(terraform -chdir="$TF_DIR" output -raw postgres_host 2>/dev/null || true)
-POSTGRES_PORT=$(terraform -chdir="$TF_DIR" output -raw postgres_port 2>/dev/null || echo "5432")
-POSTGRES_PASSWORD=$(terraform -chdir="$TF_DIR" output -raw postgres_password 2>/dev/null || true)
-REDIS_HOST=$(terraform -chdir="$TF_DIR" output -raw redis_host 2>/dev/null || true)
+if [[ -z "${LANGSMITH_LICENSE_KEY:-}" ]]; then
+  echo "ERROR: LANGSMITH_LICENSE_KEY is not set." >&2
+  echo "       export LANGSMITH_LICENSE_KEY=... and re-run." >&2
+  exit 1
+fi
 
-kubectl create namespace "$NAMESPACE" --dry-run=client -o yaml | kubectl apply -f -
+# _validate_admin_password <password> — the chart's complexity rule, ported from
+# aws/infra/scripts/setup-env.sh and azure/infra/scripts/_common.sh. The rule lives
+# in the chart's validate.yaml, which skips it entirely once
+# config.existingSecretName is set, so nothing else enforces it on this path: an
+# invalid password is accepted by Helm and rejected by the application at org
+# bootstrap.
+#
+# Prints the reason and returns non-zero. It never prints the password.
+_validate_admin_password() {
+  local _pw="$1" _len
+  # Count bytes, because the chart's rule is Go's len(), which counts bytes.
+  _len=$(printf '%s' "$_pw" | wc -c | tr -d '[:space:]')
+  if (( _len < 12 )); then
+    echo "must be at least 12 bytes long (a non-ASCII character counts as more than one)"
+    return 1
+  fi
+  # The bracket expression lists the symbols the chart accepts: ] first and - last
+  # so both are literal.
+  if ! printf '%s' "$_pw" | grep -q '[]!#$%()+,./:?@[^_{~}-]'; then
+    echo 'must contain at least one symbol from !#$%()+,-./:?@[]^_{~}'
+    return 1
+  fi
+  if ! printf '%s' "$_pw" | grep -q '[a-z]'; then
+    echo "must contain at least one lowercase letter"
+    return 1
+  fi
+  if ! printf '%s' "$_pw" | grep -q '[A-Z]'; then
+    echo "must contain at least one uppercase letter"
+    return 1
+  fi
+  return 0
+}
 
-# Grant the langsmith SCC to the namespace's service account
-oc adm policy add-scc-to-user langsmith-scc -z langsmith -n "$NAMESPACE" 2>/dev/null || true
+if [[ -n "${INITIAL_ORG_ADMIN_PASSWORD:-}" ]]; then
+  if ! _reason=$(_validate_admin_password "$INITIAL_ORG_ADMIN_PASSWORD"); then
+    echo "ERROR: INITIAL_ORG_ADMIN_PASSWORD $_reason" >&2
+    exit 1
+  fi
+fi
 
-kubectl create secret generic langsmith-postgres \
-  --namespace "$NAMESPACE" \
-  --from-literal=host="$POSTGRES_HOST" \
-  --from-literal=port="$POSTGRES_PORT" \
-  --from-literal=password="$POSTGRES_PASSWORD" \
-  --dry-run=client -o yaml | kubectl apply -f -
+# Generated once per run when not supplied. Export both to keep them stable across
+# re-runs: api_key_salt is what existing API keys are hashed against, and jwt_secret
+# invalidates live sessions when it changes.
+API_KEY_SALT="${API_KEY_SALT:-$(openssl rand -hex 32)}"
+JWT_SECRET="${JWT_SECRET:-$(openssl rand -hex 32)}"
+
+DATA_LINES=""
+EXPECTED_KEYS=""
+
+# _put <secret-key> <value> — appends a base64 data line, skipping empty values.
+# An absent key and an empty key are not the same to the chart: for the keys the
+# chart marks non-optional (insights/polly/agent_builder encryption keys) an absent
+# key fails the pod at startup, which is the loud failure we want, while an empty
+# key starts the pod with an empty secret.
+_put() {
+  local key="$1" value="${2:-}" encoded
+  [[ -n "$value" ]] || return 0
+  encoded=$(printf '%s' "$value" | base64 | tr -d '\n')
+  DATA_LINES="${DATA_LINES}  ${key}: ${encoded}
+"
+  EXPECTED_KEYS="${EXPECTED_KEYS}${key}
+"
+}
+
+_put langsmith_license_key       "$LANGSMITH_LICENSE_KEY"
+_put api_key_salt                "$API_KEY_SALT"
+_put jwt_secret                  "$JWT_SECRET"
+_put initial_org_admin_password  "${INITIAL_ORG_ADMIN_PASSWORD:-}"
+
+# OAuth / SSO. config.oauth.oauthClientId, oauthClientSecret and oauthIssuerUrl in
+# values files do nothing once existingSecretName is set — these keys are the only
+# way in. oauth_client_secret is read only when config.authType is "mixed".
+_put oauth_client_id             "${OAUTH_CLIENT_ID:-}"
+_put oauth_client_secret         "${OAUTH_CLIENT_SECRET:-}"
+_put oauth_issuer_url            "${OAUTH_ISSUER_URL:-}"
+
+# Blob storage static credentials. Leave unset when the pods reach object storage
+# through an ambient identity instead.
+_put blob_storage_access_key         "${BLOB_STORAGE_ACCESS_KEY:-}"
+_put blob_storage_access_key_secret  "${BLOB_STORAGE_ACCESS_KEY_SECRET:-}"
+
+# Per-product encryption keys (Fernet). Required by the pods of whichever product
+# is enabled, so set the matching variable when you turn one on in
+# values-overrides.yaml. Losing one makes that product's stored data unreadable.
+_put agent_builder_encryption_key  "${AGENT_BUILDER_ENCRYPTION_KEY:-}"
+_put insights_encryption_key       "${INSIGHTS_ENCRYPTION_KEY:-}"
+_put polly_encryption_key          "${POLLY_ENCRYPTION_KEY:-}"
+_put engine_encryption_key         "${ENGINE_ENCRYPTION_KEY:-}"
+_put langsmith_signing_jwks        "${LANGSMITH_SIGNING_JWKS:-}"
+_put sandbox_callback_signing_jwk  "${SANDBOX_CALLBACK_SIGNING_JWK:-}"
 
 echo ""
-echo "Secrets written to namespace: $NAMESPACE"
+echo "LangSmith on OpenShift — create chart secrets"
+echo "  namespace : $NAMESPACE"
 echo ""
-echo "Next steps:"
-echo "  1. Verify the SCC is applied: oc get scc langsmith-scc"
-echo "  2. Set redis host=$REDIS_HOST in your values-overrides.yaml"
-echo "  3. Configure storage backend in your values-overrides.yaml"
+
+oc create namespace "$NAMESPACE" --dry-run=client -o yaml | oc apply -f -
+
+# Grant the SCC created by infra/modules/scc to the namespace's service account.
+# Non-fatal: the SCC may not exist yet, or the cluster may run LangSmith under the
+# built-in nonroot SCC instead.
+oc adm policy add-scc-to-user langsmith-scc -z "$SERVICE_ACCOUNT" -n "$NAMESPACE" 2>/dev/null \
+  || echo "  NOTE: could not grant langsmith-scc to serviceaccount/$SERVICE_ACCOUNT (see TROUBLESHOOTING.md)."
+
+oc apply -n "$NAMESPACE" -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: langsmith-secrets
+type: Opaque
+data:
+${DATA_LINES}
+EOF
+
+# Datastore connection URLs. Each carries its password, so the chart needs only the
+# one key. Rename the key and you also have to set
+# postgres.external.connectionUrlSecretKey / redis.external.connectionUrlSecretKey.
+_put_datastore_secret() {
+  local secret_name="$1" url="$2" encoded
+  encoded=$(printf '%s' "$url" | base64 | tr -d '\n')
+  oc apply -n "$NAMESPACE" -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ${secret_name}
+type: Opaque
+data:
+  connection_url: ${encoded}
+EOF
+}
+
+if [[ -n "${POSTGRES_CONNECTION_URL:-}" ]]; then
+  _put_datastore_secret langsmith-postgres "$POSTGRES_CONNECTION_URL"
+else
+  echo "  SKIP: langsmith-postgres — POSTGRES_CONNECTION_URL not set (Terraform may own it)."
+fi
+
+if [[ -n "${REDIS_CONNECTION_URL:-}" ]]; then
+  _put_datastore_secret langsmith-redis "$REDIS_CONNECTION_URL"
+else
+  echo "  SKIP: langsmith-redis — REDIS_CONNECTION_URL not set (Terraform may own it)."
+fi
+
+# ── Verify ────────────────────────────────────────────────────────────────────
+echo ""
+echo "  Keys in secret/langsmith-secrets:"
+ACTUAL_KEYS=$(oc get secret langsmith-secrets -n "$NAMESPACE" \
+  -o jsonpath='{range $k,$v := .data}{$k}{"\n"}{end}')
+
+MISSING=0
+while IFS= read -r key; do
+  [[ -n "$key" ]] || continue
+  if printf '%s\n' "$ACTUAL_KEYS" | grep -qx "$key"; then
+    echo "    [ok]      $key"
+  else
+    echo "    [MISSING] $key"
+    MISSING=$((MISSING + 1))
+  fi
+done <<< "$EXPECTED_KEYS"
+
+echo ""
+if [[ "$MISSING" -ne 0 ]]; then
+  echo "ERROR: $MISSING key(s) did not land in the secret." >&2
+  exit 1
+fi
+
+echo "  Secrets ready. values.yaml already points the chart at them:"
+echo "    config.existingSecretName: langsmith-secrets"
+echo "    postgres.external.existingSecretName / redis.external.existingSecretName"
+echo ""
+echo "Next: fill in values-overrides.yaml (hostname, datastore hosts, blob storage), then run deploy.sh."

--- a/modules/ocp/helm/values/values-overrides.yaml.example
+++ b/modules/ocp/helm/values/values-overrides.yaml.example
@@ -7,6 +7,24 @@
 # values.yaml points the chart at via config.existingSecretName. Any secret-bearing
 # config.* value written in this file is silently ignored.
 
+# Internal registry. Clusters with no direct egress pull every image from a proxy
+# (Nexus, Artifactory, Quay) instead of the upstream registries. This value is
+# PREPENDED to each image's repository, which already carries its upstream host,
+# so `registry: nexus.example.com` resolves to
+# nexus.example.com/docker.io/langchain/langsmith-backend. That matches a proxy
+# laid out with one repository path per upstream host; if yours flattens them,
+# override the individual images[*].repository values instead.
+#
+# Chart 0.16 pulls from three upstream hosts, all of which need a proxy path:
+#   docker.io           — every LangSmith image, plus postgres/redis/clickhouse
+#   mcr.microsoft.com   — presidio-analyzer (only when insights is enabled)
+#   registry.k8s.io     — csi-node-driver-registrar (only with sandboxes/JuiceFS)
+#
+# images:
+#   registry: ""
+#   imagePullSecrets:
+#     - name: ""                 # Only when the proxy requires authentication
+
 config:
   initialOrgName: ""             # Required: your organization name
   hostname: langsmith.apps.cluster.example.com

--- a/modules/ocp/helm/values/values-overrides.yaml.example
+++ b/modules/ocp/helm/values/values-overrides.yaml.example
@@ -1,39 +1,60 @@
 # Customer-specific overrides for LangSmith on OpenShift.
 # Copy to values-overrides.yaml, fill in all required fields, then run deploy.sh.
+#
+# Secrets are NOT set here. The license key, api_key_salt, jwt_secret, admin
+# password, OAuth credentials and the per-product encryption keys live in the
+# langsmith-secrets Secret created by helm/scripts/generate-secrets.sh, which
+# values.yaml points the chart at via config.existingSecretName. Any secret-bearing
+# config.* value written in this file is silently ignored.
 
 config:
-  langsmithLicenseKey: ""        # Required: your LangSmith license key
-  orgName: ""                    # Required: your organization name
+  initialOrgName: ""             # Required: your organization name
   hostname: langsmith.apps.cluster.example.com
-  blobStorageBackend: s3         # s3 | gcs | azure — match your object storage provider
-  blobStorageBucket: ""          # Bucket/container name
 
+  # Required, and exactly one of basicAuth / oauth below must be enabled:
+  #   mixed = username/password, optionally alongside SSO
+  #   oauth = SSO only
+  authType: mixed
+
+  # Username/password login. The password itself is the
+  # initial_org_admin_password key in langsmith-secrets
+  # (INITIAL_ORG_ADMIN_PASSWORD), and jwt_secret is generated there too.
+  # initialOrgAdminEmail is required whenever basicAuth is on.
+  basicAuth:
+    enabled: true
+  initialOrgAdminEmail: ""       # Required with basicAuth
+
+  # SSO. oauth_client_id, oauth_client_secret and oauth_issuer_url are keys in
+  # langsmith-secrets (OAUTH_CLIENT_ID / OAUTH_CLIENT_SECRET /
+  # OAUTH_ISSUER_URL); this block only turns the flow on. oauth_client_secret is
+  # read only when authType is "mixed". Basic auth and OAuth cannot both be
+  # enabled — for SSO only, set authType: oauth and disable basicAuth above.
+  # oauth:
+  #   enabled: true
+
+  # Object storage. The access key pair is in langsmith-secrets
+  # (BLOB_STORAGE_ACCESS_KEY / BLOB_STORAGE_ACCESS_KEY_SECRET); only the
+  # non-secret settings belong here. Leave the key pair out when the pods reach
+  # object storage through an ambient identity.
+  # blobStorage:
+  #   enabled: true
+  #   engine: "S3"
+  #   bucketName: ""
+  #   apiURL: "https://s3-openshift-storage.apps.cluster.example.com"
+  #   s3UsePathStyle: true       # ODF/Noobaa serves path-style addressing
+
+# Datastore credentials come from secrets too. Each holds one key,
+# connection_url, carrying the full URI including host, port, database and
+# password — with existingSecretName set there are no separate host/port/database
+# values to fill in. Created by Terraform (postgres_connection_url /
+# redis_connection_url) or by generate-secrets.sh (POSTGRES_CONNECTION_URL /
+# REDIS_CONNECTION_URL).
 postgres:
   external:
     enabled: true
-    host: ""       # Your PostgreSQL host
-    port: 5432
-    database: langsmith
     existingSecretName: langsmith-postgres
-    existingSecretKey: password
 
 redis:
   external:
     enabled: true
-    host: ""       # Your Redis host
-    port: 6379
-
-# Object storage credentials (if not using workload identity / IAM)
-# blobStorage:
-#   accessKeyId: ""
-#   secretAccessKey: ""
-#   region: us-east-1
-
-# Uncomment to configure SSO
-# auth:
-#   sso:
-#     enabled: true
-#     provider: okta    # okta | google | azure-ad
-#     clientId: ""
-#     clientSecret: ""
-#     issuerUrl: ""
+    existingSecretName: langsmith-redis

--- a/modules/ocp/helm/values/values.yaml
+++ b/modules/ocp/helm/values/values.yaml
@@ -1,35 +1,19 @@
 # OCP-specific Helm values for LangSmith.
 # These are checked in and applied on every deploy alongside values-overrides.yaml.
-# They configure OpenShift-specific settings: Route-based ingress, restricted SCC, and OCP storage.
+# They configure the OpenShift specifics: no Ingress object (the dns Terraform module
+# creates the Route) and secrets read from an existing Secret rather than rendered.
 
 ingress:
   # OpenShift uses Routes rather than Ingress objects.
   # Disable the standard Ingress resource; the Route is managed by the dns Terraform module.
   enabled: false
 
-route:
-  enabled: true
-
-# Run as non-root to satisfy OpenShift's restricted SCC
-podSecurityContext:
-  runAsNonRoot: true
-
-containerSecurityContext:
-  allowPrivilegeEscalation: false
-  runAsNonRoot: true
-  seccompProfile:
-    type: RuntimeDefault
-  capabilities:
-    drop:
-      - ALL
-
-storage:
-  storageClassName: ""  # Use cluster default; set explicitly if needed (e.g. ocs-storagecluster-ceph-rbd)
-
-# Chart 0.16 ships insights.enabled and polly.enabled as true. This module sets no
-# config.existingSecretName, so leaving them on makes the chart hard-fail on the
-# encryption key it cannot find. Turn them on in values-overrides.yaml, together
-# with the matching encryptionKey, when you actually want those agents.
+# Chart 0.16 ships insights.enabled and polly.enabled as true, and each product's
+# pods hard-require its encryption key in the secret below. Turn one on in
+# values-overrides.yaml only together with the matching key —
+# INSIGHTS_ENCRYPTION_KEY / POLLY_ENCRYPTION_KEY in generate-secrets.sh. Setting
+# insights.encryptionKey or polly.encryptionKey inline does nothing here: with
+# config.existingSecretName set, the chart never renders its own secret.
 insights:
   enabled: false
 
@@ -37,4 +21,11 @@ polly:
   enabled: false
 
 config:
-  blobStorageBackend: s3  # Override in values-overrides.yaml if using a different backend
+  # All application secrets come from the langsmith-secrets Secret created by
+  # helm/scripts/generate-secrets.sh, so the chart skips its own secrets.yaml.
+  # Consequence: every config.* value that would have been written into that
+  # secret is inert — oauth.oauthClientId, oauth.oauthClientSecret,
+  # oauth.oauthIssuerUrl, apiKeySalt, langsmithLicenseKey,
+  # basicAuth.jwtSecret, basicAuth.initialOrgAdminPassword and the per-product
+  # encryptionKey values. Change those by updating the secret, not this file.
+  existingSecretName: "langsmith-secrets"

--- a/modules/ocp/helm/values/values.yaml
+++ b/modules/ocp/helm/values/values.yaml
@@ -8,12 +8,13 @@ ingress:
   # Disable the standard Ingress resource; the Route is managed by the dns Terraform module.
   enabled: false
 
-# Chart 0.16 ships insights.enabled and polly.enabled as true, and each product's
-# pods hard-require its encryption key in the secret below. Turn one on in
-# values-overrides.yaml only together with the matching key —
-# INSIGHTS_ENCRYPTION_KEY / POLLY_ENCRYPTION_KEY in generate-secrets.sh. Setting
-# insights.encryptionKey or polly.encryptionKey inline does nothing here: with
-# config.existingSecretName set, the chart never renders its own secret.
+# Chart 0.16 ships insights.enabled and polly.enabled as true; both are off here
+# because neither is part of a first install. Turning one on in
+# values-overrides.yaml needs no secret work: generate-secrets.sh writes all four
+# encryption keys up front, and the chart mounts each as a non-optional key only
+# for the product that is enabled. Setting insights.encryptionKey or
+# polly.encryptionKey inline does nothing — with config.existingSecretName set the
+# chart never renders its own secret.
 insights:
   enabled: false
 

--- a/modules/ocp/infra/main.tf
+++ b/modules/ocp/infra/main.tf
@@ -57,11 +57,15 @@ module "scc" {
   source = "./modules/scc"
 }
 
+# Writes langsmith-postgres / langsmith-redis, the two secrets the chart reads via
+# postgres.external.existingSecretName and redis.external.existingSecretName. Both
+# are skipped when their URL is empty; helm/scripts/generate-secrets.sh can create
+# them instead, and always owns the application-level langsmith-secrets.
 module "secrets" {
   source = "./modules/secrets"
 
-  postgres_password = module.postgres.password
-  redis_password    = module.redis.password
+  postgres_connection_url = var.postgres_connection_url
+  redis_connection_url    = var.redis_connection_url
 }
 
 module "dns" {

--- a/modules/ocp/infra/modules/secrets/main.tf
+++ b/modules/ocp/infra/modules/secrets/main.tf
@@ -1,24 +1,48 @@
 # OCP Secrets module
-# Creates a Kubernetes Secret from literal values for LangSmith on OpenShift.
+# Creates the datastore Secrets the LangSmith chart reads via existingSecretName.
 #
-# For production deployments, replace this module with an External Secrets Operator
-# or HashiCorp Vault Agent integration to avoid storing plaintext values in Terraform state.
+# Key names are fixed by chart 0.16: both secrets carry a single `connection_url`
+# key. Renaming it means also setting postgres.external.connectionUrlSecretKey /
+# redis.external.connectionUrlSecretKey in Helm values.
+#
+# Only the datastore secrets live here, because only Terraform knows the connection
+# URLs. The application-level secret (langsmith-secrets — license key, api_key_salt,
+# jwt_secret, encryption keys) is written by helm/scripts/generate-secrets.sh, which
+# also creates these two when POSTGRES_CONNECTION_URL / REDIS_CONNECTION_URL are
+# exported. Supply each URL in one place, not both.
+#
+# Each resource is inert until its URL is set, so a cluster whose datastores are
+# managed outside Terraform can leave these variables empty.
+#
+# Both URLs embed a password and therefore land in Terraform state in plaintext:
+# keep state in an encrypted remote backend (see backend.tf.example). For production,
+# replace this module with External Secrets Operator or the Vault Agent Injector.
 
-resource "random_password" "langsmith_secret_key" {
-  length  = 64
-  special = false
-}
+resource "kubernetes_secret" "postgres" {
+  count = var.postgres_connection_url != "" ? 1 : 0
 
-resource "kubernetes_secret" "langsmith" {
   metadata {
-    name      = "langsmith-secrets"
+    name      = "langsmith-postgres"
     namespace = var.namespace
   }
 
   data = {
-    "langsmith-secret-key" = random_password.langsmith_secret_key.result
-    "postgres-password"    = var.postgres_password
-    "redis-password"       = var.redis_password
+    connection_url = var.postgres_connection_url
+  }
+
+  type = "Opaque"
+}
+
+resource "kubernetes_secret" "redis" {
+  count = var.redis_connection_url != "" ? 1 : 0
+
+  metadata {
+    name      = "langsmith-redis"
+    namespace = var.namespace
+  }
+
+  data = {
+    connection_url = var.redis_connection_url
   }
 
   type = "Opaque"

--- a/modules/ocp/infra/modules/secrets/outputs.tf
+++ b/modules/ocp/infra/modules/secrets/outputs.tf
@@ -1,4 +1,9 @@
-output "secret_name" {
-  description = "Name of the Kubernetes secret"
-  value       = kubernetes_secret.langsmith.metadata[0].name
+output "postgres_secret_name" {
+  description = "Name of the Kubernetes secret holding the Postgres connection URL (postgres.external.existingSecretName), or null when Terraform does not manage it"
+  value       = one(kubernetes_secret.postgres[*].metadata[0].name)
+}
+
+output "redis_secret_name" {
+  description = "Name of the Kubernetes secret holding the Redis connection URL (redis.external.existingSecretName), or null when Terraform does not manage it"
+  value       = one(kubernetes_secret.redis[*].metadata[0].name)
 }

--- a/modules/ocp/infra/modules/secrets/variables.tf
+++ b/modules/ocp/infra/modules/secrets/variables.tf
@@ -4,14 +4,15 @@ variable "namespace" {
   default     = "langsmith"
 }
 
-variable "postgres_password" {
-  description = "PostgreSQL password"
+variable "postgres_connection_url" {
+  description = "Full PostgreSQL connection URL (postgresql://user:password@host:5432/database). Leave empty to skip the secret — generate-secrets.sh or an external secrets operator then owns it."
   type        = string
   sensitive   = true
+  default     = ""
 }
 
-variable "redis_password" {
-  description = "Redis password (leave empty if auth is disabled)"
+variable "redis_connection_url" {
+  description = "Full Redis connection URL (redis://:password@host:6379/0, or rediss:// for TLS). Leave empty to skip the secret."
   type        = string
   sensitive   = true
   default     = ""

--- a/modules/ocp/infra/terraform.tfvars.example
+++ b/modules/ocp/infra/terraform.tfvars.example
@@ -3,3 +3,10 @@ kube_context    = "my-ocp-cluster"
 environment     = "dev"
 project         = "my-project"
 hostname        = "langsmith.apps.cluster.example.com"
+
+# Datastore connection URLs, written to the langsmith-postgres / langsmith-redis
+# secrets. Both embed a password and end up in Terraform state in plaintext — keep
+# state in an encrypted remote backend, or leave these empty and export
+# POSTGRES_CONNECTION_URL / REDIS_CONNECTION_URL to generate-secrets.sh instead.
+# postgres_connection_url = "postgresql://langsmith:CHANGEME@postgres.example.com:5432/langsmith"
+# redis_connection_url    = "rediss://:CHANGEME@redis.example.com:6380/0"

--- a/modules/ocp/infra/variables.tf
+++ b/modules/ocp/infra/variables.tf
@@ -24,3 +24,17 @@ variable "hostname" {
   type        = string
   default     = ""
 }
+
+variable "postgres_connection_url" {
+  description = "Full PostgreSQL connection URL (postgresql://user:password@host:5432/database) written to the langsmith-postgres secret. Leave empty to have generate-secrets.sh create that secret instead."
+  type        = string
+  sensitive   = true
+  default     = ""
+}
+
+variable "redis_connection_url" {
+  description = "Full Redis connection URL (redis://:password@host:6379/0, or rediss:// for TLS) written to the langsmith-redis secret. Leave empty to have generate-secrets.sh create that secret instead."
+  type        = string
+  sensitive   = true
+  default     = ""
+}


### PR DESCRIPTION
The OCP module pointed the chart at existing secrets but never created them with the key names the chart looks for, and the Terraform side wrote keys the chart does not read from module outputs that do not exist. Two commits.

## Existing secrets

`generate-secrets.sh` now owns `langsmith-secrets` and writes the chart's own key names, omitting whatever is left unset. Values are base64-encoded in the shell and piped to `oc apply` on stdin instead of `--from-literal`, keeping them out of the process list. It also ports the chart's admin-password complexity rule from `setup-env.sh`, because `validate.yaml` stops enforcing that rule once `existingSecretName` is set and a weak password fails the auth-bootstrap job with no useful error.

`infra/modules/secrets` previously wrote host/port/password keys from `module.postgres.password` and `module.redis.password`, which do not exist on those stub modules. It now writes the single `connection_url` key the chart reads, `count`-gated so each secret is skipped when its URL is empty and the script or an external secrets operator can own it instead.

Five keys come out of `helm/values` that chart 0.16 has no schema for and silently ignores: `route`, `storage`, `podSecurityContext`, `containerSecurityContext` and `config.blobStorageBackend`. The Route is created by the `dns` Terraform module, so `route.enabled` was never what exposed the service. The overrides example gains the `config.authType`, `basicAuth` and `initialOrgAdminEmail` values it was missing, without which the chart refused to render at all.

## Fernet keys and the registry override

The four per-product encryption keys were passed straight through from the environment, so following the docs' `openssl rand -hex 32` yields 64 characters and the products reject it. They are Fernet keys, per the chart's own README. The script now generates 32 random bytes as URL-safe base64.

Key resolution is environment, else the value already in the secret, else generated. Re-running used to mint a new `api_key_salt` and invalidate every issued API key; now a second run cannot rotate a generated value. Anything generated fresh is named at the end of the run with instructions to back it up, since it lives only in the cluster.

Adds a commented `images.registry` block and README section for clusters with no egress to Docker Hub, including the detail that the value is *prepended* to repositories that already carry their upstream host, and the three upstream hosts chart 0.16 pulls from.

## Verification

Verified by rendering chart 0.16.9 out of the local mirror against the module's own values files:

- Renders clean. Before the `authType` fix the overrides example failed every render.
- The only Secret the chart still generates is `langsmith-clickhouse`. Pods resolve `langsmith-secrets`, `langsmith-postgres` (`connection_url`) and `langsmith-redis` (`connection_url`).
- With `images.registry: nexus.example.com`, images resolve to `nexus.example.com/docker.io/langchain/langsmith-backend`.
- The generated keys are accepted by `cryptography`'s `Fernet`, which round-trips a payload with them.
- `terraform fmt -check -recursive modules/ocp` and `agents/check.sh --scripts` are clean.

`terraform plan` is not part of this check: `modules/ocp` has no `versions.tf` to init against, and `kubernetes_manifest` reads the cluster at plan time.

## Not addressed

`modules/ocp` still has six submodules that are single-comment placeholders (`networking`, `k8s-cluster`, `k8s-bootstrap`, `postgres`, `redis`, `storage`) which the root module calls for no effect, and `ARCHITECTURE.md` documents a directory layout that is not in the tree.
