### PR TITLE
fix(azure): include group membership in preflight RBAC checks

### DIFF
--- a/modules/azure/infra/scripts/preflight.sh
+++ b/modules/azure/infra/scripts/preflight.sh
@@ -119,6 +119,8 @@ fi
 # reported as if it belonged to the service principal Terraform will use.
 PRINCIPAL_ID=""
 PRINCIPAL_IS_CALLER=1
+GROUPS_RESOLVED=0
+GROUP_IDS=""
 if [ -n "${ARM_CLIENT_ID:-}" ]; then
   PRINCIPAL_KIND="service principal from ARM_CLIENT_ID"
   PRINCIPAL_ID=$(az ad sp show --id "$ARM_CLIENT_ID" --query id -o tsv 2>/dev/null || echo "")
@@ -135,6 +137,13 @@ elif [ "$(az account show --query user.type -o tsv 2>/dev/null || echo "")" = "s
 else
   PRINCIPAL_KIND="signed-in user"
   PRINCIPAL_ID=$(az ad signed-in-user show --query id -o tsv 2>/dev/null || echo "")
+  if [ -n "$PRINCIPAL_ID" ]; then
+    if GROUP_IDS=$(az ad user get-member-groups --id "$PRINCIPAL_ID" --query '[].id' -o tsv 2>/dev/null); then
+      GROUPS_RESOLVED=1
+    else
+      warn "Could not resolve transitive group membership — denied RBAC results will be treated as inconclusive"
+    fi
+  fi
 fi
 
 if [ -n "$PRINCIPAL_ID" ]; then
@@ -211,9 +220,9 @@ else
 
   # roleAssignments/write is the action that decides; the rest are what a
   # principal without broad resource access trips over first. checkAccess batches,
-  # so all of them cost one request per scope. The object ID goes through
-  # json.dumps into a file rather than onto a command line.
-  python3 - "$PRINCIPAL_ID" > "${RBAC_TMP}/body.json" <<'PY'
+  # so all of them cost one request per scope. The subject attributes go through
+  # json.dumps into a file rather than being interpolated into JSON by the shell.
+  python3 - "$PRINCIPAL_ID" "$GROUPS_RESOLVED" "$GROUP_IDS" > "${RBAC_TMP}/body.json" <<'PY'
 import json, sys
 
 ACTIONS = [
@@ -228,8 +237,12 @@ ACTIONS = [
     "Microsoft.Cache/redis/write",
 ]
 
+attributes = {"ObjectId": sys.argv[1]}
+if sys.argv[2] == "1":
+    attributes["Groups"] = [group for group in sys.argv[3].splitlines() if group]
+
 print(json.dumps({
-    "Subject": {"Attributes": {"ObjectId": sys.argv[1]}},
+    "Subject": {"Attributes": attributes},
     "Actions": [{"Id": action, "IsDataAction": False} for action in ACTIONS],
 }))
 PY
@@ -434,12 +447,22 @@ PY
         fail "No Owner, User Access Administrator, or Role Based Access Control Administrator grant found at or above the subscription. Roles held: ${HELD_FLAT}. A custom role carrying roleAssignments/write would also work and is not detected on this path." ;;
     esac
   else
-    pass "checkAccess answered, so the verdicts below are this principal's effective access with deny assignments and ABAC conditions applied"
+    if [ "$GROUPS_RESOLVED" -eq 1 ]; then
+      pass "checkAccess answered with transitive group membership, deny assignments, and ABAC conditions applied"
+    else
+      warn "checkAccess answered without transitive group membership; denied results cover direct assignments only"
+    fi
     while IFS= read -r LINE; do
       case "$LINE" in
         pass\ *) pass "${LINE#pass }" ;;
         warn\ *) warn "${LINE#warn }" ;;
-        fail\ *) fail "${LINE#fail }" ;;
+        fail\ *)
+          if [ "$GROUPS_RESOLVED" -eq 1 ] || [[ "$LINE" == *"deny assignment"* ]]; then
+            fail "${LINE#fail }"
+          else
+            warn "${LINE#fail } This result is inconclusive without transitive group membership."
+          fi
+          ;;
         *) [ -z "$LINE" ] || warn "$LINE" ;;
       esac
     done <<EOF

--- a/modules/azure/infra/scripts/test-preflight-rbac.py
+++ b/modules/azure/infra/scripts/test-preflight-rbac.py
@@ -33,6 +33,7 @@ RG_SCOPE = f"{SUB_SCOPE}/resourceGroups/langsmith-rg-dev"
 VNET_ID = f"{SUB_SCOPE}/resourceGroups/platform-network-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet"
 USER_OID = "33333333-3333-3333-3333-333333333333"
 SP_OID = "44444444-4444-4444-4444-444444444444"
+GROUP_OID = "55555555-5555-5555-5555-555555555555"
 
 OWNER_GUID = "8e3af657a8ff443ca75c2fe8c4bcb635"
 CONTRIB_GUID = "b24988ac618042a0ab8820f7382dd24c"
@@ -208,14 +209,27 @@ CASES = [
         "reject_calls": ["postgres flexible-server list-skus"],
     },
     {
-        "name": "everything permitted passes at both scopes",
+        "name": "group-inherited access is permitted at both scopes",
+        "group_ids": [GROUP_OID],
         "ca_all": ALL_GOOD,
         "expect": [
+            "[✓] checkAccess answered with transitive group membership",
             f"[✓] roleAssignments/write permitted at {SUB_SCOPE}, granted by Owner held at",
             f"[✓] roleAssignments/write permitted at {RG_SCOPE}",
             f"[✓] Every resource type the deployment creates is writable at {SUB_SCOPE}",
         ],
+        "assert_groups": [GROUP_OID],
         "reject": ["[✗]", "Falling back"],
+    },
+    {
+        "name": "a failed group lookup makes a denied result inconclusive",
+        "groups_fail": True,
+        "ca_all": response(write=False),
+        "expect": [
+            "[!] Could not resolve transitive group membership",
+            "This result is inconclusive without transitive group membership.",
+        ],
+        "reject": ["[✗] roleAssignments/write is not permitted"],
     },
     {
         "name": "contributor is named as the granting role when it is the one that answered",
@@ -446,9 +460,11 @@ def build_case(case, index):
         (fixture / "held").write_text(case["held"])
     if "pg_caps_raw" in case:
         (fixture / "pg_caps.json").write_text(case["pg_caps_raw"])
+    if "group_ids" in case:
+        (fixture / "group_ids").write_text("\n".join(case["group_ids"]))
 
     for flag in ("no_graph", "ca_fail", "ca_rg_fail", "ca_sub_fail", "ca_vnet_fail",
-                 "assignments_fail", "pg_caps_fail", "pg_caps_stderr"):
+                 "assignments_fail", "groups_fail", "pg_caps_fail", "pg_caps_stderr"):
         if case.get(flag):
             (fixture / flag).write_text("1")
 
@@ -498,6 +514,15 @@ def run_case(case, index):
             got = json.loads(body_path.read_text())["Subject"]["Attributes"]["ObjectId"]
             if got != case["assert_subject"]:
                 problems.append(f"Subject was {got}, expected {case['assert_subject']}")
+
+    if "assert_groups" in case:
+        body_path = fixture / "last_body.json"
+        if not body_path.exists():
+            problems.append("no checkAccess body was sent")
+        else:
+            got = json.loads(body_path.read_text())["Subject"]["Attributes"].get("Groups")
+            if got != case["assert_groups"]:
+                problems.append(f"Groups were {got}, expected {case['assert_groups']}")
 
     if problems:
         rendered = [

--- a/modules/azure/infra/scripts/test-support/az
+++ b/modules/azure/infra/scripts/test-support/az
@@ -59,6 +59,9 @@ case "$ARGS" in
   "ad signed-in-user show"*)
     if [ -f "$FIX/no_graph" ]; then exit 1; fi
     emit_file "$FIX/principal_id" "33333333-3333-3333-3333-333333333333" ;;
+  "ad user get-member-groups"*)
+    if [ -f "$FIX/groups_fail" ]; then exit 1; fi
+    emit_file "$FIX/group_ids" "" ;;
   "ad sp show"*)
     if [ -f "$FIX/no_graph" ]; then exit 1; fi
     emit_file "$FIX/sp_principal_id" "44444444-4444-4444-4444-444444444444" ;;


### PR DESCRIPTION
## Summary

- include the signed-in user's transitive Entra group IDs in the Azure `checkAccess` request
- treat negative results as inconclusive when group membership cannot be resolved
- cover group-inherited access and group lookup failure in the existing preflight tests

## Why

`checkAccess` evaluates only the subject attributes supplied in the request. The preflight passes only the user's object ID, so a subscription Owner inherited through an Entra group is reported as having no access.

## Testing

- `python3 modules/azure/infra/scripts/test-preflight-rbac.py` (35/35 cases passed)
- `bash agents/check.sh --scripts`
- live `make preflight` with subscription-level Owner inherited through an Entra group

Fixes #224